### PR TITLE
Fix RoleService bug where response doesn't match struct

### DIFF
--- a/cloudstack/RoleService.go
+++ b/cloudstack/RoleService.go
@@ -160,13 +160,7 @@ func (s *RoleService) CreateRole(p *CreateRoleParams) (*CreateRoleResponse, erro
 }
 
 type CreateRoleResponse struct {
-	Description string `json:"description"`
-	Id          string `json:"id"`
-	Isdefault   bool   `json:"isdefault"`
-	JobID       string `json:"jobid"`
-	Jobstatus   int    `json:"jobstatus"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
+	Role Role `json:"role"`
 }
 
 type CreateRolePermissionParams struct {
@@ -280,14 +274,7 @@ func (s *RoleService) CreateRolePermission(p *CreateRolePermissionParams) (*Crea
 }
 
 type CreateRolePermissionResponse struct {
-	Description string `json:"description"`
-	Id          string `json:"id"`
-	JobID       string `json:"jobid"`
-	Jobstatus   int    `json:"jobstatus"`
-	Permission  string `json:"permission"`
-	Roleid      string `json:"roleid"`
-	Rolename    string `json:"rolename"`
-	Rule        string `json:"rule"`
+	RolePermission RolePermission `json:"rolepermission"`
 }
 
 type DeleteRoleParams struct {

--- a/test/RoleService_test.go
+++ b/test/RoleService_test.go
@@ -44,7 +44,7 @@ func TestRoleService(t *testing.T) {
 		if err != nil {
 			t.Errorf(err.Error())
 		}
-		if r.Id == "" {
+		if r.Role.Id == "" {
 			t.Errorf("Failed to parse response. ID not found")
 		}
 	}
@@ -59,7 +59,7 @@ func TestRoleService(t *testing.T) {
 		if err != nil {
 			t.Errorf(err.Error())
 		}
-		if r.Id == "" {
+		if r.RolePermission.Id == "" {
 			t.Errorf("Failed to parse response. ID not found")
 		}
 	}


### PR DESCRIPTION
Example raw response:

```
{"role":{"type":"DomainAdmin","id":"fake-id-12312312","name":"test-name","description":"test Role"}}

```

Struct doesn't match raw response, so the unmarshaller wasn't able to unmarshal properly and the response is always empty.

This fix handles the bug.

@mlsorensen FYI