### PR TITLE
Restore methods with optional params for 4.19 compatability

### DIFF
--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -31,7 +31,7 @@ type AddressServiceIface interface {
 	AssociateIpAddress(p *AssociateIpAddressParams) (*AssociateIpAddressResponse, error)
 	NewAssociateIpAddressParams() *AssociateIpAddressParams
 	DisassociateIpAddress(p *DisassociateIpAddressParams) (*DisassociateIpAddressResponse, error)
-	NewDisassociateIpAddressParams() *DisassociateIpAddressParams
+	NewDisassociateIpAddressParams(id string) *DisassociateIpAddressParams
 	ListPublicIpAddresses(p *ListPublicIpAddressesParams) (*ListPublicIpAddressesResponse, error)
 	NewListPublicIpAddressesParams() *ListPublicIpAddressesParams
 	GetPublicIpAddressByID(id string, opts ...OptionFunc) (*PublicIpAddress, int, error)
@@ -369,9 +369,10 @@ func (p *DisassociateIpAddressParams) GetIpaddress() (string, bool) {
 
 // You should always use this function to get a new DisassociateIpAddressParams instance,
 // as then you are sure you have configured all required params
-func (s *AddressService) NewDisassociateIpAddressParams() *DisassociateIpAddressParams {
+func (s *AddressService) NewDisassociateIpAddressParams(id string) *DisassociateIpAddressParams {
 	p := &DisassociateIpAddressParams{}
 	p.p = make(map[string]interface{})
+	p.p["id"] = id
 	return p
 }
 

--- a/cloudstack/AddressService_mock.go
+++ b/cloudstack/AddressService_mock.go
@@ -133,17 +133,17 @@ func (mr *MockAddressServiceIfaceMockRecorder) NewAssociateIpAddressParams() *go
 }
 
 // NewDisassociateIpAddressParams mocks base method.
-func (m *MockAddressServiceIface) NewDisassociateIpAddressParams() *DisassociateIpAddressParams {
+func (m *MockAddressServiceIface) NewDisassociateIpAddressParams(id string) *DisassociateIpAddressParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewDisassociateIpAddressParams")
+	ret := m.ctrl.Call(m, "NewDisassociateIpAddressParams", id)
 	ret0, _ := ret[0].(*DisassociateIpAddressParams)
 	return ret0
 }
 
 // NewDisassociateIpAddressParams indicates an expected call of NewDisassociateIpAddressParams.
-func (mr *MockAddressServiceIfaceMockRecorder) NewDisassociateIpAddressParams() *gomock.Call {
+func (mr *MockAddressServiceIfaceMockRecorder) NewDisassociateIpAddressParams(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDisassociateIpAddressParams", reflect.TypeOf((*MockAddressServiceIface)(nil).NewDisassociateIpAddressParams))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDisassociateIpAddressParams", reflect.TypeOf((*MockAddressServiceIface)(nil).NewDisassociateIpAddressParams), id)
 }
 
 // NewListPublicIpAddressesParams mocks base method.

--- a/cloudstack/KubernetesService.go
+++ b/cloudstack/KubernetesService.go
@@ -31,7 +31,7 @@ type KubernetesServiceIface interface {
 	AddKubernetesSupportedVersion(p *AddKubernetesSupportedVersionParams) (*AddKubernetesSupportedVersionResponse, error)
 	NewAddKubernetesSupportedVersionParams(mincpunumber int, minmemory int, semanticversion string) *AddKubernetesSupportedVersionParams
 	CreateKubernetesCluster(p *CreateKubernetesClusterParams) (*CreateKubernetesClusterResponse, error)
-	NewCreateKubernetesClusterParams(name string, zoneid string) *CreateKubernetesClusterParams
+	NewCreateKubernetesClusterParams(description string, kubernetesversionid string, name string, serviceofferingid string, size int64, zoneid string) *CreateKubernetesClusterParams
 	DeleteKubernetesCluster(p *DeleteKubernetesClusterParams) (*DeleteKubernetesClusterResponse, error)
 	NewDeleteKubernetesClusterParams(id string) *DeleteKubernetesClusterParams
 	DeleteKubernetesSupportedVersion(p *DeleteKubernetesSupportedVersionParams) (*DeleteKubernetesSupportedVersionResponse, error)
@@ -633,10 +633,14 @@ func (p *CreateKubernetesClusterParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new CreateKubernetesClusterParams instance,
 // as then you are sure you have configured all required params
-func (s *KubernetesService) NewCreateKubernetesClusterParams(name string, zoneid string) *CreateKubernetesClusterParams {
+func (s *KubernetesService) NewCreateKubernetesClusterParams(description string, kubernetesversionid string, name string, serviceofferingid string, size int64, zoneid string) *CreateKubernetesClusterParams {
 	p := &CreateKubernetesClusterParams{}
 	p.p = make(map[string]interface{})
+	p.p["description"] = description
+	p.p["kubernetesversionid"] = kubernetesversionid
 	p.p["name"] = name
+	p.p["serviceofferingid"] = serviceofferingid
+	p.p["size"] = size
 	p.p["zoneid"] = zoneid
 	return p
 }

--- a/cloudstack/KubernetesService.go
+++ b/cloudstack/KubernetesService.go
@@ -31,7 +31,7 @@ type KubernetesServiceIface interface {
 	AddKubernetesSupportedVersion(p *AddKubernetesSupportedVersionParams) (*AddKubernetesSupportedVersionResponse, error)
 	NewAddKubernetesSupportedVersionParams(mincpunumber int, minmemory int, semanticversion string) *AddKubernetesSupportedVersionParams
 	CreateKubernetesCluster(p *CreateKubernetesClusterParams) (*CreateKubernetesClusterResponse, error)
-	NewCreateKubernetesClusterParams(clustertype string, name string, zoneid string) *CreateKubernetesClusterParams
+	NewCreateKubernetesClusterParams(name string, zoneid string) *CreateKubernetesClusterParams
 	DeleteKubernetesCluster(p *DeleteKubernetesClusterParams) (*DeleteKubernetesClusterResponse, error)
 	NewDeleteKubernetesClusterParams(id string) *DeleteKubernetesClusterParams
 	DeleteKubernetesSupportedVersion(p *DeleteKubernetesSupportedVersionParams) (*DeleteKubernetesSupportedVersionResponse, error)
@@ -633,10 +633,9 @@ func (p *CreateKubernetesClusterParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new CreateKubernetesClusterParams instance,
 // as then you are sure you have configured all required params
-func (s *KubernetesService) NewCreateKubernetesClusterParams(clustertype string, name string, zoneid string) *CreateKubernetesClusterParams {
+func (s *KubernetesService) NewCreateKubernetesClusterParams(name string, zoneid string) *CreateKubernetesClusterParams {
 	p := &CreateKubernetesClusterParams{}
 	p.p = make(map[string]interface{})
-	p.p["clustertype"] = clustertype
 	p.p["name"] = name
 	p.p["zoneid"] = zoneid
 	return p

--- a/cloudstack/KubernetesService.go
+++ b/cloudstack/KubernetesService.go
@@ -31,7 +31,7 @@ type KubernetesServiceIface interface {
 	AddKubernetesSupportedVersion(p *AddKubernetesSupportedVersionParams) (*AddKubernetesSupportedVersionResponse, error)
 	NewAddKubernetesSupportedVersionParams(mincpunumber int, minmemory int, semanticversion string) *AddKubernetesSupportedVersionParams
 	CreateKubernetesCluster(p *CreateKubernetesClusterParams) (*CreateKubernetesClusterResponse, error)
-	NewCreateKubernetesClusterParams(name string, zoneid string) *CreateKubernetesClusterParams
+	NewCreateKubernetesClusterParams(clustertype string, name string, zoneid string) *CreateKubernetesClusterParams
 	DeleteKubernetesCluster(p *DeleteKubernetesClusterParams) (*DeleteKubernetesClusterResponse, error)
 	NewDeleteKubernetesClusterParams(id string) *DeleteKubernetesClusterParams
 	DeleteKubernetesSupportedVersion(p *DeleteKubernetesSupportedVersionParams) (*DeleteKubernetesSupportedVersionResponse, error)
@@ -633,9 +633,10 @@ func (p *CreateKubernetesClusterParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new CreateKubernetesClusterParams instance,
 // as then you are sure you have configured all required params
-func (s *KubernetesService) NewCreateKubernetesClusterParams(name string, zoneid string) *CreateKubernetesClusterParams {
+func (s *KubernetesService) NewCreateKubernetesClusterParams(clustertype string, name string, zoneid string) *CreateKubernetesClusterParams {
 	p := &CreateKubernetesClusterParams{}
 	p.p = make(map[string]interface{})
+	p.p["clustertype"] = clustertype
 	p.p["name"] = name
 	p.p["zoneid"] = zoneid
 	return p

--- a/cloudstack/KubernetesService_mock.go
+++ b/cloudstack/KubernetesService_mock.go
@@ -327,17 +327,17 @@ func (mr *MockKubernetesServiceIfaceMockRecorder) NewAddVirtualMachinesToKuberne
 }
 
 // NewCreateKubernetesClusterParams mocks base method.
-func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(name, zoneid string) *CreateKubernetesClusterParams {
+func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(description, kubernetesversionid, name, serviceofferingid string, size int64, zoneid string) *CreateKubernetesClusterParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", name, zoneid)
+	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", description, kubernetesversionid, name, serviceofferingid, size, zoneid)
 	ret0, _ := ret[0].(*CreateKubernetesClusterParams)
 	return ret0
 }
 
 // NewCreateKubernetesClusterParams indicates an expected call of NewCreateKubernetesClusterParams.
-func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(name, zoneid interface{}) *gomock.Call {
+func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(description, kubernetesversionid, name, serviceofferingid, size, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), name, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), description, kubernetesversionid, name, serviceofferingid, size, zoneid)
 }
 
 // NewDeleteKubernetesClusterParams mocks base method.

--- a/cloudstack/KubernetesService_mock.go
+++ b/cloudstack/KubernetesService_mock.go
@@ -327,17 +327,17 @@ func (mr *MockKubernetesServiceIfaceMockRecorder) NewAddVirtualMachinesToKuberne
 }
 
 // NewCreateKubernetesClusterParams mocks base method.
-func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(name, zoneid string) *CreateKubernetesClusterParams {
+func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(clustertype, name, zoneid string) *CreateKubernetesClusterParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", name, zoneid)
+	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", clustertype, name, zoneid)
 	ret0, _ := ret[0].(*CreateKubernetesClusterParams)
 	return ret0
 }
 
 // NewCreateKubernetesClusterParams indicates an expected call of NewCreateKubernetesClusterParams.
-func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(name, zoneid interface{}) *gomock.Call {
+func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(clustertype, name, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), name, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), clustertype, name, zoneid)
 }
 
 // NewDeleteKubernetesClusterParams mocks base method.

--- a/cloudstack/KubernetesService_mock.go
+++ b/cloudstack/KubernetesService_mock.go
@@ -327,17 +327,17 @@ func (mr *MockKubernetesServiceIfaceMockRecorder) NewAddVirtualMachinesToKuberne
 }
 
 // NewCreateKubernetesClusterParams mocks base method.
-func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(clustertype, name, zoneid string) *CreateKubernetesClusterParams {
+func (m *MockKubernetesServiceIface) NewCreateKubernetesClusterParams(name, zoneid string) *CreateKubernetesClusterParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", clustertype, name, zoneid)
+	ret := m.ctrl.Call(m, "NewCreateKubernetesClusterParams", name, zoneid)
 	ret0, _ := ret[0].(*CreateKubernetesClusterParams)
 	return ret0
 }
 
 // NewCreateKubernetesClusterParams indicates an expected call of NewCreateKubernetesClusterParams.
-func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(clustertype, name, zoneid interface{}) *gomock.Call {
+func (mr *MockKubernetesServiceIfaceMockRecorder) NewCreateKubernetesClusterParams(name, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), clustertype, name, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateKubernetesClusterParams", reflect.TypeOf((*MockKubernetesServiceIface)(nil).NewCreateKubernetesClusterParams), name, zoneid)
 }
 
 // NewDeleteKubernetesClusterParams mocks base method.

--- a/cloudstack/NetworkACLService.go
+++ b/cloudstack/NetworkACLService.go
@@ -31,7 +31,7 @@ type NetworkACLServiceIface interface {
 	CreateNetworkACL(p *CreateNetworkACLParams) (*CreateNetworkACLResponse, error)
 	NewCreateNetworkACLParams(protocol string) *CreateNetworkACLParams
 	CreateNetworkACLList(p *CreateNetworkACLListParams) (*CreateNetworkACLListResponse, error)
-	NewCreateNetworkACLListParams(name string) *CreateNetworkACLListParams
+	NewCreateNetworkACLListParams(name string, vpcid string) *CreateNetworkACLListParams
 	DeleteNetworkACL(p *DeleteNetworkACLParams) (*DeleteNetworkACLResponse, error)
 	NewDeleteNetworkACLParams(id string) *DeleteNetworkACLParams
 	DeleteNetworkACLList(p *DeleteNetworkACLListParams) (*DeleteNetworkACLListResponse, error)
@@ -457,10 +457,11 @@ func (p *CreateNetworkACLListParams) GetVpcid() (string, bool) {
 
 // You should always use this function to get a new CreateNetworkACLListParams instance,
 // as then you are sure you have configured all required params
-func (s *NetworkACLService) NewCreateNetworkACLListParams(name string) *CreateNetworkACLListParams {
+func (s *NetworkACLService) NewCreateNetworkACLListParams(name string, vpcid string) *CreateNetworkACLListParams {
 	p := &CreateNetworkACLListParams{}
 	p.p = make(map[string]interface{})
 	p.p["name"] = name
+	p.p["vpcid"] = vpcid
 	return p
 }
 

--- a/cloudstack/NetworkACLService_mock.go
+++ b/cloudstack/NetworkACLService_mock.go
@@ -227,17 +227,17 @@ func (mr *MockNetworkACLServiceIfaceMockRecorder) ListNetworkACLs(p interface{})
 }
 
 // NewCreateNetworkACLListParams mocks base method.
-func (m *MockNetworkACLServiceIface) NewCreateNetworkACLListParams(name string) *CreateNetworkACLListParams {
+func (m *MockNetworkACLServiceIface) NewCreateNetworkACLListParams(name, vpcid string) *CreateNetworkACLListParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateNetworkACLListParams", name)
+	ret := m.ctrl.Call(m, "NewCreateNetworkACLListParams", name, vpcid)
 	ret0, _ := ret[0].(*CreateNetworkACLListParams)
 	return ret0
 }
 
 // NewCreateNetworkACLListParams indicates an expected call of NewCreateNetworkACLListParams.
-func (mr *MockNetworkACLServiceIfaceMockRecorder) NewCreateNetworkACLListParams(name interface{}) *gomock.Call {
+func (mr *MockNetworkACLServiceIfaceMockRecorder) NewCreateNetworkACLListParams(name, vpcid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateNetworkACLListParams", reflect.TypeOf((*MockNetworkACLServiceIface)(nil).NewCreateNetworkACLListParams), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateNetworkACLListParams", reflect.TypeOf((*MockNetworkACLServiceIface)(nil).NewCreateNetworkACLListParams), name, vpcid)
 }
 
 // NewCreateNetworkACLParams mocks base method.

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -37,7 +37,7 @@ type TemplateServiceIface interface {
 	ExtractTemplate(p *ExtractTemplateParams) (*ExtractTemplateResponse, error)
 	NewExtractTemplateParams(id string, mode string) *ExtractTemplateParams
 	GetUploadParamsForTemplate(p *GetUploadParamsForTemplateParams) (*GetUploadParamsForTemplateResponse, error)
-	NewGetUploadParamsForTemplateParams(format string, hypervisor string, name string, zoneid string) *GetUploadParamsForTemplateParams
+	NewGetUploadParamsForTemplateParams(displaytext string, format string, hypervisor string, name string, zoneid string) *GetUploadParamsForTemplateParams
 	ListTemplatePermissions(p *ListTemplatePermissionsParams) (*ListTemplatePermissionsResponse, error)
 	NewListTemplatePermissionsParams(id string) *ListTemplatePermissionsParams
 	GetTemplatePermissionByID(id string, opts ...OptionFunc) (*TemplatePermission, int, error)
@@ -1472,9 +1472,10 @@ func (p *GetUploadParamsForTemplateParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new GetUploadParamsForTemplateParams instance,
 // as then you are sure you have configured all required params
-func (s *TemplateService) NewGetUploadParamsForTemplateParams(format string, hypervisor string, name string, zoneid string) *GetUploadParamsForTemplateParams {
+func (s *TemplateService) NewGetUploadParamsForTemplateParams(displaytext string, format string, hypervisor string, name string, zoneid string) *GetUploadParamsForTemplateParams {
 	p := &GetUploadParamsForTemplateParams{}
 	p.p = make(map[string]interface{})
+	p.p["displaytext"] = displaytext
 	p.p["format"] = format
 	p.p["hypervisor"] = hypervisor
 	p.p["name"] = name

--- a/cloudstack/TemplateService_mock.go
+++ b/cloudstack/TemplateService_mock.go
@@ -334,17 +334,17 @@ func (mr *MockTemplateServiceIfaceMockRecorder) NewExtractTemplateParams(id, mod
 }
 
 // NewGetUploadParamsForTemplateParams mocks base method.
-func (m *MockTemplateServiceIface) NewGetUploadParamsForTemplateParams(format, hypervisor, name, zoneid string) *GetUploadParamsForTemplateParams {
+func (m *MockTemplateServiceIface) NewGetUploadParamsForTemplateParams(displaytext, format, hypervisor, name, zoneid string) *GetUploadParamsForTemplateParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewGetUploadParamsForTemplateParams", format, hypervisor, name, zoneid)
+	ret := m.ctrl.Call(m, "NewGetUploadParamsForTemplateParams", displaytext, format, hypervisor, name, zoneid)
 	ret0, _ := ret[0].(*GetUploadParamsForTemplateParams)
 	return ret0
 }
 
 // NewGetUploadParamsForTemplateParams indicates an expected call of NewGetUploadParamsForTemplateParams.
-func (mr *MockTemplateServiceIfaceMockRecorder) NewGetUploadParamsForTemplateParams(format, hypervisor, name, zoneid interface{}) *gomock.Call {
+func (mr *MockTemplateServiceIfaceMockRecorder) NewGetUploadParamsForTemplateParams(displaytext, format, hypervisor, name, zoneid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGetUploadParamsForTemplateParams", reflect.TypeOf((*MockTemplateServiceIface)(nil).NewGetUploadParamsForTemplateParams), format, hypervisor, name, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGetUploadParamsForTemplateParams", reflect.TypeOf((*MockTemplateServiceIface)(nil).NewGetUploadParamsForTemplateParams), displaytext, format, hypervisor, name, zoneid)
 }
 
 // NewListTemplateDirectDownloadCertificatesParams mocks base method.

--- a/generate/requiredParams.go
+++ b/generate/requiredParams.go
@@ -27,6 +27,12 @@ var requiredParams = map[string][]string{
 	"createDiskOffering": {
 		"displaytext",
 	},
+	"createKubernetesCluster": {
+		"description",
+		"kubernetesversionid",
+		"serviceofferingid",
+		"size",
+	},
 	"createNetworkACLList": {
 		"vpcid",
 	},

--- a/generate/requiredParams.go
+++ b/generate/requiredParams.go
@@ -24,31 +24,43 @@ package main
 // the CloudStack API.
 
 var requiredParams = map[string][]string{
-	"createNetworkOffering": {
-		"displaytext",
-	},
 	"createDiskOffering": {
 		"displaytext",
 	},
-	"createServiceOffering": {
-		"displaytext",
+	"createKubernetesCluster": {
+		"clustertype",
 	},
-	"createVPCOffering": {
-		"displaytext",
+	"createNetworkACLList": {
+		"vpcid",
 	},
-	"registerIso": {
+	"createNetworkOffering": {
 		"displaytext",
 	},
 	"createProject": {
 		"displaytext",
 	},
+	"createServiceOffering": {
+		"displaytext",
+	},
 	"createTemplate": {
 		"displaytext",
 	},
-	"registerTemplate": {
+	"createVPC": {
 		"displaytext",
 	},
-	"createVPC": {
+	"createVPCOffering": {
+		"displaytext",
+	},
+	"disassociateIpAddress": {
+		"id",
+	},
+	"getUploadParamsForTemplate": {
+		"displaytext",
+	},
+	"registerIso": {
+		"displaytext",
+	},
+	"registerTemplate": {
 		"displaytext",
 	},
 }

--- a/generate/requiredParams.go
+++ b/generate/requiredParams.go
@@ -27,9 +27,6 @@ var requiredParams = map[string][]string{
 	"createDiskOffering": {
 		"displaytext",
 	},
-	"createKubernetesCluster": {
-		"clustertype",
-	},
 	"createNetworkACLList": {
 		"vpcid",
 	},

--- a/test/AddressService_test.go
+++ b/test/AddressService_test.go
@@ -54,7 +54,7 @@ func TestAddressService(t *testing.T) {
 		if _, ok := response["disassociateIpAddress"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Address.NewDisassociateIpAddressParams()
+		p := client.Address.NewDisassociateIpAddressParams("id")
 		_, err := client.Address.DisassociateIpAddress(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/KubernetesService_test.go
+++ b/test/KubernetesService_test.go
@@ -54,7 +54,7 @@ func TestKubernetesService(t *testing.T) {
 		if _, ok := response["createKubernetesCluster"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Kubernetes.NewCreateKubernetesClusterParams("name", "zoneid")
+		p := client.Kubernetes.NewCreateKubernetesClusterParams("description", "kubernetesversionid", "name", "serviceofferingid", 0, "zoneid")
 		r, err := client.Kubernetes.CreateKubernetesCluster(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/KubernetesService_test.go
+++ b/test/KubernetesService_test.go
@@ -54,7 +54,7 @@ func TestKubernetesService(t *testing.T) {
 		if _, ok := response["createKubernetesCluster"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Kubernetes.NewCreateKubernetesClusterParams("name", "zoneid")
+		p := client.Kubernetes.NewCreateKubernetesClusterParams("clustertype", "name", "zoneid")
 		r, err := client.Kubernetes.CreateKubernetesCluster(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/KubernetesService_test.go
+++ b/test/KubernetesService_test.go
@@ -54,7 +54,7 @@ func TestKubernetesService(t *testing.T) {
 		if _, ok := response["createKubernetesCluster"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Kubernetes.NewCreateKubernetesClusterParams("clustertype", "name", "zoneid")
+		p := client.Kubernetes.NewCreateKubernetesClusterParams("name", "zoneid")
 		r, err := client.Kubernetes.CreateKubernetesCluster(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/NetworkACLService_test.go
+++ b/test/NetworkACLService_test.go
@@ -54,7 +54,7 @@ func TestNetworkACLService(t *testing.T) {
 		if _, ok := response["createNetworkACLList"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.NetworkACL.NewCreateNetworkACLListParams("name")
+		p := client.NetworkACL.NewCreateNetworkACLListParams("name", "vpcid")
 		r, err := client.NetworkACL.CreateNetworkACLList(p)
 		if err != nil {
 			t.Errorf(err.Error())

--- a/test/TemplateService_test.go
+++ b/test/TemplateService_test.go
@@ -96,7 +96,7 @@ func TestTemplateService(t *testing.T) {
 		if _, ok := response["getUploadParamsForTemplate"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Template.NewGetUploadParamsForTemplateParams("format", "hypervisor", "name", "zoneid")
+		p := client.Template.NewGetUploadParamsForTemplateParams("displaytext", "format", "hypervisor", "name", "zoneid")
 		_, err := client.Template.GetUploadParamsForTemplate(p)
 		if err != nil {
 			t.Errorf(err.Error())


### PR DESCRIPTION
Add optional params from https://github.com/apache/cloudstack-go/pull/77 to the `requiredParams.go`.