### PR TITLE
Add support for unmanaged kubernetes

### DIFF
--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -289,6 +289,7 @@ type AssociateIpAddressResponse struct {
 	Fordisplay                bool   `json:"fordisplay"`
 	Forvirtualnetwork         bool   `json:"forvirtualnetwork"`
 	Hasannotations            bool   `json:"hasannotations"`
+	Hasrules                  bool   `json:"hasrules"`
 	Id                        string `json:"id"`
 	Ipaddress                 string `json:"ipaddress"`
 	Isportable                bool   `json:"isportable"`
@@ -308,6 +309,7 @@ type AssociateIpAddressResponse struct {
 	Virtualmachinedisplayname string `json:"virtualmachinedisplayname"`
 	Virtualmachineid          string `json:"virtualmachineid"`
 	Virtualmachinename        string `json:"virtualmachinename"`
+	Virtualmachinetype        string `json:"virtualmachinetype"`
 	Vlanid                    string `json:"vlanid"`
 	Vlanname                  string `json:"vlanname"`
 	Vmipaddress               string `json:"vmipaddress"`
@@ -468,6 +470,10 @@ func (p *ListPublicIpAddressesParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["projectid"]; found {
 		u.Set("projectid", v.(string))
+	}
+	if v, found := p.p["retrieveonlyresourcecount"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("retrieveonlyresourcecount", vv)
 	}
 	if v, found := p.p["state"]; found {
 		u.Set("state", v.(string))
@@ -776,6 +782,21 @@ func (p *ListPublicIpAddressesParams) GetProjectid() (string, bool) {
 	return value, ok
 }
 
+func (p *ListPublicIpAddressesParams) SetRetrieveonlyresourcecount(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListPublicIpAddressesParams) GetRetrieveonlyresourcecount() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["retrieveonlyresourcecount"].(bool)
+	return value, ok
+}
+
 func (p *ListPublicIpAddressesParams) SetState(v string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -922,6 +943,7 @@ type PublicIpAddress struct {
 	Fordisplay                bool   `json:"fordisplay"`
 	Forvirtualnetwork         bool   `json:"forvirtualnetwork"`
 	Hasannotations            bool   `json:"hasannotations"`
+	Hasrules                  bool   `json:"hasrules"`
 	Id                        string `json:"id"`
 	Ipaddress                 string `json:"ipaddress"`
 	Isportable                bool   `json:"isportable"`
@@ -941,6 +963,7 @@ type PublicIpAddress struct {
 	Virtualmachinedisplayname string `json:"virtualmachinedisplayname"`
 	Virtualmachineid          string `json:"virtualmachineid"`
 	Virtualmachinename        string `json:"virtualmachinename"`
+	Virtualmachinetype        string `json:"virtualmachinetype"`
 	Vlanid                    string `json:"vlanid"`
 	Vlanname                  string `json:"vlanname"`
 	Vmipaddress               string `json:"vmipaddress"`
@@ -1071,6 +1094,7 @@ type UpdateIpAddressResponse struct {
 	Fordisplay                bool   `json:"fordisplay"`
 	Forvirtualnetwork         bool   `json:"forvirtualnetwork"`
 	Hasannotations            bool   `json:"hasannotations"`
+	Hasrules                  bool   `json:"hasrules"`
 	Id                        string `json:"id"`
 	Ipaddress                 string `json:"ipaddress"`
 	Isportable                bool   `json:"isportable"`
@@ -1090,6 +1114,7 @@ type UpdateIpAddressResponse struct {
 	Virtualmachinedisplayname string `json:"virtualmachinedisplayname"`
 	Virtualmachineid          string `json:"virtualmachineid"`
 	Virtualmachinename        string `json:"virtualmachinename"`
+	Virtualmachinetype        string `json:"virtualmachinetype"`
 	Vlanid                    string `json:"vlanid"`
 	Vlanname                  string `json:"vlanname"`
 	Vmipaddress               string `json:"vmipaddress"`

--- a/cloudstack/AsyncjobService.go
+++ b/cloudstack/AsyncjobService.go
@@ -59,6 +59,9 @@ func (p *ListAsyncJobsParams) toURLValues() url.Values {
 		vv := strconv.FormatBool(v.(bool))
 		u.Set("listall", vv)
 	}
+	if v, found := p.p["managementserverid"]; found {
+		u.Set("managementserverid", v.(string))
+	}
 	if v, found := p.p["page"]; found {
 		vv := strconv.Itoa(v.(int))
 		u.Set("page", vv)
@@ -148,6 +151,21 @@ func (p *ListAsyncJobsParams) GetListall() (bool, bool) {
 	return value, ok
 }
 
+func (p *ListAsyncJobsParams) SetManagementserverid(v UUID) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managementserverid"] = v
+}
+
+func (p *ListAsyncJobsParams) GetManagementserverid() (UUID, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["managementserverid"].(UUID)
+	return value, ok
+}
+
 func (p *ListAsyncJobsParams) SetPage(v int) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -222,19 +240,23 @@ type ListAsyncJobsResponse struct {
 }
 
 type AsyncJob struct {
-	Accountid       string          `json:"accountid"`
-	Cmd             string          `json:"cmd"`
-	Completed       string          `json:"completed"`
-	Created         string          `json:"created"`
-	JobID           string          `json:"jobid"`
-	Jobinstanceid   string          `json:"jobinstanceid"`
-	Jobinstancetype string          `json:"jobinstancetype"`
-	Jobprocstatus   int             `json:"jobprocstatus"`
-	Jobresult       json.RawMessage `json:"jobresult"`
-	Jobresultcode   int             `json:"jobresultcode"`
-	Jobresulttype   string          `json:"jobresulttype"`
-	Jobstatus       int             `json:"jobstatus"`
-	Userid          string          `json:"userid"`
+	Account            string          `json:"account"`
+	Accountid          string          `json:"accountid"`
+	Cmd                string          `json:"cmd"`
+	Completed          string          `json:"completed"`
+	Created            string          `json:"created"`
+	Domainid           string          `json:"domainid"`
+	Domainpath         string          `json:"domainpath"`
+	JobID              string          `json:"jobid"`
+	Jobinstanceid      string          `json:"jobinstanceid"`
+	Jobinstancetype    string          `json:"jobinstancetype"`
+	Jobprocstatus      int             `json:"jobprocstatus"`
+	Jobresult          json.RawMessage `json:"jobresult"`
+	Jobresultcode      int             `json:"jobresultcode"`
+	Jobresulttype      string          `json:"jobresulttype"`
+	Jobstatus          int             `json:"jobstatus"`
+	Managementserverid UUID            `json:"managementserverid"`
+	Userid             string          `json:"userid"`
 }
 
 type QueryAsyncJobResultParams struct {
@@ -302,17 +324,21 @@ func (s *AsyncjobService) QueryAsyncJobResult(p *QueryAsyncJobResultParams) (*Qu
 }
 
 type QueryAsyncJobResultResponse struct {
-	Accountid       string          `json:"accountid"`
-	Cmd             string          `json:"cmd"`
-	Completed       string          `json:"completed"`
-	Created         string          `json:"created"`
-	JobID           string          `json:"jobid"`
-	Jobinstanceid   string          `json:"jobinstanceid"`
-	Jobinstancetype string          `json:"jobinstancetype"`
-	Jobprocstatus   int             `json:"jobprocstatus"`
-	Jobresult       json.RawMessage `json:"jobresult"`
-	Jobresultcode   int             `json:"jobresultcode"`
-	Jobresulttype   string          `json:"jobresulttype"`
-	Jobstatus       int             `json:"jobstatus"`
-	Userid          string          `json:"userid"`
+	Account            string          `json:"account"`
+	Accountid          string          `json:"accountid"`
+	Cmd                string          `json:"cmd"`
+	Completed          string          `json:"completed"`
+	Created            string          `json:"created"`
+	Domainid           string          `json:"domainid"`
+	Domainpath         string          `json:"domainpath"`
+	JobID              string          `json:"jobid"`
+	Jobinstanceid      string          `json:"jobinstanceid"`
+	Jobinstancetype    string          `json:"jobinstancetype"`
+	Jobprocstatus      int             `json:"jobprocstatus"`
+	Jobresult          json.RawMessage `json:"jobresult"`
+	Jobresultcode      int             `json:"jobresultcode"`
+	Jobresulttype      string          `json:"jobresulttype"`
+	Jobstatus          int             `json:"jobstatus"`
+	Managementserverid UUID            `json:"managementserverid"`
+	Userid             string          `json:"userid"`
 }

--- a/cloudstack/DiskOfferingService.go
+++ b/cloudstack/DiskOfferingService.go
@@ -29,7 +29,7 @@ import (
 
 type DiskOfferingServiceIface interface {
 	CreateDiskOffering(p *CreateDiskOfferingParams) (*CreateDiskOfferingResponse, error)
-	NewCreateDiskOfferingParams(displaytext string, name string) *CreateDiskOfferingParams
+	NewCreateDiskOfferingParams(name string) *CreateDiskOfferingParams
 	DeleteDiskOffering(p *DeleteDiskOfferingParams) (*DeleteDiskOfferingResponse, error)
 	NewDeleteDiskOfferingParams(id string) *DeleteDiskOfferingParams
 	ListDiskOfferings(p *ListDiskOfferingsParams) (*ListDiskOfferingsResponse, error)
@@ -639,10 +639,9 @@ func (p *CreateDiskOfferingParams) GetZoneid() ([]string, bool) {
 
 // You should always use this function to get a new CreateDiskOfferingParams instance,
 // as then you are sure you have configured all required params
-func (s *DiskOfferingService) NewCreateDiskOfferingParams(displaytext string, name string) *CreateDiskOfferingParams {
+func (s *DiskOfferingService) NewCreateDiskOfferingParams(name string) *CreateDiskOfferingParams {
 	p := &CreateDiskOfferingParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	return p
 }

--- a/cloudstack/DiskOfferingService_mock.go
+++ b/cloudstack/DiskOfferingService_mock.go
@@ -161,17 +161,17 @@ func (mr *MockDiskOfferingServiceIfaceMockRecorder) ListDiskOfferings(p interfac
 }
 
 // NewCreateDiskOfferingParams mocks base method.
-func (m *MockDiskOfferingServiceIface) NewCreateDiskOfferingParams(displaytext, name string) *CreateDiskOfferingParams {
+func (m *MockDiskOfferingServiceIface) NewCreateDiskOfferingParams(name string) *CreateDiskOfferingParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateDiskOfferingParams", displaytext, name)
+	ret := m.ctrl.Call(m, "NewCreateDiskOfferingParams", name)
 	ret0, _ := ret[0].(*CreateDiskOfferingParams)
 	return ret0
 }
 
 // NewCreateDiskOfferingParams indicates an expected call of NewCreateDiskOfferingParams.
-func (mr *MockDiskOfferingServiceIfaceMockRecorder) NewCreateDiskOfferingParams(displaytext, name interface{}) *gomock.Call {
+func (mr *MockDiskOfferingServiceIfaceMockRecorder) NewCreateDiskOfferingParams(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateDiskOfferingParams", reflect.TypeOf((*MockDiskOfferingServiceIface)(nil).NewCreateDiskOfferingParams), displaytext, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateDiskOfferingParams", reflect.TypeOf((*MockDiskOfferingServiceIface)(nil).NewCreateDiskOfferingParams), name)
 }
 
 // NewDeleteDiskOfferingParams mocks base method.

--- a/cloudstack/EventService.go
+++ b/cloudstack/EventService.go
@@ -381,6 +381,10 @@ func (p *ListEventsParams) toURLValues() url.Values {
 	if v, found := p.p["account"]; found {
 		u.Set("account", v.(string))
 	}
+	if v, found := p.p["archived"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("archived", vv)
+	}
 	if v, found := p.p["domainid"]; found {
 		u.Set("domainid", v.(string))
 	}
@@ -453,6 +457,21 @@ func (p *ListEventsParams) GetAccount() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["account"].(string)
+	return value, ok
+}
+
+func (p *ListEventsParams) SetArchived(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["archived"] = v
+}
+
+func (p *ListEventsParams) GetArchived() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["archived"].(bool)
 	return value, ok
 }
 
@@ -774,6 +793,7 @@ type ListEventsResponse struct {
 
 type Event struct {
 	Account      string `json:"account"`
+	Archived     bool   `json:"archived"`
 	Created      string `json:"created"`
 	Description  string `json:"description"`
 	Domain       string `json:"domain"`

--- a/cloudstack/GuestOSService_mock.go
+++ b/cloudstack/GuestOSService_mock.go
@@ -187,6 +187,48 @@ func (mr *MockGuestOSServiceIfaceMockRecorder) GetOsTypeByID(id interface{}, opt
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsTypeByID", reflect.TypeOf((*MockGuestOSServiceIface)(nil).GetOsTypeByID), varargs...)
 }
 
+// GetOsTypeByName mocks base method.
+func (m *MockGuestOSServiceIface) GetOsTypeByName(name string, opts ...OptionFunc) (*OsType, int, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{name}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetOsTypeByName", varargs...)
+	ret0, _ := ret[0].(*OsType)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOsTypeByName indicates an expected call of GetOsTypeByName.
+func (mr *MockGuestOSServiceIfaceMockRecorder) GetOsTypeByName(name interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{name}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsTypeByName", reflect.TypeOf((*MockGuestOSServiceIface)(nil).GetOsTypeByName), varargs...)
+}
+
+// GetOsTypeID mocks base method.
+func (m *MockGuestOSServiceIface) GetOsTypeID(keyword string, opts ...OptionFunc) (string, int, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{keyword}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetOsTypeID", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOsTypeID indicates an expected call of GetOsTypeID.
+func (mr *MockGuestOSServiceIfaceMockRecorder) GetOsTypeID(keyword interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{keyword}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsTypeID", reflect.TypeOf((*MockGuestOSServiceIface)(nil).GetOsTypeID), varargs...)
+}
+
 // ListGuestOsMapping mocks base method.
 func (m *MockGuestOSServiceIface) ListGuestOsMapping(p *ListGuestOsMappingParams) (*ListGuestOsMappingResponse, error) {
 	m.ctrl.T.Helper()
@@ -247,17 +289,17 @@ func (mr *MockGuestOSServiceIfaceMockRecorder) NewAddGuestOsMappingParams(hyperv
 }
 
 // NewAddGuestOsParams mocks base method.
-func (m *MockGuestOSServiceIface) NewAddGuestOsParams(details map[string]string, oscategoryid, osdisplayname string) *AddGuestOsParams {
+func (m *MockGuestOSServiceIface) NewAddGuestOsParams(oscategoryid, osdisplayname string) *AddGuestOsParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewAddGuestOsParams", details, oscategoryid, osdisplayname)
+	ret := m.ctrl.Call(m, "NewAddGuestOsParams", oscategoryid, osdisplayname)
 	ret0, _ := ret[0].(*AddGuestOsParams)
 	return ret0
 }
 
 // NewAddGuestOsParams indicates an expected call of NewAddGuestOsParams.
-func (mr *MockGuestOSServiceIfaceMockRecorder) NewAddGuestOsParams(details, oscategoryid, osdisplayname interface{}) *gomock.Call {
+func (mr *MockGuestOSServiceIfaceMockRecorder) NewAddGuestOsParams(oscategoryid, osdisplayname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddGuestOsParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewAddGuestOsParams), details, oscategoryid, osdisplayname)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddGuestOsParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewAddGuestOsParams), oscategoryid, osdisplayname)
 }
 
 // NewListGuestOsMappingParams mocks base method.
@@ -345,17 +387,17 @@ func (mr *MockGuestOSServiceIfaceMockRecorder) NewUpdateGuestOsMappingParams(id,
 }
 
 // NewUpdateGuestOsParams mocks base method.
-func (m *MockGuestOSServiceIface) NewUpdateGuestOsParams(details map[string]string, id, osdisplayname string) *UpdateGuestOsParams {
+func (m *MockGuestOSServiceIface) NewUpdateGuestOsParams(id, osdisplayname string) *UpdateGuestOsParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewUpdateGuestOsParams", details, id, osdisplayname)
+	ret := m.ctrl.Call(m, "NewUpdateGuestOsParams", id, osdisplayname)
 	ret0, _ := ret[0].(*UpdateGuestOsParams)
 	return ret0
 }
 
 // NewUpdateGuestOsParams indicates an expected call of NewUpdateGuestOsParams.
-func (mr *MockGuestOSServiceIfaceMockRecorder) NewUpdateGuestOsParams(details, id, osdisplayname interface{}) *gomock.Call {
+func (mr *MockGuestOSServiceIfaceMockRecorder) NewUpdateGuestOsParams(id, osdisplayname interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpdateGuestOsParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewUpdateGuestOsParams), details, id, osdisplayname)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpdateGuestOsParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewUpdateGuestOsParams), id, osdisplayname)
 }
 
 // RemoveGuestOs mocks base method.

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -47,7 +47,7 @@ type ISOServiceIface interface {
 	GetIsoByName(name string, isofilter string, zoneid string, opts ...OptionFunc) (*Iso, int, error)
 	GetIsoByID(id string, opts ...OptionFunc) (*Iso, int, error)
 	RegisterIso(p *RegisterIsoParams) (*RegisterIsoResponse, error)
-	NewRegisterIsoParams(displaytext string, name string, url string, zoneid string) *RegisterIsoParams
+	NewRegisterIsoParams(name string, url string, zoneid string) *RegisterIsoParams
 	UpdateIso(p *UpdateIsoParams) (*UpdateIsoResponse, error)
 	NewUpdateIsoParams(id string) *UpdateIsoParams
 	UpdateIsoPermissions(p *UpdateIsoPermissionsParams) (*UpdateIsoPermissionsResponse, error)
@@ -2040,10 +2040,9 @@ func (p *RegisterIsoParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new RegisterIsoParams instance,
 // as then you are sure you have configured all required params
-func (s *ISOService) NewRegisterIsoParams(displaytext string, name string, url string, zoneid string) *RegisterIsoParams {
+func (s *ISOService) NewRegisterIsoParams(name string, url string, zoneid string) *RegisterIsoParams {
 	p := &RegisterIsoParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	p.p["url"] = url
 	p.p["zoneid"] = zoneid

--- a/cloudstack/ISOService_mock.go
+++ b/cloudstack/ISOService_mock.go
@@ -340,17 +340,17 @@ func (mr *MockISOServiceIfaceMockRecorder) NewListIsosParams() *gomock.Call {
 }
 
 // NewRegisterIsoParams mocks base method.
-func (m *MockISOServiceIface) NewRegisterIsoParams(displaytext, name, url, zoneid string) *RegisterIsoParams {
+func (m *MockISOServiceIface) NewRegisterIsoParams(name, url, zoneid string) *RegisterIsoParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewRegisterIsoParams", displaytext, name, url, zoneid)
+	ret := m.ctrl.Call(m, "NewRegisterIsoParams", name, url, zoneid)
 	ret0, _ := ret[0].(*RegisterIsoParams)
 	return ret0
 }
 
 // NewRegisterIsoParams indicates an expected call of NewRegisterIsoParams.
-func (mr *MockISOServiceIfaceMockRecorder) NewRegisterIsoParams(displaytext, name, url, zoneid interface{}) *gomock.Call {
+func (mr *MockISOServiceIfaceMockRecorder) NewRegisterIsoParams(name, url, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRegisterIsoParams", reflect.TypeOf((*MockISOServiceIface)(nil).NewRegisterIsoParams), displaytext, name, url, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRegisterIsoParams", reflect.TypeOf((*MockISOServiceIface)(nil).NewRegisterIsoParams), name, url, zoneid)
 }
 
 // NewUpdateIsoParams mocks base method.

--- a/cloudstack/InfrastructureUsageService.go
+++ b/cloudstack/InfrastructureUsageService.go
@@ -291,6 +291,7 @@ type ManagementServersMetric struct {
 	Loginfo                 string  `json:"loginfo"`
 	Name                    string  `json:"name"`
 	Osdistribution          string  `json:"osdistribution"`
+	Serviceip               string  `json:"serviceip"`
 	Sessions                int64   `json:"sessions"`
 	State                   string  `json:"state"`
 	Systemcycleusage        string  `json:"systemcycleusage"`

--- a/cloudstack/KubernetesService_mock.go
+++ b/cloudstack/KubernetesService_mock.go
@@ -67,6 +67,21 @@ func (mr *MockKubernetesServiceIfaceMockRecorder) AddKubernetesSupportedVersion(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddKubernetesSupportedVersion", reflect.TypeOf((*MockKubernetesServiceIface)(nil).AddKubernetesSupportedVersion), p)
 }
 
+// AddVirtualMachinesToKubernetesCluster mocks base method.
+func (m *MockKubernetesServiceIface) AddVirtualMachinesToKubernetesCluster(p *AddVirtualMachinesToKubernetesClusterParams) (*AddVirtualMachinesToKubernetesClusterResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddVirtualMachinesToKubernetesCluster", p)
+	ret0, _ := ret[0].(*AddVirtualMachinesToKubernetesClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddVirtualMachinesToKubernetesCluster indicates an expected call of AddVirtualMachinesToKubernetesCluster.
+func (mr *MockKubernetesServiceIfaceMockRecorder) AddVirtualMachinesToKubernetesCluster(p interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVirtualMachinesToKubernetesCluster", reflect.TypeOf((*MockKubernetesServiceIface)(nil).AddVirtualMachinesToKubernetesCluster), p)
+}
+
 // CreateKubernetesCluster mocks base method.
 func (m *MockKubernetesServiceIface) CreateKubernetesCluster(p *CreateKubernetesClusterParams) (*CreateKubernetesClusterResponse, error) {
 	m.ctrl.T.Helper()
@@ -297,18 +312,32 @@ func (mr *MockKubernetesServiceIfaceMockRecorder) NewAddKubernetesSupportedVersi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddKubernetesSupportedVersionParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewAddKubernetesSupportedVersionParams), mincpunumber, minmemory, semanticversion)
 }
 
-// NewCreateKubernetesClusterParams mocks base method.
-func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(description, kubernetesversionid, name, serviceofferingid string, size int64, zoneid string) *CreateKubernetesClusterParams {
+// NewAddVirtualMachinesToKubernetesClusterParams mocks base method.
+func (m *MockKubernetesServiceIface) NewAddVirtualMachinesToKubernetesClusterParams(id string, virtualmachineids []string) *AddVirtualMachinesToKubernetesClusterParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", description, kubernetesversionid, name, serviceofferingid, size, zoneid)
+	ret := m.ctrl.Call(m, "NewAddVirtualMachinesToKubernetesClusterParams", id, virtualmachineids)
+	ret0, _ := ret[0].(*AddVirtualMachinesToKubernetesClusterParams)
+	return ret0
+}
+
+// NewAddVirtualMachinesToKubernetesClusterParams indicates an expected call of NewAddVirtualMachinesToKubernetesClusterParams.
+func (mr *MockKubernetesServiceIfaceMockRecorder) NewAddVirtualMachinesToKubernetesClusterParams(id, virtualmachineids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddVirtualMachinesToKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewAddVirtualMachinesToKubernetesClusterParams), id, virtualmachineids)
+}
+
+// NewCreateKubernetesClusterParams mocks base method.
+func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(clustertype, name, zoneid string) *CreateKubernetesClusterParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", clustertype, name, zoneid)
 	ret0, _ := ret[0].(*CreateKubernetesClusterParams)
 	return ret0
 }
 
 // NewCreateKubernetesClusterParams indicates an expected call of NewCreateKubernetesClusterParams.
-func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(description, kubernetesversionid, name, serviceofferingid, size, zoneid interface{}) *gomock.Call {
+func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(clustertype, name, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), description, kubernetesversionid, name, serviceofferingid, size, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), clustertype, name, zoneid)
 }
 
 // NewDeleteKubernetesClusterParams mocks base method.
@@ -381,6 +410,20 @@ func (mr *MockKubernetesServiceIfaceMockRecorder) NewListKubernetesSupportedVers
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListKubernetesSupportedVersionsParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewListKubernetesSupportedVersionsParams))
 }
 
+// NewRemoveVirtualMachinesFromKubernetesClusterParams mocks base method.
+func (m *MockKubernetesServiceIface) NewRemoveVirtualMachinesFromKubernetesClusterParams(id string, virtualmachineids []string) *RemoveVirtualMachinesFromKubernetesClusterParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewRemoveVirtualMachinesFromKubernetesClusterParams", id, virtualmachineids)
+	ret0, _ := ret[0].(*RemoveVirtualMachinesFromKubernetesClusterParams)
+	return ret0
+}
+
+// NewRemoveVirtualMachinesFromKubernetesClusterParams indicates an expected call of NewRemoveVirtualMachinesFromKubernetesClusterParams.
+func (mr *MockKubernetesServiceIfaceMockRecorder) NewRemoveVirtualMachinesFromKubernetesClusterParams(id, virtualmachineids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoveVirtualMachinesFromKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewRemoveVirtualMachinesFromKubernetesClusterParams), id, virtualmachineids)
+}
+
 // NewScaleKubernetesClusterParams mocks base method.
 func (m *MockKubernetesServiceIface) NewScaleKubernetesClusterParams(id string) *ScaleKubernetesClusterParams {
 	m.ctrl.T.Helper()
@@ -449,6 +492,21 @@ func (m *MockKubernetesServiceIface) NewUpgradeKubernetesClusterParams(id, kuber
 func (mr *MockKubernetesServiceIfaceMockRecorder) NewUpgradeKubernetesClusterParams(id, kubernetesversionid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpgradeKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewUpgradeKubernetesClusterParams), id, kubernetesversionid)
+}
+
+// RemoveVirtualMachinesFromKubernetesCluster mocks base method.
+func (m *MockKubernetesServiceIface) RemoveVirtualMachinesFromKubernetesCluster(p *RemoveVirtualMachinesFromKubernetesClusterParams) (*RemoveVirtualMachinesFromKubernetesClusterResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveVirtualMachinesFromKubernetesCluster", p)
+	ret0, _ := ret[0].(*RemoveVirtualMachinesFromKubernetesClusterResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveVirtualMachinesFromKubernetesCluster indicates an expected call of RemoveVirtualMachinesFromKubernetesCluster.
+func (mr *MockKubernetesServiceIfaceMockRecorder) RemoveVirtualMachinesFromKubernetesCluster(p interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVirtualMachinesFromKubernetesCluster", reflect.TypeOf((*MockKubernetesServiceIface)(nil).RemoveVirtualMachinesFromKubernetesCluster), p)
 }
 
 // ScaleKubernetesCluster mocks base method.

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -29,7 +29,7 @@ import (
 
 type NetworkOfferingServiceIface interface {
 	CreateNetworkOffering(p *CreateNetworkOfferingParams) (*CreateNetworkOfferingResponse, error)
-	NewCreateNetworkOfferingParams(displaytext string, guestiptype string, name string, traffictype string) *CreateNetworkOfferingParams
+	NewCreateNetworkOfferingParams(guestiptype string, name string, traffictype string) *CreateNetworkOfferingParams
 	DeleteNetworkOffering(p *DeleteNetworkOfferingParams) (*DeleteNetworkOfferingResponse, error)
 	NewDeleteNetworkOfferingParams(id string) *DeleteNetworkOfferingParams
 	ListNetworkOfferings(p *ListNetworkOfferingsParams) (*ListNetworkOfferingsResponse, error)
@@ -530,10 +530,9 @@ func (p *CreateNetworkOfferingParams) GetZoneid() ([]string, bool) {
 
 // You should always use this function to get a new CreateNetworkOfferingParams instance,
 // as then you are sure you have configured all required params
-func (s *NetworkOfferingService) NewCreateNetworkOfferingParams(displaytext string, guestiptype string, name string, traffictype string) *CreateNetworkOfferingParams {
+func (s *NetworkOfferingService) NewCreateNetworkOfferingParams(guestiptype string, name string, traffictype string) *CreateNetworkOfferingParams {
 	p := &CreateNetworkOfferingParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["guestiptype"] = guestiptype
 	p.p["name"] = name
 	p.p["traffictype"] = traffictype

--- a/cloudstack/NetworkOfferingService_mock.go
+++ b/cloudstack/NetworkOfferingService_mock.go
@@ -161,17 +161,17 @@ func (mr *MockNetworkOfferingServiceIfaceMockRecorder) ListNetworkOfferings(p in
 }
 
 // NewCreateNetworkOfferingParams mocks base method.
-func (m *MockNetworkOfferingServiceIface) NewCreateNetworkOfferingParams(displaytext, guestiptype, name, traffictype string) *CreateNetworkOfferingParams {
+func (m *MockNetworkOfferingServiceIface) NewCreateNetworkOfferingParams(guestiptype, name, traffictype string) *CreateNetworkOfferingParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateNetworkOfferingParams", displaytext, guestiptype, name, traffictype)
+	ret := m.ctrl.Call(m, "NewCreateNetworkOfferingParams", guestiptype, name, traffictype)
 	ret0, _ := ret[0].(*CreateNetworkOfferingParams)
 	return ret0
 }
 
 // NewCreateNetworkOfferingParams indicates an expected call of NewCreateNetworkOfferingParams.
-func (mr *MockNetworkOfferingServiceIfaceMockRecorder) NewCreateNetworkOfferingParams(displaytext, guestiptype, name, traffictype interface{}) *gomock.Call {
+func (mr *MockNetworkOfferingServiceIfaceMockRecorder) NewCreateNetworkOfferingParams(guestiptype, name, traffictype interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateNetworkOfferingParams", reflect.TypeOf((*MockNetworkOfferingServiceIface)(nil).NewCreateNetworkOfferingParams), displaytext, guestiptype, name, traffictype)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateNetworkOfferingParams", reflect.TypeOf((*MockNetworkOfferingServiceIface)(nil).NewCreateNetworkOfferingParams), guestiptype, name, traffictype)
 }
 
 // NewDeleteNetworkOfferingParams mocks base method.

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -351,7 +351,7 @@ func (s *NetworkService) NewAddOpenDaylightControllerParams(password string, phy
 	return p
 }
 
-// Adds an OpenDaylight controller
+// Adds an OpenDyalight controler
 func (s *NetworkService) AddOpenDaylightController(p *AddOpenDaylightControllerParams) (*AddOpenDaylightControllerResponse, error) {
 	resp, err := s.cs.newRequest("addOpenDaylightController", p.toURLValues())
 	if err != nil {
@@ -502,6 +502,9 @@ func (p *CreateNetworkParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["routeripv6"]; found {
 		u.Set("routeripv6", v.(string))
+	}
+	if v, found := p.p["sourcenatipaddress"]; found {
+		u.Set("sourcenatipaddress", v.(string))
 	}
 	if v, found := p.p["startip"]; found {
 		u.Set("startip", v.(string))
@@ -990,6 +993,21 @@ func (p *CreateNetworkParams) GetRouteripv6() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["routeripv6"].(string)
+	return value, ok
+}
+
+func (p *CreateNetworkParams) SetSourcenatipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcenatipaddress"] = v
+}
+
+func (p *CreateNetworkParams) GetSourcenatipaddress() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["sourcenatipaddress"].(string)
 	return value, ok
 }
 
@@ -2210,7 +2228,7 @@ func (s *NetworkService) NewDeleteOpenDaylightControllerParams(id string) *Delet
 	return p
 }
 
-// Removes an OpenDaylight controller
+// Removes an OpenDyalight controler
 func (s *NetworkService) DeleteOpenDaylightController(p *DeleteOpenDaylightControllerParams) (*DeleteOpenDaylightControllerResponse, error) {
 	resp, err := s.cs.newRequest("deleteOpenDaylightController", p.toURLValues())
 	if err != nil {
@@ -3031,6 +3049,10 @@ func (p *ListNetworksParams) toURLValues() url.Values {
 		vv := strconv.FormatBool(v.(bool))
 		u.Set("restartrequired", vv)
 	}
+	if v, found := p.p["retrieveonlyresourcecount"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("retrieveonlyresourcecount", vv)
+	}
 	if v, found := p.p["showicon"]; found {
 		vv := strconv.FormatBool(v.(bool))
 		u.Set("showicon", vv)
@@ -3350,6 +3372,21 @@ func (p *ListNetworksParams) GetRestartrequired() (bool, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["restartrequired"].(bool)
+	return value, ok
+}
+
+func (p *ListNetworksParams) SetRetrieveonlyresourcecount(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListNetworksParams) GetRetrieveonlyresourcecount() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["retrieveonlyresourcecount"].(bool)
 	return value, ok
 }
 
@@ -4034,7 +4071,7 @@ func (s *NetworkService) GetOpenDaylightControllerByID(id string, opts ...Option
 	return nil, l.Count, fmt.Errorf("There is more then one result for OpenDaylightController UUID: %s!", id)
 }
 
-// Lists OpenDaylight controllers
+// Lists OpenDyalight controllers
 func (s *NetworkService) ListOpenDaylightControllers(p *ListOpenDaylightControllersParams) (*ListOpenDaylightControllersResponse, error) {
 	resp, err := s.cs.newRequest("listOpenDaylightControllers", p.toURLValues())
 	if err != nil {
@@ -5202,6 +5239,9 @@ func (p *UpdateNetworkParams) toURLValues() url.Values {
 		vv := strconv.Itoa(v.(int))
 		u.Set("publicmtu", vv)
 	}
+	if v, found := p.p["sourcenatipaddress"]; found {
+		u.Set("sourcenatipaddress", v.(string))
+	}
 	if v, found := p.p["updateinsequence"]; found {
 		vv := strconv.FormatBool(v.(bool))
 		u.Set("updateinsequence", vv)
@@ -5461,6 +5501,21 @@ func (p *UpdateNetworkParams) GetPublicmtu() (int, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["publicmtu"].(int)
+	return value, ok
+}
+
+func (p *UpdateNetworkParams) SetSourcenatipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcenatipaddress"] = v
+}
+
+func (p *UpdateNetworkParams) GetSourcenatipaddress() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["sourcenatipaddress"].(string)
 	return value, ok
 }
 

--- a/cloudstack/PoolService.go
+++ b/cloudstack/PoolService.go
@@ -647,6 +647,9 @@ func (p *ListStoragePoolsParams) toURLValues() url.Values {
 	if v, found := p.p["scope"]; found {
 		u.Set("scope", v.(string))
 	}
+	if v, found := p.p["status"]; found {
+		u.Set("status", v.(string))
+	}
 	if v, found := p.p["zoneid"]; found {
 		u.Set("zoneid", v.(string))
 	}
@@ -800,6 +803,21 @@ func (p *ListStoragePoolsParams) GetScope() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["scope"].(string)
+	return value, ok
+}
+
+func (p *ListStoragePoolsParams) SetStatus(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["status"] = v
+}
+
+func (p *ListStoragePoolsParams) GetStatus() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["status"].(string)
 	return value, ok
 }
 

--- a/cloudstack/ProjectService.go
+++ b/cloudstack/ProjectService.go
@@ -35,7 +35,7 @@ type ProjectServiceIface interface {
 	AddUserToProject(p *AddUserToProjectParams) (*AddUserToProjectResponse, error)
 	NewAddUserToProjectParams(projectid string, username string) *AddUserToProjectParams
 	CreateProject(p *CreateProjectParams) (*CreateProjectResponse, error)
-	NewCreateProjectParams(displaytext string, name string) *CreateProjectParams
+	NewCreateProjectParams(name string) *CreateProjectParams
 	DeleteAccountFromProject(p *DeleteAccountFromProjectParams) (*DeleteAccountFromProjectResponse, error)
 	NewDeleteAccountFromProjectParams(account string, projectid string) *DeleteAccountFromProjectParams
 	DeleteUserFromProject(p *DeleteUserFromProjectParams) (*DeleteUserFromProjectResponse, error)
@@ -612,10 +612,9 @@ func (p *CreateProjectParams) GetUserid() (string, bool) {
 
 // You should always use this function to get a new CreateProjectParams instance,
 // as then you are sure you have configured all required params
-func (s *ProjectService) NewCreateProjectParams(displaytext string, name string) *CreateProjectParams {
+func (s *ProjectService) NewCreateProjectParams(name string) *CreateProjectParams {
 	p := &CreateProjectParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	return p
 }
@@ -1972,6 +1971,9 @@ func (p *UpdateProjectParams) toURLValues() url.Values {
 	if v, found := p.p["id"]; found {
 		u.Set("id", v.(string))
 	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
 	if v, found := p.p["roletype"]; found {
 		u.Set("roletype", v.(string))
 	}
@@ -2027,6 +2029,21 @@ func (p *UpdateProjectParams) GetId() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["id"].(string)
+	return value, ok
+}
+
+func (p *UpdateProjectParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+}
+
+func (p *UpdateProjectParams) GetName() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["name"].(string)
 	return value, ok
 }
 

--- a/cloudstack/ProjectService_mock.go
+++ b/cloudstack/ProjectService_mock.go
@@ -374,17 +374,17 @@ func (mr *MockProjectServiceIfaceMockRecorder) NewAddUserToProjectParams(project
 }
 
 // NewCreateProjectParams mocks base method.
-func (m *MockProjectServiceIface) NewCreateProjectParams(displaytext, name string) *CreateProjectParams {
+func (m *MockProjectServiceIface) NewCreateProjectParams(name string) *CreateProjectParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateProjectParams", displaytext, name)
+	ret := m.ctrl.Call(m, "NewCreateProjectParams", name)
 	ret0, _ := ret[0].(*CreateProjectParams)
 	return ret0
 }
 
 // NewCreateProjectParams indicates an expected call of NewCreateProjectParams.
-func (mr *MockProjectServiceIfaceMockRecorder) NewCreateProjectParams(displaytext, name interface{}) *gomock.Call {
+func (mr *MockProjectServiceIfaceMockRecorder) NewCreateProjectParams(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateProjectParams", reflect.TypeOf((*MockProjectServiceIface)(nil).NewCreateProjectParams), displaytext, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateProjectParams", reflect.TypeOf((*MockProjectServiceIface)(nil).NewCreateProjectParams), name)
 }
 
 // NewCreateProjectRolePermissionParams mocks base method.

--- a/cloudstack/RoleService.go
+++ b/cloudstack/RoleService.go
@@ -63,6 +63,10 @@ func (p *CreateRoleParams) toURLValues() url.Values {
 	if v, found := p.p["description"]; found {
 		u.Set("description", v.(string))
 	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
 	if v, found := p.p["name"]; found {
 		u.Set("name", v.(string))
 	}
@@ -87,6 +91,21 @@ func (p *CreateRoleParams) GetDescription() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["description"].(string)
+	return value, ok
+}
+
+func (p *CreateRoleParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+}
+
+func (p *CreateRoleParams) GetIspublic() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["ispublic"].(bool)
 	return value, ok
 }
 
@@ -166,6 +185,7 @@ type CreateRoleResponse struct {
 	Description string `json:"description"`
 	Id          string `json:"id"`
 	Isdefault   bool   `json:"isdefault"`
+	Ispublic    bool   `json:"ispublic"`
 	JobID       string `json:"jobid"`
 	Jobstatus   int    `json:"jobstatus"`
 	Name        string `json:"name"`
@@ -488,6 +508,10 @@ func (p *ImportRoleParams) toURLValues() url.Values {
 		vv := strconv.FormatBool(v.(bool))
 		u.Set("forced", vv)
 	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
+	}
 	if v, found := p.p["name"]; found {
 		u.Set("name", v.(string))
 	}
@@ -531,6 +555,21 @@ func (p *ImportRoleParams) GetForced() (bool, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["forced"].(bool)
+	return value, ok
+}
+
+func (p *ImportRoleParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+}
+
+func (p *ImportRoleParams) GetIspublic() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["ispublic"].(bool)
 	return value, ok
 }
 
@@ -608,6 +647,7 @@ type ImportRoleResponse struct {
 	Description string `json:"description"`
 	Id          string `json:"id"`
 	Isdefault   bool   `json:"isdefault"`
+	Ispublic    bool   `json:"ispublic"`
 	JobID       string `json:"jobid"`
 	Jobstatus   int    `json:"jobstatus"`
 	Name        string `json:"name"`
@@ -920,6 +960,7 @@ type Role struct {
 	Description string `json:"description"`
 	Id          string `json:"id"`
 	Isdefault   bool   `json:"isdefault"`
+	Ispublic    bool   `json:"ispublic"`
 	JobID       string `json:"jobid"`
 	Jobstatus   int    `json:"jobstatus"`
 	Name        string `json:"name"`
@@ -943,6 +984,10 @@ func (p *UpdateRoleParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["id"]; found {
 		u.Set("id", v.(string))
+	}
+	if v, found := p.p["ispublic"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("ispublic", vv)
 	}
 	if v, found := p.p["name"]; found {
 		u.Set("name", v.(string))
@@ -980,6 +1025,21 @@ func (p *UpdateRoleParams) GetId() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["id"].(string)
+	return value, ok
+}
+
+func (p *UpdateRoleParams) SetIspublic(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["ispublic"] = v
+}
+
+func (p *UpdateRoleParams) GetIspublic() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["ispublic"].(bool)
 	return value, ok
 }
 
@@ -1041,6 +1101,7 @@ type UpdateRoleResponse struct {
 	Description string `json:"description"`
 	Id          string `json:"id"`
 	Isdefault   bool   `json:"isdefault"`
+	Ispublic    bool   `json:"ispublic"`
 	JobID       string `json:"jobid"`
 	Jobstatus   int    `json:"jobstatus"`
 	Name        string `json:"name"`

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -29,7 +29,7 @@ import (
 
 type ServiceOfferingServiceIface interface {
 	CreateServiceOffering(p *CreateServiceOfferingParams) (*CreateServiceOfferingResponse, error)
-	NewCreateServiceOfferingParams(displaytext string, name string) *CreateServiceOfferingParams
+	NewCreateServiceOfferingParams(name string) *CreateServiceOfferingParams
 	DeleteServiceOffering(p *DeleteServiceOfferingParams) (*DeleteServiceOfferingResponse, error)
 	NewDeleteServiceOfferingParams(id string) *DeleteServiceOfferingParams
 	ListServiceOfferings(p *ListServiceOfferingsParams) (*ListServiceOfferingsResponse, error)
@@ -940,10 +940,9 @@ func (p *CreateServiceOfferingParams) GetZoneid() ([]string, bool) {
 
 // You should always use this function to get a new CreateServiceOfferingParams instance,
 // as then you are sure you have configured all required params
-func (s *ServiceOfferingService) NewCreateServiceOfferingParams(displaytext string, name string) *CreateServiceOfferingParams {
+func (s *ServiceOfferingService) NewCreateServiceOfferingParams(name string) *CreateServiceOfferingParams {
 	p := &CreateServiceOfferingParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	return p
 }

--- a/cloudstack/ServiceOfferingService_mock.go
+++ b/cloudstack/ServiceOfferingService_mock.go
@@ -161,17 +161,17 @@ func (mr *MockServiceOfferingServiceIfaceMockRecorder) ListServiceOfferings(p in
 }
 
 // NewCreateServiceOfferingParams mocks base method.
-func (m *MockServiceOfferingServiceIface) NewCreateServiceOfferingParams(displaytext, name string) *CreateServiceOfferingParams {
+func (m *MockServiceOfferingServiceIface) NewCreateServiceOfferingParams(name string) *CreateServiceOfferingParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateServiceOfferingParams", displaytext, name)
+	ret := m.ctrl.Call(m, "NewCreateServiceOfferingParams", name)
 	ret0, _ := ret[0].(*CreateServiceOfferingParams)
 	return ret0
 }
 
 // NewCreateServiceOfferingParams indicates an expected call of NewCreateServiceOfferingParams.
-func (mr *MockServiceOfferingServiceIfaceMockRecorder) NewCreateServiceOfferingParams(displaytext, name interface{}) *gomock.Call {
+func (mr *MockServiceOfferingServiceIfaceMockRecorder) NewCreateServiceOfferingParams(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateServiceOfferingParams", reflect.TypeOf((*MockServiceOfferingServiceIface)(nil).NewCreateServiceOfferingParams), displaytext, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateServiceOfferingParams", reflect.TypeOf((*MockServiceOfferingServiceIface)(nil).NewCreateServiceOfferingParams), name)
 }
 
 // NewDeleteServiceOfferingParams mocks base method.

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -31,7 +31,7 @@ type TemplateServiceIface interface {
 	CopyTemplate(p *CopyTemplateParams) (*CopyTemplateResponse, error)
 	NewCopyTemplateParams(id string) *CopyTemplateParams
 	CreateTemplate(p *CreateTemplateParams) (*CreateTemplateResponse, error)
-	NewCreateTemplateParams(displaytext string, name string, ostypeid string) *CreateTemplateParams
+	NewCreateTemplateParams(name string, ostypeid string) *CreateTemplateParams
 	DeleteTemplate(p *DeleteTemplateParams) (*DeleteTemplateResponse, error)
 	NewDeleteTemplateParams(id string) *DeleteTemplateParams
 	ExtractTemplate(p *ExtractTemplateParams) (*ExtractTemplateResponse, error)
@@ -49,7 +49,7 @@ type TemplateServiceIface interface {
 	PrepareTemplate(p *PrepareTemplateParams) (*PrepareTemplateResponse, error)
 	NewPrepareTemplateParams(templateid string, zoneid string) *PrepareTemplateParams
 	RegisterTemplate(p *RegisterTemplateParams) (*RegisterTemplateResponse, error)
-	NewRegisterTemplateParams(displaytext string, format string, hypervisor string, name string, url string) *RegisterTemplateParams
+	NewRegisterTemplateParams(format string, hypervisor string, name string, url string) *RegisterTemplateParams
 	UpdateTemplate(p *UpdateTemplateParams) (*UpdateTemplateResponse, error)
 	NewUpdateTemplateParams(id string) *UpdateTemplateParams
 	UpdateTemplatePermissions(p *UpdateTemplatePermissionsParams) (*UpdateTemplatePermissionsResponse, error)
@@ -606,10 +606,9 @@ func (p *CreateTemplateParams) GetVolumeid() (string, bool) {
 
 // You should always use this function to get a new CreateTemplateParams instance,
 // as then you are sure you have configured all required params
-func (s *TemplateService) NewCreateTemplateParams(displaytext string, name string, ostypeid string) *CreateTemplateParams {
+func (s *TemplateService) NewCreateTemplateParams(name string, ostypeid string) *CreateTemplateParams {
 	p := &CreateTemplateParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	p.p["ostypeid"] = ostypeid
 	return p
@@ -2797,10 +2796,9 @@ func (p *RegisterTemplateParams) GetZoneids() ([]string, bool) {
 
 // You should always use this function to get a new RegisterTemplateParams instance,
 // as then you are sure you have configured all required params
-func (s *TemplateService) NewRegisterTemplateParams(displaytext string, format string, hypervisor string, name string, url string) *RegisterTemplateParams {
+func (s *TemplateService) NewRegisterTemplateParams(format string, hypervisor string, name string, url string) *RegisterTemplateParams {
 	p := &RegisterTemplateParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["format"] = format
 	p.p["hypervisor"] = hypervisor
 	p.p["name"] = name

--- a/cloudstack/TemplateService_mock.go
+++ b/cloudstack/TemplateService_mock.go
@@ -292,17 +292,17 @@ func (mr *MockTemplateServiceIfaceMockRecorder) NewCopyTemplateParams(id interfa
 }
 
 // NewCreateTemplateParams mocks base method.
-func (m *MockTemplateServiceIface) NewCreateTemplateParams(displaytext, name, ostypeid string) *CreateTemplateParams {
+func (m *MockTemplateServiceIface) NewCreateTemplateParams(name, ostypeid string) *CreateTemplateParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateTemplateParams", displaytext, name, ostypeid)
+	ret := m.ctrl.Call(m, "NewCreateTemplateParams", name, ostypeid)
 	ret0, _ := ret[0].(*CreateTemplateParams)
 	return ret0
 }
 
 // NewCreateTemplateParams indicates an expected call of NewCreateTemplateParams.
-func (mr *MockTemplateServiceIfaceMockRecorder) NewCreateTemplateParams(displaytext, name, ostypeid interface{}) *gomock.Call {
+func (mr *MockTemplateServiceIfaceMockRecorder) NewCreateTemplateParams(name, ostypeid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateTemplateParams", reflect.TypeOf((*MockTemplateServiceIface)(nil).NewCreateTemplateParams), displaytext, name, ostypeid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateTemplateParams", reflect.TypeOf((*MockTemplateServiceIface)(nil).NewCreateTemplateParams), name, ostypeid)
 }
 
 // NewDeleteTemplateParams mocks base method.
@@ -418,17 +418,17 @@ func (mr *MockTemplateServiceIfaceMockRecorder) NewProvisionTemplateDirectDownlo
 }
 
 // NewRegisterTemplateParams mocks base method.
-func (m *MockTemplateServiceIface) NewRegisterTemplateParams(displaytext, format, hypervisor, name, url string) *RegisterTemplateParams {
+func (m *MockTemplateServiceIface) NewRegisterTemplateParams(format, hypervisor, name, url string) *RegisterTemplateParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewRegisterTemplateParams", displaytext, format, hypervisor, name, url)
+	ret := m.ctrl.Call(m, "NewRegisterTemplateParams", format, hypervisor, name, url)
 	ret0, _ := ret[0].(*RegisterTemplateParams)
 	return ret0
 }
 
 // NewRegisterTemplateParams indicates an expected call of NewRegisterTemplateParams.
-func (mr *MockTemplateServiceIfaceMockRecorder) NewRegisterTemplateParams(displaytext, format, hypervisor, name, url interface{}) *gomock.Call {
+func (mr *MockTemplateServiceIfaceMockRecorder) NewRegisterTemplateParams(format, hypervisor, name, url interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRegisterTemplateParams", reflect.TypeOf((*MockTemplateServiceIface)(nil).NewRegisterTemplateParams), displaytext, format, hypervisor, name, url)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRegisterTemplateParams", reflect.TypeOf((*MockTemplateServiceIface)(nil).NewRegisterTemplateParams), format, hypervisor, name, url)
 }
 
 // NewUpdateTemplateParams mocks base method.

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -33,9 +33,9 @@ type VPCServiceIface interface {
 	CreateStaticRoute(p *CreateStaticRouteParams) (*CreateStaticRouteResponse, error)
 	NewCreateStaticRouteParams(cidr string, gatewayid string) *CreateStaticRouteParams
 	CreateVPC(p *CreateVPCParams) (*CreateVPCResponse, error)
-	NewCreateVPCParams(cidr string, displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams
+	NewCreateVPCParams(cidr string, name string, vpcofferingid string, zoneid string) *CreateVPCParams
 	CreateVPCOffering(p *CreateVPCOfferingParams) (*CreateVPCOfferingResponse, error)
-	NewCreateVPCOfferingParams(displaytext string, name string, supportedservices []string) *CreateVPCOfferingParams
+	NewCreateVPCOfferingParams(name string, supportedservices []string) *CreateVPCOfferingParams
 	DeletePrivateGateway(p *DeletePrivateGatewayParams) (*DeletePrivateGatewayResponse, error)
 	NewDeletePrivateGatewayParams(id string) *DeletePrivateGatewayParams
 	DeleteStaticRoute(p *DeleteStaticRouteParams) (*DeleteStaticRouteResponse, error)
@@ -513,6 +513,9 @@ func (p *CreateVPCParams) toURLValues() url.Values {
 		vv := strconv.Itoa(v.(int))
 		u.Set("publicmtu", vv)
 	}
+	if v, found := p.p["sourcenatipaddress"]; found {
+		u.Set("sourcenatipaddress", v.(string))
+	}
 	if v, found := p.p["start"]; found {
 		vv := strconv.FormatBool(v.(bool))
 		u.Set("start", vv)
@@ -721,6 +724,21 @@ func (p *CreateVPCParams) GetPublicmtu() (int, bool) {
 	return value, ok
 }
 
+func (p *CreateVPCParams) SetSourcenatipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcenatipaddress"] = v
+}
+
+func (p *CreateVPCParams) GetSourcenatipaddress() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["sourcenatipaddress"].(string)
+	return value, ok
+}
+
 func (p *CreateVPCParams) SetStart(v bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -768,11 +786,10 @@ func (p *CreateVPCParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new CreateVPCParams instance,
 // as then you are sure you have configured all required params
-func (s *VPCService) NewCreateVPCParams(cidr string, displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams {
+func (s *VPCService) NewCreateVPCParams(cidr string, name string, vpcofferingid string, zoneid string) *CreateVPCParams {
 	p := &CreateVPCParams{}
 	p.p = make(map[string]interface{})
 	p.p["cidr"] = cidr
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	p.p["vpcofferingid"] = vpcofferingid
 	p.p["zoneid"] = zoneid
@@ -1079,10 +1096,9 @@ func (p *CreateVPCOfferingParams) GetZoneid() ([]string, bool) {
 
 // You should always use this function to get a new CreateVPCOfferingParams instance,
 // as then you are sure you have configured all required params
-func (s *VPCService) NewCreateVPCOfferingParams(displaytext string, name string, supportedservices []string) *CreateVPCOfferingParams {
+func (s *VPCService) NewCreateVPCOfferingParams(name string, supportedservices []string) *CreateVPCOfferingParams {
 	p := &CreateVPCOfferingParams{}
 	p.p = make(map[string]interface{})
-	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	p.p["supportedservices"] = supportedservices
 	return p
@@ -3219,6 +3235,9 @@ func (p *UpdateVPCParams) toURLValues() url.Values {
 		vv := strconv.Itoa(v.(int))
 		u.Set("publicmtu", vv)
 	}
+	if v, found := p.p["sourcenatipaddress"]; found {
+		u.Set("sourcenatipaddress", v.(string))
+	}
 	return u
 }
 
@@ -3309,6 +3328,21 @@ func (p *UpdateVPCParams) GetPublicmtu() (int, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["publicmtu"].(int)
+	return value, ok
+}
+
+func (p *UpdateVPCParams) SetSourcenatipaddress(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sourcenatipaddress"] = v
+}
+
+func (p *UpdateVPCParams) GetSourcenatipaddress() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["sourcenatipaddress"].(string)
 	return value, ok
 }
 

--- a/cloudstack/VPCService_mock.go
+++ b/cloudstack/VPCService_mock.go
@@ -429,31 +429,31 @@ func (mr *MockVPCServiceIfaceMockRecorder) NewCreateStaticRouteParams(cidr, gate
 }
 
 // NewCreateVPCOfferingParams mocks base method.
-func (m *MockVPCServiceIface) NewCreateVPCOfferingParams(displaytext, name string, supportedservices []string) *CreateVPCOfferingParams {
+func (m *MockVPCServiceIface) NewCreateVPCOfferingParams(name string, supportedservices []string) *CreateVPCOfferingParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateVPCOfferingParams", displaytext, name, supportedservices)
+	ret := m.ctrl.Call(m, "NewCreateVPCOfferingParams", name, supportedservices)
 	ret0, _ := ret[0].(*CreateVPCOfferingParams)
 	return ret0
 }
 
 // NewCreateVPCOfferingParams indicates an expected call of NewCreateVPCOfferingParams.
-func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCOfferingParams(displaytext, name, supportedservices interface{}) *gomock.Call {
+func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCOfferingParams(name, supportedservices interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateVPCOfferingParams", reflect.TypeOf((*MockVPCServiceIface)(nil).NewCreateVPCOfferingParams), displaytext, name, supportedservices)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateVPCOfferingParams", reflect.TypeOf((*MockVPCServiceIface)(nil).NewCreateVPCOfferingParams), name, supportedservices)
 }
 
 // NewCreateVPCParams mocks base method.
-func (m *MockVPCServiceIface) NewCreateVPCParams(cidr, displaytext, name, vpcofferingid, zoneid string) *CreateVPCParams {
+func (m *MockVPCServiceIface) NewCreateVPCParams(cidr, name, vpcofferingid, zoneid string) *CreateVPCParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateVPCParams", cidr, displaytext, name, vpcofferingid, zoneid)
+	ret := m.ctrl.Call(m, "NewCreateVPCParams", cidr, name, vpcofferingid, zoneid)
 	ret0, _ := ret[0].(*CreateVPCParams)
 	return ret0
 }
 
 // NewCreateVPCParams indicates an expected call of NewCreateVPCParams.
-func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCParams(cidr, displaytext, name, vpcofferingid, zoneid interface{}) *gomock.Call {
+func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCParams(cidr, name, vpcofferingid, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateVPCParams", reflect.TypeOf((*MockVPCServiceIface)(nil).NewCreateVPCParams), cidr, displaytext, name, vpcofferingid, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateVPCParams", reflect.TypeOf((*MockVPCServiceIface)(nil).NewCreateVPCParams), cidr, name, vpcofferingid, zoneid)
 }
 
 // NewDeletePrivateGatewayParams mocks base method.

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -1214,6 +1214,10 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 		vv := strings.Join(v.([]string), ",")
 		u.Set("networkids", vv)
 	}
+	if v, found := p.p["nicmultiqueuenumber"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("nicmultiqueuenumber", vv)
+	}
 	if v, found := p.p["nicnetworklist"]; found {
 		l := v.([]map[string]string)
 		for i, m := range l {
@@ -1221,6 +1225,10 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 				u.Set(fmt.Sprintf("nicnetworklist[%d].%s", i, key), val)
 			}
 		}
+	}
+	if v, found := p.p["nicpackedvirtqueuesenabled"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("nicpackedvirtqueuesenabled", vv)
 	}
 	if v, found := p.p["overridediskofferingid"]; found {
 		u.Set("overridediskofferingid", v.(string))
@@ -1806,6 +1814,21 @@ func (p *DeployVirtualMachineParams) GetNetworkids() ([]string, bool) {
 	return value, ok
 }
 
+func (p *DeployVirtualMachineParams) SetNicmultiqueuenumber(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicmultiqueuenumber"] = v
+}
+
+func (p *DeployVirtualMachineParams) GetNicmultiqueuenumber() (int, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["nicmultiqueuenumber"].(int)
+	return value, ok
+}
+
 func (p *DeployVirtualMachineParams) SetNicnetworklist(v []map[string]string) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1833,6 +1856,21 @@ func (p *DeployVirtualMachineParams) AddNicnetworklist(item map[string]string) {
 	l := val.([]map[string]string)
 	l = append(l, item)
 	p.p["nicnetworklist"] = l
+}
+
+func (p *DeployVirtualMachineParams) SetNicpackedvirtqueuesenabled(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["nicpackedvirtqueuesenabled"] = v
+}
+
+func (p *DeployVirtualMachineParams) GetNicpackedvirtqueuesenabled() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["nicpackedvirtqueuesenabled"].(bool)
+	return value, ok
 }
 
 func (p *DeployVirtualMachineParams) SetOverridediskofferingid(v string) {
@@ -2768,6 +2806,10 @@ func (p *ListVirtualMachinesParams) toURLValues() url.Values {
 	if v, found := p.p["projectid"]; found {
 		u.Set("projectid", v.(string))
 	}
+	if v, found := p.p["retrieveonlyresourcecount"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("retrieveonlyresourcecount", vv)
+	}
 	if v, found := p.p["securitygroupid"]; found {
 		u.Set("securitygroupid", v.(string))
 	}
@@ -3212,6 +3254,21 @@ func (p *ListVirtualMachinesParams) GetProjectid() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["projectid"].(string)
+	return value, ok
+}
+
+func (p *ListVirtualMachinesParams) SetRetrieveonlyresourcecount(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListVirtualMachinesParams) GetRetrieveonlyresourcecount() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["retrieveonlyresourcecount"].(bool)
 	return value, ok
 }
 
@@ -3748,6 +3805,10 @@ func (p *ListVirtualMachinesMetricsParams) toURLValues() url.Values {
 	if v, found := p.p["projectid"]; found {
 		u.Set("projectid", v.(string))
 	}
+	if v, found := p.p["retrieveonlyresourcecount"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("retrieveonlyresourcecount", vv)
+	}
 	if v, found := p.p["securitygroupid"]; found {
 		u.Set("securitygroupid", v.(string))
 	}
@@ -4192,6 +4253,21 @@ func (p *ListVirtualMachinesMetricsParams) GetProjectid() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["projectid"].(string)
+	return value, ok
+}
+
+func (p *ListVirtualMachinesMetricsParams) SetRetrieveonlyresourcecount(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) GetRetrieveonlyresourcecount() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["retrieveonlyresourcecount"].(bool)
 	return value, ok
 }
 
@@ -4931,6 +5007,10 @@ func (p *MigrateVirtualMachineWithVolumeParams) toURLValues() url.Values {
 	if p.p == nil {
 		return u
 	}
+	if v, found := p.p["autoselect"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("autoselect", vv)
+	}
 	if v, found := p.p["hostid"]; found {
 		u.Set("hostid", v.(string))
 	}
@@ -4946,6 +5026,21 @@ func (p *MigrateVirtualMachineWithVolumeParams) toURLValues() url.Values {
 		u.Set("virtualmachineid", v.(string))
 	}
 	return u
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) SetAutoselect(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["autoselect"] = v
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) GetAutoselect() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["autoselect"].(bool)
+	return value, ok
 }
 
 func (p *MigrateVirtualMachineWithVolumeParams) SetHostid(v string) {

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -1664,6 +1664,10 @@ func (p *ListVolumesParams) toURLValues() url.Values {
 	if v, found := p.p["projectid"]; found {
 		u.Set("projectid", v.(string))
 	}
+	if v, found := p.p["retrieveonlyresourcecount"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("retrieveonlyresourcecount", vv)
+	}
 	if v, found := p.p["state"]; found {
 		u.Set("state", v.(string))
 	}
@@ -1941,6 +1945,21 @@ func (p *ListVolumesParams) GetProjectid() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["projectid"].(string)
+	return value, ok
+}
+
+func (p *ListVolumesParams) SetRetrieveonlyresourcecount(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListVolumesParams) GetRetrieveonlyresourcecount() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["retrieveonlyresourcecount"].(bool)
 	return value, ok
 }
 
@@ -2283,6 +2302,10 @@ func (p *ListVolumesMetricsParams) toURLValues() url.Values {
 	if v, found := p.p["projectid"]; found {
 		u.Set("projectid", v.(string))
 	}
+	if v, found := p.p["retrieveonlyresourcecount"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("retrieveonlyresourcecount", vv)
+	}
 	if v, found := p.p["state"]; found {
 		u.Set("state", v.(string))
 	}
@@ -2560,6 +2583,21 @@ func (p *ListVolumesMetricsParams) GetProjectid() (string, bool) {
 		p.p = make(map[string]interface{})
 	}
 	value, ok := p.p["projectid"].(string)
+	return value, ok
+}
+
+func (p *ListVolumesMetricsParams) SetRetrieveonlyresourcecount(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListVolumesMetricsParams) GetRetrieveonlyresourcecount() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["retrieveonlyresourcecount"].(bool)
 	return value, ok
 }
 

--- a/generate/layout.go
+++ b/generate/layout.go
@@ -717,6 +717,8 @@ var layout = apiInfo{
 		"stopKubernetesCluster",
 		"updateKubernetesSupportedVersion",
 		"upgradeKubernetesCluster",
+		"addVirtualMachinesToKubernetesCluster",
+		"removeVirtualMachinesFromKubernetesCluster",
 	},
 	"InfrastructureUsageService": {
 		"listManagementServersMetrics",

--- a/test/DiskOfferingService_test.go
+++ b/test/DiskOfferingService_test.go
@@ -39,7 +39,7 @@ func TestDiskOfferingService(t *testing.T) {
 		if _, ok := response["createDiskOffering"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.DiskOffering.NewCreateDiskOfferingParams("displaytext", "name")
+		p := client.DiskOffering.NewCreateDiskOfferingParams("name")
 		r, err := client.DiskOffering.CreateDiskOffering(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/GuestOSService_test.go
+++ b/test/GuestOSService_test.go
@@ -39,7 +39,7 @@ func TestGuestOSService(t *testing.T) {
 		if _, ok := response["addGuestOs"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.GuestOS.NewAddGuestOsParams(map[string]string{}, "oscategoryid", "osdisplayname")
+		p := client.GuestOS.NewAddGuestOsParams("oscategoryid", "osdisplayname")
 		r, err := client.GuestOS.AddGuestOs(p)
 		if err != nil {
 			t.Errorf(err.Error())
@@ -129,7 +129,7 @@ func TestGuestOSService(t *testing.T) {
 		if _, ok := response["updateGuestOs"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.GuestOS.NewUpdateGuestOsParams(map[string]string{}, "id", "osdisplayname")
+		p := client.GuestOS.NewUpdateGuestOsParams("id", "osdisplayname")
 		r, err := client.GuestOS.UpdateGuestOs(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/ISOService_test.go
+++ b/test/ISOService_test.go
@@ -135,7 +135,7 @@ func TestISOService(t *testing.T) {
 		if _, ok := response["registerIso"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.ISO.NewRegisterIsoParams("displaytext", "name", "url", "zoneid")
+		p := client.ISO.NewRegisterIsoParams("name", "url", "zoneid")
 		r, err := client.ISO.RegisterIso(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/KubernetesService_test.go
+++ b/test/KubernetesService_test.go
@@ -54,7 +54,7 @@ func TestKubernetesService(t *testing.T) {
 		if _, ok := response["createKubernetesCluster"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Kubernetes.NewCreateKubernetesClusterParams("description", "kubernetesversionid", "name", "serviceofferingid", 0, "zoneid")
+		p := client.Kubernetes.NewCreateKubernetesClusterParams("clustertype", "name", "zoneid")
 		r, err := client.Kubernetes.CreateKubernetesCluster(p)
 		if err != nil {
 			t.Errorf(err.Error())
@@ -199,5 +199,32 @@ func TestKubernetesService(t *testing.T) {
 		}
 	}
 	t.Run("UpgradeKubernetesCluster", testupgradeKubernetesCluster)
+
+	testaddVirtualMachinesToKubernetesCluster := func(t *testing.T) {
+		if _, ok := response["addVirtualMachinesToKubernetesCluster"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Kubernetes.NewAddVirtualMachinesToKubernetesClusterParams("id", []string{})
+		_, err := client.Kubernetes.AddVirtualMachinesToKubernetesCluster(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("AddVirtualMachinesToKubernetesCluster", testaddVirtualMachinesToKubernetesCluster)
+
+	testremoveVirtualMachinesFromKubernetesCluster := func(t *testing.T) {
+		if _, ok := response["removeVirtualMachinesFromKubernetesCluster"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Kubernetes.NewRemoveVirtualMachinesFromKubernetesClusterParams("id", []string{})
+		r, err := client.Kubernetes.RemoveVirtualMachinesFromKubernetesCluster(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		if r.Id == "" {
+			t.Errorf("Failed to parse response. ID not found")
+		}
+	}
+	t.Run("RemoveVirtualMachinesFromKubernetesCluster", testremoveVirtualMachinesFromKubernetesCluster)
 
 }

--- a/test/NetworkOfferingService_test.go
+++ b/test/NetworkOfferingService_test.go
@@ -39,7 +39,7 @@ func TestNetworkOfferingService(t *testing.T) {
 		if _, ok := response["createNetworkOffering"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.NetworkOffering.NewCreateNetworkOfferingParams("displaytext", "guestiptype", "name", "traffictype")
+		p := client.NetworkOffering.NewCreateNetworkOfferingParams("guestiptype", "name", "traffictype")
 		r, err := client.NetworkOffering.CreateNetworkOffering(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/ProjectService_test.go
+++ b/test/ProjectService_test.go
@@ -78,7 +78,7 @@ func TestProjectService(t *testing.T) {
 		if _, ok := response["createProject"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Project.NewCreateProjectParams("displaytext", "name")
+		p := client.Project.NewCreateProjectParams("name")
 		r, err := client.Project.CreateProject(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/ServiceOfferingService_test.go
+++ b/test/ServiceOfferingService_test.go
@@ -39,7 +39,7 @@ func TestServiceOfferingService(t *testing.T) {
 		if _, ok := response["createServiceOffering"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.ServiceOffering.NewCreateServiceOfferingParams("displaytext", "name")
+		p := client.ServiceOffering.NewCreateServiceOfferingParams("name")
 		r, err := client.ServiceOffering.CreateServiceOffering(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/TemplateService_test.go
+++ b/test/TemplateService_test.go
@@ -54,7 +54,7 @@ func TestTemplateService(t *testing.T) {
 		if _, ok := response["createTemplate"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Template.NewCreateTemplateParams("displaytext", "name", "ostypeid")
+		p := client.Template.NewCreateTemplateParams("name", "ostypeid")
 		r, err := client.Template.CreateTemplate(p)
 		if err != nil {
 			t.Errorf(err.Error())
@@ -147,7 +147,7 @@ func TestTemplateService(t *testing.T) {
 		if _, ok := response["registerTemplate"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Template.NewRegisterTemplateParams("displaytext", "format", "hypervisor", "name", "url")
+		p := client.Template.NewRegisterTemplateParams("format", "hypervisor", "name", "url")
 		_, err := client.Template.RegisterTemplate(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/VPCService_test.go
+++ b/test/VPCService_test.go
@@ -69,7 +69,7 @@ func TestVPCService(t *testing.T) {
 		if _, ok := response["createVPC"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.VPC.NewCreateVPCParams("cidr", "displaytext", "name", "vpcofferingid", "zoneid")
+		p := client.VPC.NewCreateVPCParams("cidr", "name", "vpcofferingid", "zoneid")
 		r, err := client.VPC.CreateVPC(p)
 		if err != nil {
 			t.Errorf(err.Error())
@@ -84,7 +84,7 @@ func TestVPCService(t *testing.T) {
 		if _, ok := response["createVPCOffering"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.VPC.NewCreateVPCOfferingParams("displaytext", "name", []string{})
+		p := client.VPC.NewCreateVPCOfferingParams("name", []string{})
 		r, err := client.VPC.CreateVPCOffering(p)
 		if err != nil {
 			t.Errorf(err.Error())


### PR DESCRIPTION
Update APIs with latest main. Depends on https://github.com/apache/cloudstack/pull/7515

`displaytext` was made not required for a couple of APIs because of which there might be some breaking changes.
