### PR TITLE
Fix asterisk encoding

### DIFF
--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -468,8 +468,9 @@ func (cs *CloudStackClient) newRawRequest(api string, post bool, params url.Valu
 	// * Serialize parameters, URL encoding only values and sort them by key, done by encodeValues
 	// * Convert the entire argument string to lowercase
 	// * Replace all instances of '+' to '%20'
-	// * Replace encoded asterisk (*) back to literal.  CloudStack’s internal encoder does not encode them; this results in an authentication failure for your API call.
-	//     http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started/en/latest/dev.html)
+	// * Replace encoded asterisk (*) back to literal.
+	//    CloudStack’s internal encoder does not encode them; this results in an authentication failure for your API call.
+	//    http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started/en/latest/dev.html)
 	// * Calculate HMAC SHA1 of argument string with CloudStack secret
 	// * URL encode the string and convert to base64
 	s := encodeValues(params)


### PR DESCRIPTION
Resolving errors when Configuration values contain an asterisk.

```
Error: CloudStack API error 401 (CSExceptionErrorCode: 0): unable to verify user credentials and/or request signature
```

Found the following note [here](http://docs.cloudstack.apache.org/projects/archived-cloudstack-getting-started/en/latest/dev.html):

> If you have API calls which contain * (asterisk) characters, you will need to add the option “safe = ‘*’” for the URL encoding. The reason is that Python’s urllib will encode * characters by default, while CloudStack’s internal encoder does not encode them; this results in an authentication failure for your API call. In the above you would replace “urllib.quote_plus(request[k])” with “urllib.quote_plus(request[k], safe=’*’)”.
