### PR TITLE
FindHostsForMigration returns a list response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ mocks:
 test:
 	go test -v github.com/apache/cloudstack-go/v2/test
 
-MOCKGEN := $(shell pwd)/bin/mockgen
+MOCKGEN ?= $(shell pwd)/bin/mockgen
 mockgen: ## Download conversion-gen locally if necessary.
 	$(call go-get-tool,$(MOCKGEN),github.com/golang/mock/mockgen)
 

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -1805,6 +1805,11 @@ func (s *HostService) FindHostsForMigration(p *FindHostsForMigrationParams) (*Fi
 }
 
 type FindHostsForMigrationResponse struct {
+	Count int                 `json:"count"`
+	Host  []*HostForMigration `json:"host"`
+}
+
+type HostForMigration struct {
 	Averageload                      int64  `json:"averageload"`
 	Capabilities                     string `json:"capabilities"`
 	Clusterid                        string `json:"clusterid"`

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1094,7 +1094,7 @@ func (s *service) generateAPITest(a *API) {
 	}
 	pn(")")
 	idPresent := false
-	if !(strings.HasPrefix(a.Name, "list") || a.Name == "registerTemplate") {
+	if !(strings.HasPrefix(a.Name, "list") || a.Name == "registerTemplate" || a.Name == "findHostsForMigration") {
 		for _, ap := range a.Response {
 			if ap.Name == "id" && ap.Type == "string" {
 				pn("		r, err := client.%s.%s(p)", strings.TrimSuffix(s.name, "Service"), capitalize(a.Name))

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -79,6 +79,12 @@ var longToStringConvertedParams = map[string]bool{
 	"managementserverid": true,
 }
 
+// customResponseStructTypes maps the API call to a custom struct name
+// This is to change the struct type name to something other than the API name
+var customResponseStructTypes = map[string]string{
+	"findHostsForMigration": "HostForMigration",
+}
+
 // We prefill this one value to make sure it is not
 // created twice, as this is also a top level type.
 var typeNames = map[string]bool{"Nic": true}
@@ -1766,7 +1772,7 @@ func (s *service) generateResponseType(a *API) {
 	// If this is a 'list' response, we need an separate list struct. There seem to be other
 	// types of responses that also need a separate list struct, so checking on exact matches
 	// for those once.
-	if strings.HasPrefix(a.Name, "list") || a.Name == "registerTemplate" {
+	if strings.HasPrefix(a.Name, "list") || a.Name == "registerTemplate" || a.Name == "findHostsForMigration" {
 		pn("type %s struct {", tn)
 
 		// This nasty check is for some specific response that do not behave consistent
@@ -1792,6 +1798,9 @@ func (s *service) generateResponseType(a *API) {
 		case "listDomainChildren":
 			pn("	Count int `json:\"count\"`")
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), "domain")
+		case "findHostsForMigration":
+			pn(" Count int `json:\"count\"`")
+			pn(" Host []*%s `json:\"%s\"`", customResponseStructTypes[a.Name], "host")
 		default:
 			pn("	Count int `json:\"count\"`")
 			pn("	%s []*%s `json:\"%s\"`", ln, parseSingular(ln), strings.ToLower(parseSingular(ln)))
@@ -1849,6 +1858,10 @@ func (s *service) recusiveGenerateResponseType(aName string, tn string, resp API
 	pn := s.pn
 	customMarshal := false
 	found := make(map[string]bool)
+
+	if val, ok := customResponseStructTypes[aName]; ok {
+		tn = val
+	}
 
 	pn("type %s struct {", tn)
 

--- a/test/HostService_test.go
+++ b/test/HostService_test.go
@@ -187,15 +187,9 @@ func TestHostService(t *testing.T) {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
 		p := client.Host.NewFindHostsForMigrationParams("virtualmachineid")
-		r, err := client.Host.FindHostsForMigration(p)
+		_, err := client.Host.FindHostsForMigration(p)
 		if err != nil {
 			t.Errorf(err.Error())
-		}
-		if len(r.Host) != 1 {
-			t.Errorf("Failed to parse response. Host is missing")
-		}
-		if r.Host[0].Id != "6a5b8975-225f-4630-9093-3d55cec439d8" {
-			t.Errorf("Failed to parse response. ID incorrect")
 		}
 	}
 	t.Run("FindHostsForMigration", testfindHostsForMigration)

--- a/test/HostService_test.go
+++ b/test/HostService_test.go
@@ -191,8 +191,11 @@ func TestHostService(t *testing.T) {
 		if err != nil {
 			t.Errorf(err.Error())
 		}
-		if r.Id == "" {
-			t.Errorf("Failed to parse response. ID not found")
+		if len(r.Host) != 1 {
+			t.Errorf("Failed to parse response. Host is missing")
+		}
+		if r.Host[0].Id != "6a5b8975-225f-4630-9093-3d55cec439d8" {
+			t.Errorf("Failed to parse response. ID incorrect")
 		}
 	}
 	t.Run("FindHostsForMigration", testfindHostsForMigration)

--- a/test/testdata/HostService.json
+++ b/test/testdata/HostService.json
@@ -317,5 +317,56 @@
       "completed": "2021-10-03T07:10:09+0000",
       "jobid": "79da9d4b-6368-4ce5-9054-952295fc2c8a"
     }
+  },
+  "findHostsForMigration": {
+    "findhostsformigrationresponse": {
+      "count": 1,
+      "host": [
+        {
+          "capabilities": "hvm",
+          "clusterid": "3bf3ffc6-7f75-487c-a4b0-307b8fc96119",
+          "clustername": "C1",
+          "clustertype": "CloudManaged",
+          "cpuallocated": "0%",
+          "cpuallocatedpercentage": "0%",
+          "cpuallocatedvalue": 0,
+          "cpuallocatedwithoverprovisioning": "0%",
+          "cpunumber": 4,
+          "cpuspeed": 8000,
+          "cpuused": "0%",
+          "cpuwithoverprovisioning": "32000",
+          "created": "2021-12-01T00:15:50+0000",
+          "events": "ShutdownRequested; AgentConnected; AgentDisconnected; PingTimeout; StartAgentRebalance; Remove; Ping; HostDown; ManagementServerDown",
+          "hahost": false,
+          "hypervisor": "Simulator",
+          "hypervisorversion": "4.16.0.0",
+          "id": "6a5b8975-225f-4630-9093-3d55cec439d8",
+          "ipaddress": "172.16.15.16",
+          "islocalstorageactive": false,
+          "jobstatus": 0,
+          "lastpinged": "1970-01-19T18:10:51+0000",
+          "managementserverid": 2886860803,
+          "memoryallocated": "0%",
+          "memoryallocatedbytes": 0,
+          "memoryallocatedpercentage": "0%",
+          "memorytotal": 8589934592,
+          "memoryused": 0,
+          "memorywithoverprovisioning": "8589934592",
+          "name": "SimulatedAgent.c5e22bf2-9444-4de9-a731-f6001a33ef3a",
+          "networkkbsread": 32768,
+          "networkkbswrite": 16384,
+          "podid": "5fe0ee61-581b-425a-afb4-d9301589b11e",
+          "podname": "POD0",
+          "requiresStorageMotion": false,
+          "resourcestate": "Enabled",
+          "state": "Up",
+          "suitableformigration": true,
+          "type": "Routing",
+          "version": "4.16.0.0",
+          "zoneid": "a6166bb3-d997-4093-acfe-a5c51c38a9e3",
+          "zonename": "Sandbox-simulator"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Currently the client is unable to parse the findHostsForMigration API. This turns it into a list response as expected, and updates the tests for it.