### PR TITLE
getRawValue - AddCluster and CreatePod

### DIFF
--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -434,6 +434,10 @@ func (s *ClusterService) AddCluster(p *AddClusterParams) (*AddClusterResponse, e
 		return nil, err
 	}
 
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
 	var r AddClusterResponse
 	if err := json.Unmarshal(resp, &r); err != nil {
 		return nil, err

--- a/cloudstack/PodService.go
+++ b/cloudstack/PodService.go
@@ -202,6 +202,10 @@ func (s *PodService) CreatePod(p *CreatePodParams) (*CreatePodResponse, error) {
 		return nil, err
 	}
 
+	if resp, err = getRawValue(resp); err != nil {
+		return nil, err
+	}
+
 	var r CreatePodResponse
 	if err := json.Unmarshal(resp, &r); err != nil {
 		return nil, err

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1710,6 +1710,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 	pn("")
 	switch n {
 	case
+		"AddCluster",
 		"AddImageStore",
 		"CreateAccount",
 		"CreateDomain",
@@ -1721,6 +1722,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 		"UpdateServiceOffering",
 		"UpdateConfiguration",
 		"UpdateCluster",
+		"CreatePod",
 		"CreateSSHKeyPair",
 		"CreateSecurityGroup",
 		"CreateServiceOffering",


### PR DESCRIPTION
Adding additional APIs to `getRawValue`.

- AddCluster
- CreatePod



```json
{
    "listclustersmetricsresponse": {
        "count": 1,
        "cluster": [
            {
                "state": "Enabled",
                 ....
}

```


```json
{
    "listpodsresponse": {
        "count": 1,
        "pod": [
            {
                "id": "82d8c07d-87c8-4e42-852e-7329f7ba2451",
                "name": "test",
                 ....
}
```

