### PR TITLE
Fix generation for UUID type

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1291,7 +1291,7 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 	pn := s.pn
 
 	switch typ {
-	case "string":
+	case "string", "UUID":
 		pn("u.Set(\"%s\", v.(string))", name)
 	case "int":
 		pn("vv := strconv.Itoa(v.(int))")


### PR DESCRIPTION
`managementserverid` has been added as a parameter in some APIs (`listAsyncJobs`, `readyForShutdown`, etc.) in 4.19. Generated output doesn't have the setters for `managementserverid` field in `toURLValues()` method.