### PR TITLE
Adding getRawValue to CreateZone api

### DIFF
--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -364,6 +364,10 @@ func (s *ZoneService) CreateZone(p *CreateZoneParams) (*CreateZoneResponse, erro
 		return nil, err
 	}
 
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
 	var r CreateZoneResponse
 	if err := json.Unmarshal(resp, &r); err != nil {
 		return nil, err

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1725,6 +1725,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 		"CreateSecurityGroup",
 		"CreateServiceOffering",
 		"CreateUser",
+		"CreateZone",
 		"DedicateGuestVlanRange",
 		"EnableUser",
 		"GetVirtualMachineUserData",


### PR DESCRIPTION
Adding `getRawValue` function to `CreateZone` api.  

Fixes: https://github.com/apache/cloudstack-go/issues/66

