### PR TITLE
generate: fix error logging for goimports

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -123,10 +123,11 @@ func (e *generateError) Error() string {
 
 type goimportError struct {
 	output string
+	error  error
 }
 
 func (e *goimportError) Error() string {
-	return fmt.Sprintf("GoImport failed to format:\n%v", e.output)
+	return fmt.Sprintf("GoImport failed to format:\n%v\n%v", e.output, e.error)
 }
 
 type service struct {
@@ -238,7 +239,7 @@ func main() {
 	}
 	out, err := exec.Command("goimports", "-w", outdir).CombinedOutput()
 	if err != nil {
-		errors = append(errors, &goimportError{string(out)})
+		errors = append(errors, &goimportError{string(out), err})
 	}
 
 	testdir, err := testDir()
@@ -247,7 +248,7 @@ func main() {
 	}
 	out, err = exec.Command("goimports", "-w", testdir).CombinedOutput()
 	if err != nil {
-		errors = append(errors, &goimportError{string(out)})
+		errors = append(errors, &goimportError{string(out), err})
 	}
 
 	if len(errors) > 0 {


### PR DESCRIPTION
This PR adds error returned by goimports in the log.
Currently, only output is printed,
```
⇒  go run -v generate/generate.go generate/layout.go --api=generate/listApis.json 
command-line-arguments
2023/03/15 17:20:50 1 API(s) failed to generate:
2023/03/15 17:20:50 GoImport failed to format:
exit status 1
```

With fix,
```
⇒  go run -v generate/generate.go generate/layout.go --api=generate/listApis.json 
command-line-arguments
2023/03/15 17:21:24 1 API(s) failed to generate:
2023/03/15 17:21:24 GoImport failed to format:

exec: "goimports": executable file not found in $PATH
exit status 1
```