### PR TITLE
Generate account details correctly (accountdetails[0].somekey=someval)

### DIFF
--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -68,9 +68,8 @@ func (p *CreateAccountParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["accountdetails"]; found {
 		m := v.(map[string]string)
-		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("accountdetails[%d].value", i), m[k])
+		for _, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("accountdetails[0].%s", k), m[k])
 		}
 	}
 	if v, found := p.p["accountid"]; found {
@@ -2114,9 +2113,8 @@ func (p *UpdateAccountParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["accountdetails"]; found {
 		m := v.(map[string]string)
-		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("accountdetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("accountdetails[%d].value", i), m[k])
+		for _, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("accountdetails[0].%s", k), m[k])
 		}
 	}
 	if v, found := p.p["domainid"]; found {

--- a/cloudstack/BigSwitchBCFService.go
+++ b/cloudstack/BigSwitchBCFService.go
@@ -237,7 +237,7 @@ func (s *BigSwitchBCFService) NewDeleteBigSwitchBcfDeviceParams(bcfdeviceid stri
 	return p
 }
 
-//  delete a BigSwitch BCF Controller device
+// delete a BigSwitch BCF Controller device
 func (s *BigSwitchBCFService) DeleteBigSwitchBcfDevice(p *DeleteBigSwitchBcfDeviceParams) (*DeleteBigSwitchBcfDeviceResponse, error) {
 	resp, err := s.cs.newRequest("deleteBigSwitchBcfDevice", p.toURLValues())
 	if err != nil {

--- a/cloudstack/BrocadeVCSService.go
+++ b/cloudstack/BrocadeVCSService.go
@@ -218,7 +218,7 @@ func (s *BrocadeVCSService) NewDeleteBrocadeVcsDeviceParams(vcsdeviceid string) 
 	return p
 }
 
-//  delete a Brocade VCS Switch
+// delete a Brocade VCS Switch
 func (s *BrocadeVCSService) DeleteBrocadeVcsDevice(p *DeleteBrocadeVcsDeviceParams) (*DeleteBrocadeVcsDeviceResponse, error) {
 	resp, err := s.cs.newRequest("deleteBrocadeVcsDevice", p.toURLValues())
 	if err != nil {

--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -1438,7 +1438,7 @@ func (s *FirewallService) NewDeletePaloAltoFirewallParams(fwdeviceid string) *De
 	return p
 }
 
-//  delete a Palo Alto firewall device
+// delete a Palo Alto firewall device
 func (s *FirewallService) DeletePaloAltoFirewall(p *DeletePaloAltoFirewallParams) (*DeletePaloAltoFirewallResponse, error) {
 	resp, err := s.cs.newRequest("deletePaloAltoFirewall", p.toURLValues())
 	if err != nil {

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -2582,7 +2582,7 @@ func (s *LoadBalancerService) NewDeleteNetscalerLoadBalancerParams(lbdeviceid st
 	return p
 }
 
-//  delete a netscaler load balancer device
+// delete a netscaler load balancer device
 func (s *LoadBalancerService) DeleteNetscalerLoadBalancer(p *DeleteNetscalerLoadBalancerParams) (*DeleteNetscalerLoadBalancerResponse, error) {
 	resp, err := s.cs.newRequest("deleteNetscalerLoadBalancer", p.toURLValues())
 	if err != nil {

--- a/cloudstack/NiciraNVPService.go
+++ b/cloudstack/NiciraNVPService.go
@@ -272,7 +272,7 @@ func (s *NiciraNVPService) NewDeleteNiciraNvpDeviceParams(nvpdeviceid string) *D
 	return p
 }
 
-//  delete a nicira nvp device
+// delete a nicira nvp device
 func (s *NiciraNVPService) DeleteNiciraNvpDevice(p *DeleteNiciraNvpDeviceParams) (*DeleteNiciraNvpDeviceResponse, error) {
 	resp, err := s.cs.newRequest("deleteNiciraNvpDevice", p.toURLValues())
 	if err != nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -54,6 +54,8 @@ var detailsRequireKeyValue = map[string]bool{
 var detailsRequireZeroIndex = map[string]bool{
 	"registerTemplate": true,
 	"updateTemplate":   true,
+	"createAccount":    true,
+	"updateAccount":    true,
 }
 
 var mapRequireList = map[string]map[string]bool{
@@ -1336,8 +1338,12 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 				pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
 			}
 		default:
-			pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", name)
-			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
+			if zeroIndex && !detailsRequireKeyValue[cmd] {
+				pn("	u.Set(fmt.Sprintf(\"%s[0].%%s\", k), m[k])", name)
+			} else {
+				pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", name)
+				pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
+			}
 		}
 		pn("}")
 	}


### PR DESCRIPTION
When creating or updating accounts using the API, the parameters are expected to be in format:

```
accountdetails[0].somekey=someval
```

not

```
accountdetails[0].key=somekey
accountdetails[0].value=someval
```

Since `accountdetails` is handled via `default` switch, I'm using the `detailsRequireZeroIndex` list to ensure we don't make this change broad. Any other APIs that require this format can just be added to `detailsRequireZeroIndex` as we identify them, rather than making a sweeping change.

I don't know what's up with the change in comment on the delete calls... possibly a change that wasn't properly committed earlier.