### PR TITLE
Do not encode values with an asterisk in them.

### DIFF
--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -541,6 +541,13 @@ func encodeValues(v url.Values) string {
 				buf.WriteByte('&')
 			}
 			buf.WriteString(prefix)
+			// There is a requirement for some API values to contain “*” such as `consoleproxy.url.domain`
+			// otherwise an exception is thrown.
+			// If key == "value" do not encode if value contains '*'.
+			if k == "value" && strings.Contains(v, "*") {
+				buf.WriteString(v)
+				continue
+			}
 			buf.WriteString(url.QueryEscape(v))
 		}
 	}


### PR DESCRIPTION
There is a requirement for some API values to contain “*” such as ```consoleproxy.url.domain``` otherwise an exception is thrown. If key == "value" do not encode if value contains '*'

```CloudStack API error 401 (CSExceptionErrorCode: 0): unable to verify user credentials and/or request signature]```