### PR TITLE
Log apis missing in layout.go

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -2005,6 +2005,22 @@ func getUniqueTypeName(prefix, name string) (string, bool) {
 	return getUniqueTypeName(prefix, name+"Internal")
 }
 
+func logMissingApis(ai map[string]*API, as *allServices) {
+	asMap := make(map[string]*API)
+	for _, svc := range as.services {
+		for _, api := range svc.apis {
+			asMap[api.Name] = api
+		}
+	}
+
+	for apiName, _ := range ai {
+		_, found := asMap[apiName]
+		if !found {
+			log.Printf("Api missing in layout: %s", apiName)
+		}
+	}
+}
+
 func getAllServices(listApis string) (*allServices, []error, error) {
 	// Get a map with all API info
 	ai, err := getAPIInfo(listApis)
@@ -2035,6 +2051,8 @@ func getAllServices(listApis string) (*allServices, []error, error) {
 	// Add an extra field to enable adding a custom service
 	as.services = append(as.services, &service{name: "CustomService"})
 	sort.Sort(as.services)
+
+	logMissingApis(ai, as)
 
 	return as, errors, nil
 }


### PR DESCRIPTION
There are a lot of open issues regarding missing APIs in the SDK (e.g. - https://github.com/apache/cloudstack-go/issues/22, https://github.com/apache/cloudstack-go/issues/54, etc.)
This helps in identifying APIs which are missing in `layout.go` but present in `listApis.json`.