### PR TITLE
Fix registerTemplate/updateTemplate details map

### DIFF
--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -2322,8 +2322,8 @@ func (p *RegisterTemplateParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["details"]; found {
 		m := v.(map[string]string)
-		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
+		for _, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[0].%s", k), m[k])
 		}
 	}
 	if v, found := p.p["directdownload"]; found {
@@ -2906,8 +2906,8 @@ func (p *UpdateTemplateParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["details"]; found {
 		m := v.(map[string]string)
-		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
+		for _, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[0].%s", k), m[k])
 		}
 	}
 	if v, found := p.p["displaytext"]; found {


### PR DESCRIPTION
This should fix #43 - it's possible that other API calls that accept multiple details need this fix as well, but I've been selective in applying only to the known ones via the `detailsRequireZeroIndex` map.  I just don't have the ability to go through each API call right now to determine if this fix is required.

I don't see a way in the existing test framework to inspect/test the `toUrlValues()` or the final rendered parameters. If there's an existing way to add this I'm happy to add a test.