### PR TITLE
Generate methods to reset params

### DIFF
--- a/cloudstack/APIDiscoveryService.go
+++ b/cloudstack/APIDiscoveryService.go
@@ -51,6 +51,12 @@ func (p *ListApisParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListApisParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListApisParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})

--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -119,6 +119,12 @@ func (p *CreateAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -132,6 +138,12 @@ func (p *CreateAccountParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
+}
+
+func (p *CreateAccountParams) ResetAccountdetails() {
+	if p.p != nil && p.p["accountdetails"] != nil {
+		delete(p.p, "accountdetails")
+	}
 }
 
 func (p *CreateAccountParams) GetAccountdetails() (map[string]string, bool) {
@@ -149,6 +161,12 @@ func (p *CreateAccountParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *CreateAccountParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *CreateAccountParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -162,6 +180,12 @@ func (p *CreateAccountParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
+}
+
+func (p *CreateAccountParams) ResetAccounttype() {
+	if p.p != nil && p.p["accounttype"] != nil {
+		delete(p.p, "accounttype")
+	}
 }
 
 func (p *CreateAccountParams) GetAccounttype() (int, bool) {
@@ -179,6 +203,12 @@ func (p *CreateAccountParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateAccountParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -192,6 +222,12 @@ func (p *CreateAccountParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
+}
+
+func (p *CreateAccountParams) ResetEmail() {
+	if p.p != nil && p.p["email"] != nil {
+		delete(p.p, "email")
+	}
 }
 
 func (p *CreateAccountParams) GetEmail() (string, bool) {
@@ -209,6 +245,12 @@ func (p *CreateAccountParams) SetFirstname(v string) {
 	p.p["firstname"] = v
 }
 
+func (p *CreateAccountParams) ResetFirstname() {
+	if p.p != nil && p.p["firstname"] != nil {
+		delete(p.p, "firstname")
+	}
+}
+
 func (p *CreateAccountParams) GetFirstname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -222,6 +264,12 @@ func (p *CreateAccountParams) SetLastname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lastname"] = v
+}
+
+func (p *CreateAccountParams) ResetLastname() {
+	if p.p != nil && p.p["lastname"] != nil {
+		delete(p.p, "lastname")
+	}
 }
 
 func (p *CreateAccountParams) GetLastname() (string, bool) {
@@ -239,6 +287,12 @@ func (p *CreateAccountParams) SetNetworkdomain(v string) {
 	p.p["networkdomain"] = v
 }
 
+func (p *CreateAccountParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
+}
+
 func (p *CreateAccountParams) GetNetworkdomain() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -252,6 +306,12 @@ func (p *CreateAccountParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *CreateAccountParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *CreateAccountParams) GetPassword() (string, bool) {
@@ -269,6 +329,12 @@ func (p *CreateAccountParams) SetRoleid(v string) {
 	p.p["roleid"] = v
 }
 
+func (p *CreateAccountParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
+}
+
 func (p *CreateAccountParams) GetRoleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -282,6 +348,12 @@ func (p *CreateAccountParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
+}
+
+func (p *CreateAccountParams) ResetTimezone() {
+	if p.p != nil && p.p["timezone"] != nil {
+		delete(p.p, "timezone")
+	}
 }
 
 func (p *CreateAccountParams) GetTimezone() (string, bool) {
@@ -299,6 +371,12 @@ func (p *CreateAccountParams) SetUserid(v string) {
 	p.p["userid"] = v
 }
 
+func (p *CreateAccountParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
+}
+
 func (p *CreateAccountParams) GetUserid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -312,6 +390,12 @@ func (p *CreateAccountParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *CreateAccountParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *CreateAccountParams) GetUsername() (string, bool) {
@@ -467,6 +551,12 @@ func (p *DeleteAccountParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteAccountParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteAccountParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -553,6 +643,12 @@ func (p *DisableAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DisableAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DisableAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -566,6 +662,12 @@ func (p *DisableAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DisableAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DisableAccountParams) GetDomainid() (string, bool) {
@@ -583,6 +685,12 @@ func (p *DisableAccountParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DisableAccountParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DisableAccountParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -596,6 +704,12 @@ func (p *DisableAccountParams) SetLock(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lock"] = v
+}
+
+func (p *DisableAccountParams) ResetLock() {
+	if p.p != nil && p.p["lock"] != nil {
+		delete(p.p, "lock")
+	}
 }
 
 func (p *DisableAccountParams) GetLock() (bool, bool) {
@@ -769,6 +883,12 @@ func (p *EnableAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *EnableAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *EnableAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -784,6 +904,12 @@ func (p *EnableAccountParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *EnableAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *EnableAccountParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -797,6 +923,12 @@ func (p *EnableAccountParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *EnableAccountParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *EnableAccountParams) GetId() (string, bool) {
@@ -946,6 +1078,12 @@ func (p *GetSolidFireAccountIdParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *GetSolidFireAccountIdParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *GetSolidFireAccountIdParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -959,6 +1097,12 @@ func (p *GetSolidFireAccountIdParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *GetSolidFireAccountIdParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *GetSolidFireAccountIdParams) GetStorageid() (string, bool) {
@@ -1066,6 +1210,12 @@ func (p *ListAccountsParams) SetAccounttype(v int) {
 	p.p["accounttype"] = v
 }
 
+func (p *ListAccountsParams) ResetAccounttype() {
+	if p.p != nil && p.p["accounttype"] != nil {
+		delete(p.p, "accounttype")
+	}
+}
+
 func (p *ListAccountsParams) GetAccounttype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1079,6 +1229,12 @@ func (p *ListAccountsParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ListAccountsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ListAccountsParams) GetDetails() ([]string, bool) {
@@ -1096,6 +1252,12 @@ func (p *ListAccountsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListAccountsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListAccountsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1109,6 +1271,12 @@ func (p *ListAccountsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListAccountsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListAccountsParams) GetId() (string, bool) {
@@ -1126,6 +1294,12 @@ func (p *ListAccountsParams) SetIscleanuprequired(v bool) {
 	p.p["iscleanuprequired"] = v
 }
 
+func (p *ListAccountsParams) ResetIscleanuprequired() {
+	if p.p != nil && p.p["iscleanuprequired"] != nil {
+		delete(p.p, "iscleanuprequired")
+	}
+}
+
 func (p *ListAccountsParams) GetIscleanuprequired() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1139,6 +1313,12 @@ func (p *ListAccountsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListAccountsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListAccountsParams) GetIsrecursive() (bool, bool) {
@@ -1156,6 +1336,12 @@ func (p *ListAccountsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListAccountsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListAccountsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1169,6 +1355,12 @@ func (p *ListAccountsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListAccountsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListAccountsParams) GetListall() (bool, bool) {
@@ -1186,6 +1378,12 @@ func (p *ListAccountsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListAccountsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListAccountsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1199,6 +1397,12 @@ func (p *ListAccountsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListAccountsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListAccountsParams) GetPage() (int, bool) {
@@ -1216,6 +1420,12 @@ func (p *ListAccountsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAccountsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAccountsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1231,6 +1441,12 @@ func (p *ListAccountsParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListAccountsParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListAccountsParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1244,6 +1460,12 @@ func (p *ListAccountsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListAccountsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListAccountsParams) GetState() (string, bool) {
@@ -1501,6 +1723,12 @@ func (p *ListProjectAccountsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListProjectAccountsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListProjectAccountsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1514,6 +1742,12 @@ func (p *ListProjectAccountsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListProjectAccountsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListProjectAccountsParams) GetKeyword() (string, bool) {
@@ -1531,6 +1765,12 @@ func (p *ListProjectAccountsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListProjectAccountsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListProjectAccountsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1544,6 +1784,12 @@ func (p *ListProjectAccountsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListProjectAccountsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListProjectAccountsParams) GetPagesize() (int, bool) {
@@ -1561,6 +1807,12 @@ func (p *ListProjectAccountsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListProjectAccountsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListProjectAccountsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1574,6 +1826,12 @@ func (p *ListProjectAccountsParams) SetProjectroleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectroleid"] = v
+}
+
+func (p *ListProjectAccountsParams) ResetProjectroleid() {
+	if p.p != nil && p.p["projectroleid"] != nil {
+		delete(p.p, "projectroleid")
+	}
 }
 
 func (p *ListProjectAccountsParams) GetProjectroleid() (string, bool) {
@@ -1591,6 +1849,12 @@ func (p *ListProjectAccountsParams) SetRole(v string) {
 	p.p["role"] = v
 }
 
+func (p *ListProjectAccountsParams) ResetRole() {
+	if p.p != nil && p.p["role"] != nil {
+		delete(p.p, "role")
+	}
+}
+
 func (p *ListProjectAccountsParams) GetRole() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1604,6 +1868,12 @@ func (p *ListProjectAccountsParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *ListProjectAccountsParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *ListProjectAccountsParams) GetUserid() (string, bool) {
@@ -1769,6 +2039,12 @@ func (p *LockAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *LockAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *LockAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1782,6 +2058,12 @@ func (p *LockAccountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *LockAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *LockAccountParams) GetDomainid() (string, bool) {
@@ -1936,6 +2218,12 @@ func (p *MarkDefaultZoneForAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *MarkDefaultZoneForAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *MarkDefaultZoneForAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1951,6 +2239,12 @@ func (p *MarkDefaultZoneForAccountParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *MarkDefaultZoneForAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *MarkDefaultZoneForAccountParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1964,6 +2258,12 @@ func (p *MarkDefaultZoneForAccountParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *MarkDefaultZoneForAccountParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *MarkDefaultZoneForAccountParams) GetZoneid() (string, bool) {
@@ -2154,6 +2454,12 @@ func (p *UpdateAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UpdateAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UpdateAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2167,6 +2473,12 @@ func (p *UpdateAccountParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
+}
+
+func (p *UpdateAccountParams) ResetAccountdetails() {
+	if p.p != nil && p.p["accountdetails"] != nil {
+		delete(p.p, "accountdetails")
+	}
 }
 
 func (p *UpdateAccountParams) GetAccountdetails() (map[string]string, bool) {
@@ -2184,6 +2496,12 @@ func (p *UpdateAccountParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *UpdateAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *UpdateAccountParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2197,6 +2515,12 @@ func (p *UpdateAccountParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateAccountParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateAccountParams) GetId() (string, bool) {
@@ -2214,6 +2538,12 @@ func (p *UpdateAccountParams) SetNetworkdomain(v string) {
 	p.p["networkdomain"] = v
 }
 
+func (p *UpdateAccountParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
+}
+
 func (p *UpdateAccountParams) GetNetworkdomain() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2229,6 +2559,12 @@ func (p *UpdateAccountParams) SetNewname(v string) {
 	p.p["newname"] = v
 }
 
+func (p *UpdateAccountParams) ResetNewname() {
+	if p.p != nil && p.p["newname"] != nil {
+		delete(p.p, "newname")
+	}
+}
+
 func (p *UpdateAccountParams) GetNewname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2242,6 +2578,12 @@ func (p *UpdateAccountParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
+}
+
+func (p *UpdateAccountParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
 }
 
 func (p *UpdateAccountParams) GetRoleid() (string, bool) {

--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -93,6 +93,12 @@ func (p *AssociateIpAddressParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AssociateIpAddressParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AssociateIpAddressParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -106,6 +112,12 @@ func (p *AssociateIpAddressParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *AssociateIpAddressParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *AssociateIpAddressParams) GetDomainid() (string, bool) {
@@ -123,6 +135,12 @@ func (p *AssociateIpAddressParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *AssociateIpAddressParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *AssociateIpAddressParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -136,6 +154,12 @@ func (p *AssociateIpAddressParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+}
+
+func (p *AssociateIpAddressParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
 }
 
 func (p *AssociateIpAddressParams) GetIpaddress() (string, bool) {
@@ -153,6 +177,12 @@ func (p *AssociateIpAddressParams) SetIsportable(v bool) {
 	p.p["isportable"] = v
 }
 
+func (p *AssociateIpAddressParams) ResetIsportable() {
+	if p.p != nil && p.p["isportable"] != nil {
+		delete(p.p, "isportable")
+	}
+}
+
 func (p *AssociateIpAddressParams) GetIsportable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -166,6 +196,12 @@ func (p *AssociateIpAddressParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *AssociateIpAddressParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *AssociateIpAddressParams) GetNetworkid() (string, bool) {
@@ -183,6 +219,12 @@ func (p *AssociateIpAddressParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *AssociateIpAddressParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *AssociateIpAddressParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -196,6 +238,12 @@ func (p *AssociateIpAddressParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
+}
+
+func (p *AssociateIpAddressParams) ResetRegionid() {
+	if p.p != nil && p.p["regionid"] != nil {
+		delete(p.p, "regionid")
+	}
 }
 
 func (p *AssociateIpAddressParams) GetRegionid() (int, bool) {
@@ -213,6 +261,12 @@ func (p *AssociateIpAddressParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *AssociateIpAddressParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *AssociateIpAddressParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -226,6 +280,12 @@ func (p *AssociateIpAddressParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AssociateIpAddressParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AssociateIpAddressParams) GetZoneid() (string, bool) {
@@ -344,6 +404,12 @@ func (p *DisassociateIpAddressParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DisassociateIpAddressParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DisassociateIpAddressParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -357,6 +423,12 @@ func (p *DisassociateIpAddressParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+}
+
+func (p *DisassociateIpAddressParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
 }
 
 func (p *DisassociateIpAddressParams) GetIpaddress() (string, bool) {
@@ -522,6 +594,12 @@ func (p *ListPublicIpAddressesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -535,6 +613,12 @@ func (p *ListPublicIpAddressesParams) SetAllocatedonly(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["allocatedonly"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetAllocatedonly() {
+	if p.p != nil && p.p["allocatedonly"] != nil {
+		delete(p.p, "allocatedonly")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetAllocatedonly() (bool, bool) {
@@ -552,6 +636,12 @@ func (p *ListPublicIpAddressesParams) SetAssociatednetworkid(v string) {
 	p.p["associatednetworkid"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetAssociatednetworkid() {
+	if p.p != nil && p.p["associatednetworkid"] != nil {
+		delete(p.p, "associatednetworkid")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetAssociatednetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -565,6 +655,12 @@ func (p *ListPublicIpAddressesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetDomainid() (string, bool) {
@@ -582,6 +678,12 @@ func (p *ListPublicIpAddressesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -595,6 +697,12 @@ func (p *ListPublicIpAddressesParams) SetForloadbalancing(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forloadbalancing"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetForloadbalancing() {
+	if p.p != nil && p.p["forloadbalancing"] != nil {
+		delete(p.p, "forloadbalancing")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetForloadbalancing() (bool, bool) {
@@ -612,6 +720,12 @@ func (p *ListPublicIpAddressesParams) SetForvirtualnetwork(v bool) {
 	p.p["forvirtualnetwork"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetForvirtualnetwork() {
+	if p.p != nil && p.p["forvirtualnetwork"] != nil {
+		delete(p.p, "forvirtualnetwork")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetForvirtualnetwork() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -625,6 +739,12 @@ func (p *ListPublicIpAddressesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetId() (string, bool) {
@@ -642,6 +762,12 @@ func (p *ListPublicIpAddressesParams) SetIpaddress(v string) {
 	p.p["ipaddress"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetIpaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -655,6 +781,12 @@ func (p *ListPublicIpAddressesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetIsrecursive() (bool, bool) {
@@ -672,6 +804,12 @@ func (p *ListPublicIpAddressesParams) SetIssourcenat(v bool) {
 	p.p["issourcenat"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetIssourcenat() {
+	if p.p != nil && p.p["issourcenat"] != nil {
+		delete(p.p, "issourcenat")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetIssourcenat() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -685,6 +823,12 @@ func (p *ListPublicIpAddressesParams) SetIsstaticnat(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isstaticnat"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetIsstaticnat() {
+	if p.p != nil && p.p["isstaticnat"] != nil {
+		delete(p.p, "isstaticnat")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetIsstaticnat() (bool, bool) {
@@ -702,6 +846,12 @@ func (p *ListPublicIpAddressesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -715,6 +865,12 @@ func (p *ListPublicIpAddressesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetListall() (bool, bool) {
@@ -732,6 +888,12 @@ func (p *ListPublicIpAddressesParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -745,6 +907,12 @@ func (p *ListPublicIpAddressesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetPage() (int, bool) {
@@ -762,6 +930,12 @@ func (p *ListPublicIpAddressesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -775,6 +949,12 @@ func (p *ListPublicIpAddressesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetPhysicalnetworkid() (string, bool) {
@@ -792,6 +972,12 @@ func (p *ListPublicIpAddressesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -805,6 +991,12 @@ func (p *ListPublicIpAddressesParams) SetRetrieveonlyresourcecount(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetRetrieveonlyresourcecount() {
+	if p.p != nil && p.p["retrieveonlyresourcecount"] != nil {
+		delete(p.p, "retrieveonlyresourcecount")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetRetrieveonlyresourcecount() (bool, bool) {
@@ -822,6 +1014,12 @@ func (p *ListPublicIpAddressesParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -835,6 +1033,12 @@ func (p *ListPublicIpAddressesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetTags() (map[string]string, bool) {
@@ -852,6 +1056,12 @@ func (p *ListPublicIpAddressesParams) SetVlanid(v string) {
 	p.p["vlanid"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetVlanid() {
+	if p.p != nil && p.p["vlanid"] != nil {
+		delete(p.p, "vlanid")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetVlanid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -867,6 +1077,12 @@ func (p *ListPublicIpAddressesParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *ListPublicIpAddressesParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *ListPublicIpAddressesParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -880,6 +1096,12 @@ func (p *ListPublicIpAddressesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListPublicIpAddressesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListPublicIpAddressesParams) GetZoneid() (string, bool) {
@@ -1020,6 +1242,12 @@ func (p *UpdateIpAddressParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateIpAddressParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateIpAddressParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1035,6 +1263,12 @@ func (p *UpdateIpAddressParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateIpAddressParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateIpAddressParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1048,6 +1282,12 @@ func (p *UpdateIpAddressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateIpAddressParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateIpAddressParams) GetId() (string, bool) {
@@ -1162,6 +1402,12 @@ func (p *ReleaseIpAddressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ReleaseIpAddressParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ReleaseIpAddressParams) GetId() (string, bool) {

--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -80,6 +80,12 @@ func (p *CreateAffinityGroupParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateAffinityGroupParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateAffinityGroupParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -93,6 +99,12 @@ func (p *CreateAffinityGroupParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *CreateAffinityGroupParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *CreateAffinityGroupParams) GetDescription() (string, bool) {
@@ -110,6 +122,12 @@ func (p *CreateAffinityGroupParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateAffinityGroupParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateAffinityGroupParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -123,6 +141,12 @@ func (p *CreateAffinityGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateAffinityGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateAffinityGroupParams) GetName() (string, bool) {
@@ -140,6 +164,12 @@ func (p *CreateAffinityGroupParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *CreateAffinityGroupParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *CreateAffinityGroupParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -153,6 +183,12 @@ func (p *CreateAffinityGroupParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *CreateAffinityGroupParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *CreateAffinityGroupParams) GetType() (string, bool) {
@@ -257,6 +293,12 @@ func (p *DeleteAffinityGroupParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DeleteAffinityGroupParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DeleteAffinityGroupParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -270,6 +312,12 @@ func (p *DeleteAffinityGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DeleteAffinityGroupParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DeleteAffinityGroupParams) GetDomainid() (string, bool) {
@@ -287,6 +335,12 @@ func (p *DeleteAffinityGroupParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteAffinityGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteAffinityGroupParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -302,6 +356,12 @@ func (p *DeleteAffinityGroupParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *DeleteAffinityGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *DeleteAffinityGroupParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -315,6 +375,12 @@ func (p *DeleteAffinityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *DeleteAffinityGroupParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *DeleteAffinityGroupParams) GetProjectid() (string, bool) {
@@ -400,6 +466,12 @@ func (p *ListAffinityGroupTypesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListAffinityGroupTypesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListAffinityGroupTypesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -415,6 +487,12 @@ func (p *ListAffinityGroupTypesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListAffinityGroupTypesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListAffinityGroupTypesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -428,6 +506,12 @@ func (p *ListAffinityGroupTypesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListAffinityGroupTypesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListAffinityGroupTypesParams) GetPagesize() (int, bool) {
@@ -531,6 +615,12 @@ func (p *ListAffinityGroupsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListAffinityGroupsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListAffinityGroupsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -544,6 +634,12 @@ func (p *ListAffinityGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListAffinityGroupsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListAffinityGroupsParams) GetDomainid() (string, bool) {
@@ -561,6 +657,12 @@ func (p *ListAffinityGroupsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListAffinityGroupsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListAffinityGroupsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -574,6 +676,12 @@ func (p *ListAffinityGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListAffinityGroupsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListAffinityGroupsParams) GetIsrecursive() (bool, bool) {
@@ -591,6 +699,12 @@ func (p *ListAffinityGroupsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListAffinityGroupsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListAffinityGroupsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -604,6 +718,12 @@ func (p *ListAffinityGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListAffinityGroupsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListAffinityGroupsParams) GetListall() (bool, bool) {
@@ -621,6 +741,12 @@ func (p *ListAffinityGroupsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListAffinityGroupsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListAffinityGroupsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -634,6 +760,12 @@ func (p *ListAffinityGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListAffinityGroupsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListAffinityGroupsParams) GetPage() (int, bool) {
@@ -651,6 +783,12 @@ func (p *ListAffinityGroupsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAffinityGroupsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAffinityGroupsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -664,6 +802,12 @@ func (p *ListAffinityGroupsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListAffinityGroupsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListAffinityGroupsParams) GetProjectid() (string, bool) {
@@ -681,6 +825,12 @@ func (p *ListAffinityGroupsParams) SetType(v string) {
 	p.p["type"] = v
 }
 
+func (p *ListAffinityGroupsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
+}
+
 func (p *ListAffinityGroupsParams) GetType() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -694,6 +844,12 @@ func (p *ListAffinityGroupsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *ListAffinityGroupsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *ListAffinityGroupsParams) GetVirtualmachineid() (string, bool) {
@@ -868,6 +1024,12 @@ func (p *UpdateVMAffinityGroupParams) SetAffinitygroupids(v []string) {
 	p.p["affinitygroupids"] = v
 }
 
+func (p *UpdateVMAffinityGroupParams) ResetAffinitygroupids() {
+	if p.p != nil && p.p["affinitygroupids"] != nil {
+		delete(p.p, "affinitygroupids")
+	}
+}
+
 func (p *UpdateVMAffinityGroupParams) GetAffinitygroupids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -883,6 +1045,12 @@ func (p *UpdateVMAffinityGroupParams) SetAffinitygroupnames(v []string) {
 	p.p["affinitygroupnames"] = v
 }
 
+func (p *UpdateVMAffinityGroupParams) ResetAffinitygroupnames() {
+	if p.p != nil && p.p["affinitygroupnames"] != nil {
+		delete(p.p, "affinitygroupnames")
+	}
+}
+
 func (p *UpdateVMAffinityGroupParams) GetAffinitygroupnames() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -896,6 +1064,12 @@ func (p *UpdateVMAffinityGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateVMAffinityGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateVMAffinityGroupParams) GetId() (string, bool) {

--- a/cloudstack/AlertService.go
+++ b/cloudstack/AlertService.go
@@ -73,6 +73,12 @@ func (p *ArchiveAlertsParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *ArchiveAlertsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *ArchiveAlertsParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -86,6 +92,12 @@ func (p *ArchiveAlertsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ArchiveAlertsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ArchiveAlertsParams) GetIds() ([]string, bool) {
@@ -103,6 +115,12 @@ func (p *ArchiveAlertsParams) SetStartdate(v string) {
 	p.p["startdate"] = v
 }
 
+func (p *ArchiveAlertsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
+}
+
 func (p *ArchiveAlertsParams) GetStartdate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -116,6 +134,12 @@ func (p *ArchiveAlertsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ArchiveAlertsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ArchiveAlertsParams) GetType() (string, bool) {
@@ -215,6 +239,12 @@ func (p *DeleteAlertsParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *DeleteAlertsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *DeleteAlertsParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -228,6 +258,12 @@ func (p *DeleteAlertsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *DeleteAlertsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *DeleteAlertsParams) GetIds() ([]string, bool) {
@@ -245,6 +281,12 @@ func (p *DeleteAlertsParams) SetStartdate(v string) {
 	p.p["startdate"] = v
 }
 
+func (p *DeleteAlertsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
+}
+
 func (p *DeleteAlertsParams) GetStartdate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -258,6 +300,12 @@ func (p *DeleteAlertsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *DeleteAlertsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *DeleteAlertsParams) GetType() (string, bool) {
@@ -360,6 +408,12 @@ func (p *GenerateAlertParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *GenerateAlertParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *GenerateAlertParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -373,6 +427,12 @@ func (p *GenerateAlertParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *GenerateAlertParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *GenerateAlertParams) GetName() (string, bool) {
@@ -390,6 +450,12 @@ func (p *GenerateAlertParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *GenerateAlertParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *GenerateAlertParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -405,6 +471,12 @@ func (p *GenerateAlertParams) SetType(v int) {
 	p.p["type"] = v
 }
 
+func (p *GenerateAlertParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
+}
+
 func (p *GenerateAlertParams) GetType() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -418,6 +490,12 @@ func (p *GenerateAlertParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *GenerateAlertParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *GenerateAlertParams) GetZoneid() (string, bool) {
@@ -515,6 +593,12 @@ func (p *ListAlertsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListAlertsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListAlertsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -528,6 +612,12 @@ func (p *ListAlertsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListAlertsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListAlertsParams) GetKeyword() (string, bool) {
@@ -545,6 +635,12 @@ func (p *ListAlertsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListAlertsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListAlertsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -558,6 +654,12 @@ func (p *ListAlertsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListAlertsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListAlertsParams) GetPage() (int, bool) {
@@ -575,6 +677,12 @@ func (p *ListAlertsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAlertsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAlertsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -588,6 +696,12 @@ func (p *ListAlertsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListAlertsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListAlertsParams) GetType() (string, bool) {

--- a/cloudstack/AnnotationService.go
+++ b/cloudstack/AnnotationService.go
@@ -71,6 +71,12 @@ func (p *AddAnnotationParams) SetAdminsonly(v bool) {
 	p.p["adminsonly"] = v
 }
 
+func (p *AddAnnotationParams) ResetAdminsonly() {
+	if p.p != nil && p.p["adminsonly"] != nil {
+		delete(p.p, "adminsonly")
+	}
+}
+
 func (p *AddAnnotationParams) GetAdminsonly() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -84,6 +90,12 @@ func (p *AddAnnotationParams) SetAnnotation(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["annotation"] = v
+}
+
+func (p *AddAnnotationParams) ResetAnnotation() {
+	if p.p != nil && p.p["annotation"] != nil {
+		delete(p.p, "annotation")
+	}
 }
 
 func (p *AddAnnotationParams) GetAnnotation() (string, bool) {
@@ -101,6 +113,12 @@ func (p *AddAnnotationParams) SetEntityid(v string) {
 	p.p["entityid"] = v
 }
 
+func (p *AddAnnotationParams) ResetEntityid() {
+	if p.p != nil && p.p["entityid"] != nil {
+		delete(p.p, "entityid")
+	}
+}
+
 func (p *AddAnnotationParams) GetEntityid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -114,6 +132,12 @@ func (p *AddAnnotationParams) SetEntitytype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["entitytype"] = v
+}
+
+func (p *AddAnnotationParams) ResetEntitytype() {
+	if p.p != nil && p.p["entitytype"] != nil {
+		delete(p.p, "entitytype")
+	}
 }
 
 func (p *AddAnnotationParams) GetEntitytype() (string, bool) {
@@ -211,6 +235,12 @@ func (p *ListAnnotationsParams) SetAnnotationfilter(v string) {
 	p.p["annotationfilter"] = v
 }
 
+func (p *ListAnnotationsParams) ResetAnnotationfilter() {
+	if p.p != nil && p.p["annotationfilter"] != nil {
+		delete(p.p, "annotationfilter")
+	}
+}
+
 func (p *ListAnnotationsParams) GetAnnotationfilter() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -224,6 +254,12 @@ func (p *ListAnnotationsParams) SetEntityid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["entityid"] = v
+}
+
+func (p *ListAnnotationsParams) ResetEntityid() {
+	if p.p != nil && p.p["entityid"] != nil {
+		delete(p.p, "entityid")
+	}
 }
 
 func (p *ListAnnotationsParams) GetEntityid() (string, bool) {
@@ -241,6 +277,12 @@ func (p *ListAnnotationsParams) SetEntitytype(v string) {
 	p.p["entitytype"] = v
 }
 
+func (p *ListAnnotationsParams) ResetEntitytype() {
+	if p.p != nil && p.p["entitytype"] != nil {
+		delete(p.p, "entitytype")
+	}
+}
+
 func (p *ListAnnotationsParams) GetEntitytype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -254,6 +296,12 @@ func (p *ListAnnotationsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListAnnotationsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListAnnotationsParams) GetId() (string, bool) {
@@ -271,6 +319,12 @@ func (p *ListAnnotationsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListAnnotationsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListAnnotationsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -284,6 +338,12 @@ func (p *ListAnnotationsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListAnnotationsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListAnnotationsParams) GetPage() (int, bool) {
@@ -301,6 +361,12 @@ func (p *ListAnnotationsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAnnotationsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAnnotationsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -314,6 +380,12 @@ func (p *ListAnnotationsParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *ListAnnotationsParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *ListAnnotationsParams) GetUserid() (string, bool) {
@@ -422,6 +494,12 @@ func (p *RemoveAnnotationParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RemoveAnnotationParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RemoveAnnotationParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -499,6 +577,12 @@ func (p *UpdateAnnotationVisibilityParams) SetAdminsonly(v bool) {
 	p.p["adminsonly"] = v
 }
 
+func (p *UpdateAnnotationVisibilityParams) ResetAdminsonly() {
+	if p.p != nil && p.p["adminsonly"] != nil {
+		delete(p.p, "adminsonly")
+	}
+}
+
 func (p *UpdateAnnotationVisibilityParams) GetAdminsonly() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -512,6 +596,12 @@ func (p *UpdateAnnotationVisibilityParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateAnnotationVisibilityParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateAnnotationVisibilityParams) GetId() (string, bool) {

--- a/cloudstack/AsyncjobService.go
+++ b/cloudstack/AsyncjobService.go
@@ -83,6 +83,12 @@ func (p *ListAsyncJobsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListAsyncJobsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListAsyncJobsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -96,6 +102,12 @@ func (p *ListAsyncJobsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListAsyncJobsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListAsyncJobsParams) GetDomainid() (string, bool) {
@@ -113,6 +125,12 @@ func (p *ListAsyncJobsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListAsyncJobsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListAsyncJobsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -126,6 +144,12 @@ func (p *ListAsyncJobsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListAsyncJobsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListAsyncJobsParams) GetKeyword() (string, bool) {
@@ -143,6 +167,12 @@ func (p *ListAsyncJobsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListAsyncJobsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListAsyncJobsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -156,6 +186,12 @@ func (p *ListAsyncJobsParams) SetManagementserverid(v UUID) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managementserverid"] = v
+}
+
+func (p *ListAsyncJobsParams) ResetManagementserverid() {
+	if p.p != nil && p.p["managementserverid"] != nil {
+		delete(p.p, "managementserverid")
+	}
 }
 
 func (p *ListAsyncJobsParams) GetManagementserverid() (UUID, bool) {
@@ -173,6 +209,12 @@ func (p *ListAsyncJobsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListAsyncJobsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListAsyncJobsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -188,6 +230,12 @@ func (p *ListAsyncJobsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAsyncJobsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAsyncJobsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -201,6 +249,12 @@ func (p *ListAsyncJobsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
+}
+
+func (p *ListAsyncJobsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
 }
 
 func (p *ListAsyncJobsParams) GetStartdate() (string, bool) {
@@ -279,6 +333,12 @@ func (p *QueryAsyncJobResultParams) SetJobID(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["jobid"] = v
+}
+
+func (p *QueryAsyncJobResultParams) ResetJobID() {
+	if p.p != nil && p.p["jobid"] != nil {
+		delete(p.p, "jobid")
+	}
 }
 
 func (p *QueryAsyncJobResultParams) GetJobID() (string, bool) {

--- a/cloudstack/AuthenticationService.go
+++ b/cloudstack/AuthenticationService.go
@@ -64,6 +64,12 @@ func (p *LoginParams) SetDomain(v string) {
 	p.p["domain"] = v
 }
 
+func (p *LoginParams) ResetDomain() {
+	if p.p != nil && p.p["domain"] != nil {
+		delete(p.p, "domain")
+	}
+}
+
 func (p *LoginParams) GetDomain() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -77,6 +83,12 @@ func (p *LoginParams) SetDomainId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainId"] = v
+}
+
+func (p *LoginParams) ResetDomainId() {
+	if p.p != nil && p.p["domainId"] != nil {
+		delete(p.p, "domainId")
+	}
 }
 
 func (p *LoginParams) GetDomainId() (int64, bool) {
@@ -94,6 +106,12 @@ func (p *LoginParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *LoginParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *LoginParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -107,6 +125,12 @@ func (p *LoginParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *LoginParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *LoginParams) GetUsername() (string, bool) {

--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -118,6 +118,12 @@ func (p *CreateAutoScalePolicyParams) SetAction(v string) {
 	p.p["action"] = v
 }
 
+func (p *CreateAutoScalePolicyParams) ResetAction() {
+	if p.p != nil && p.p["action"] != nil {
+		delete(p.p, "action")
+	}
+}
+
 func (p *CreateAutoScalePolicyParams) GetAction() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -131,6 +137,12 @@ func (p *CreateAutoScalePolicyParams) SetConditionids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["conditionids"] = v
+}
+
+func (p *CreateAutoScalePolicyParams) ResetConditionids() {
+	if p.p != nil && p.p["conditionids"] != nil {
+		delete(p.p, "conditionids")
+	}
 }
 
 func (p *CreateAutoScalePolicyParams) GetConditionids() ([]string, bool) {
@@ -148,6 +160,12 @@ func (p *CreateAutoScalePolicyParams) SetDuration(v int) {
 	p.p["duration"] = v
 }
 
+func (p *CreateAutoScalePolicyParams) ResetDuration() {
+	if p.p != nil && p.p["duration"] != nil {
+		delete(p.p, "duration")
+	}
+}
+
 func (p *CreateAutoScalePolicyParams) GetDuration() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -163,6 +181,12 @@ func (p *CreateAutoScalePolicyParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateAutoScalePolicyParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateAutoScalePolicyParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -176,6 +200,12 @@ func (p *CreateAutoScalePolicyParams) SetQuiettime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["quiettime"] = v
+}
+
+func (p *CreateAutoScalePolicyParams) ResetQuiettime() {
+	if p.p != nil && p.p["quiettime"] != nil {
+		delete(p.p, "quiettime")
+	}
 }
 
 func (p *CreateAutoScalePolicyParams) GetQuiettime() (int, bool) {
@@ -300,6 +330,12 @@ func (p *CreateAutoScaleVmGroupParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateAutoScaleVmGroupParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateAutoScaleVmGroupParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -313,6 +349,12 @@ func (p *CreateAutoScaleVmGroupParams) SetInterval(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["interval"] = v
+}
+
+func (p *CreateAutoScaleVmGroupParams) ResetInterval() {
+	if p.p != nil && p.p["interval"] != nil {
+		delete(p.p, "interval")
+	}
 }
 
 func (p *CreateAutoScaleVmGroupParams) GetInterval() (int, bool) {
@@ -330,6 +372,12 @@ func (p *CreateAutoScaleVmGroupParams) SetLbruleid(v string) {
 	p.p["lbruleid"] = v
 }
 
+func (p *CreateAutoScaleVmGroupParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
+}
+
 func (p *CreateAutoScaleVmGroupParams) GetLbruleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -343,6 +391,12 @@ func (p *CreateAutoScaleVmGroupParams) SetMaxmembers(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxmembers"] = v
+}
+
+func (p *CreateAutoScaleVmGroupParams) ResetMaxmembers() {
+	if p.p != nil && p.p["maxmembers"] != nil {
+		delete(p.p, "maxmembers")
+	}
 }
 
 func (p *CreateAutoScaleVmGroupParams) GetMaxmembers() (int, bool) {
@@ -360,6 +414,12 @@ func (p *CreateAutoScaleVmGroupParams) SetMinmembers(v int) {
 	p.p["minmembers"] = v
 }
 
+func (p *CreateAutoScaleVmGroupParams) ResetMinmembers() {
+	if p.p != nil && p.p["minmembers"] != nil {
+		delete(p.p, "minmembers")
+	}
+}
+
 func (p *CreateAutoScaleVmGroupParams) GetMinmembers() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -373,6 +433,12 @@ func (p *CreateAutoScaleVmGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateAutoScaleVmGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateAutoScaleVmGroupParams) GetName() (string, bool) {
@@ -390,6 +456,12 @@ func (p *CreateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
 	p.p["scaledownpolicyids"] = v
 }
 
+func (p *CreateAutoScaleVmGroupParams) ResetScaledownpolicyids() {
+	if p.p != nil && p.p["scaledownpolicyids"] != nil {
+		delete(p.p, "scaledownpolicyids")
+	}
+}
+
 func (p *CreateAutoScaleVmGroupParams) GetScaledownpolicyids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -405,6 +477,12 @@ func (p *CreateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
 	p.p["scaleuppolicyids"] = v
 }
 
+func (p *CreateAutoScaleVmGroupParams) ResetScaleuppolicyids() {
+	if p.p != nil && p.p["scaleuppolicyids"] != nil {
+		delete(p.p, "scaleuppolicyids")
+	}
+}
+
 func (p *CreateAutoScaleVmGroupParams) GetScaleuppolicyids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -418,6 +496,12 @@ func (p *CreateAutoScaleVmGroupParams) SetVmprofileid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmprofileid"] = v
+}
+
+func (p *CreateAutoScaleVmGroupParams) ResetVmprofileid() {
+	if p.p != nil && p.p["vmprofileid"] != nil {
+		delete(p.p, "vmprofileid")
+	}
 }
 
 func (p *CreateAutoScaleVmGroupParams) GetVmprofileid() (string, bool) {
@@ -583,6 +667,12 @@ func (p *CreateAutoScaleVmProfileParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -596,6 +686,12 @@ func (p *CreateAutoScaleVmProfileParams) SetAutoscaleuserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["autoscaleuserid"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetAutoscaleuserid() {
+	if p.p != nil && p.p["autoscaleuserid"] != nil {
+		delete(p.p, "autoscaleuserid")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetAutoscaleuserid() (string, bool) {
@@ -613,6 +709,12 @@ func (p *CreateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
 	p.p["counterparam"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetCounterparam() {
+	if p.p != nil && p.p["counterparam"] != nil {
+		delete(p.p, "counterparam")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetCounterparam() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -626,6 +728,12 @@ func (p *CreateAutoScaleVmProfileParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetDomainid() (string, bool) {
@@ -643,6 +751,12 @@ func (p *CreateAutoScaleVmProfileParams) SetExpungevmgraceperiod(v int) {
 	p.p["expungevmgraceperiod"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetExpungevmgraceperiod() {
+	if p.p != nil && p.p["expungevmgraceperiod"] != nil {
+		delete(p.p, "expungevmgraceperiod")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetExpungevmgraceperiod() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -656,6 +770,12 @@ func (p *CreateAutoScaleVmProfileParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetFordisplay() (bool, bool) {
@@ -673,6 +793,12 @@ func (p *CreateAutoScaleVmProfileParams) SetOtherdeployparams(v map[string]strin
 	p.p["otherdeployparams"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetOtherdeployparams() {
+	if p.p != nil && p.p["otherdeployparams"] != nil {
+		delete(p.p, "otherdeployparams")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetOtherdeployparams() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -686,6 +812,12 @@ func (p *CreateAutoScaleVmProfileParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetProjectid() (string, bool) {
@@ -703,6 +835,12 @@ func (p *CreateAutoScaleVmProfileParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -716,6 +854,12 @@ func (p *CreateAutoScaleVmProfileParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetTemplateid() (string, bool) {
@@ -733,6 +877,12 @@ func (p *CreateAutoScaleVmProfileParams) SetUserdata(v string) {
 	p.p["userdata"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetUserdata() {
+	if p.p != nil && p.p["userdata"] != nil {
+		delete(p.p, "userdata")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetUserdata() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -746,6 +896,12 @@ func (p *CreateAutoScaleVmProfileParams) SetUserdatadetails(v map[string]string)
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdatadetails"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetUserdatadetails() {
+	if p.p != nil && p.p["userdatadetails"] != nil {
+		delete(p.p, "userdatadetails")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetUserdatadetails() (map[string]string, bool) {
@@ -763,6 +919,12 @@ func (p *CreateAutoScaleVmProfileParams) SetUserdataid(v string) {
 	p.p["userdataid"] = v
 }
 
+func (p *CreateAutoScaleVmProfileParams) ResetUserdataid() {
+	if p.p != nil && p.p["userdataid"] != nil {
+		delete(p.p, "userdataid")
+	}
+}
+
 func (p *CreateAutoScaleVmProfileParams) GetUserdataid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -776,6 +938,12 @@ func (p *CreateAutoScaleVmProfileParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateAutoScaleVmProfileParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateAutoScaleVmProfileParams) GetZoneid() (string, bool) {
@@ -893,6 +1061,12 @@ func (p *CreateConditionParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateConditionParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateConditionParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -906,6 +1080,12 @@ func (p *CreateConditionParams) SetCounterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterid"] = v
+}
+
+func (p *CreateConditionParams) ResetCounterid() {
+	if p.p != nil && p.p["counterid"] != nil {
+		delete(p.p, "counterid")
+	}
 }
 
 func (p *CreateConditionParams) GetCounterid() (string, bool) {
@@ -923,6 +1103,12 @@ func (p *CreateConditionParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateConditionParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateConditionParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -936,6 +1122,12 @@ func (p *CreateConditionParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateConditionParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateConditionParams) GetProjectid() (string, bool) {
@@ -953,6 +1145,12 @@ func (p *CreateConditionParams) SetRelationaloperator(v string) {
 	p.p["relationaloperator"] = v
 }
 
+func (p *CreateConditionParams) ResetRelationaloperator() {
+	if p.p != nil && p.p["relationaloperator"] != nil {
+		delete(p.p, "relationaloperator")
+	}
+}
+
 func (p *CreateConditionParams) GetRelationaloperator() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -966,6 +1164,12 @@ func (p *CreateConditionParams) SetThreshold(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["threshold"] = v
+}
+
+func (p *CreateConditionParams) ResetThreshold() {
+	if p.p != nil && p.p["threshold"] != nil {
+		delete(p.p, "threshold")
+	}
 }
 
 func (p *CreateConditionParams) GetThreshold() (int64, bool) {
@@ -1070,6 +1274,12 @@ func (p *CreateCounterParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateCounterParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateCounterParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1083,6 +1293,12 @@ func (p *CreateCounterParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
+}
+
+func (p *CreateCounterParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
 }
 
 func (p *CreateCounterParams) GetProvider() (string, bool) {
@@ -1100,6 +1316,12 @@ func (p *CreateCounterParams) SetSource(v string) {
 	p.p["source"] = v
 }
 
+func (p *CreateCounterParams) ResetSource() {
+	if p.p != nil && p.p["source"] != nil {
+		delete(p.p, "source")
+	}
+}
+
 func (p *CreateCounterParams) GetSource() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1113,6 +1335,12 @@ func (p *CreateCounterParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
+}
+
+func (p *CreateCounterParams) ResetValue() {
+	if p.p != nil && p.p["value"] != nil {
+		delete(p.p, "value")
+	}
 }
 
 func (p *CreateCounterParams) GetValue() (string, bool) {
@@ -1203,6 +1431,12 @@ func (p *DeleteAutoScalePolicyParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteAutoScalePolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteAutoScalePolicyParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1283,6 +1517,12 @@ func (p *DeleteAutoScaleVmGroupParams) SetCleanup(v bool) {
 	p.p["cleanup"] = v
 }
 
+func (p *DeleteAutoScaleVmGroupParams) ResetCleanup() {
+	if p.p != nil && p.p["cleanup"] != nil {
+		delete(p.p, "cleanup")
+	}
+}
+
 func (p *DeleteAutoScaleVmGroupParams) GetCleanup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1296,6 +1536,12 @@ func (p *DeleteAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteAutoScaleVmGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteAutoScaleVmGroupParams) GetId() (string, bool) {
@@ -1374,6 +1620,12 @@ func (p *DeleteAutoScaleVmProfileParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteAutoScaleVmProfileParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteAutoScaleVmProfileParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1448,6 +1700,12 @@ func (p *DeleteConditionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteConditionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteConditionParams) GetId() (string, bool) {
@@ -1526,6 +1784,12 @@ func (p *DeleteCounterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteCounterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteCounterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1600,6 +1864,12 @@ func (p *DisableAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DisableAutoScaleVmGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DisableAutoScaleVmGroupParams) GetId() (string, bool) {
@@ -1705,6 +1975,12 @@ func (p *EnableAutoScaleVmGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *EnableAutoScaleVmGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *EnableAutoScaleVmGroupParams) GetId() (string, bool) {
@@ -1852,6 +2128,12 @@ func (p *ListAutoScalePoliciesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1865,6 +2147,12 @@ func (p *ListAutoScalePoliciesParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
+}
+
+func (p *ListAutoScalePoliciesParams) ResetAction() {
+	if p.p != nil && p.p["action"] != nil {
+		delete(p.p, "action")
+	}
 }
 
 func (p *ListAutoScalePoliciesParams) GetAction() (string, bool) {
@@ -1882,6 +2170,12 @@ func (p *ListAutoScalePoliciesParams) SetConditionid(v string) {
 	p.p["conditionid"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetConditionid() {
+	if p.p != nil && p.p["conditionid"] != nil {
+		delete(p.p, "conditionid")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetConditionid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1895,6 +2189,12 @@ func (p *ListAutoScalePoliciesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListAutoScalePoliciesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListAutoScalePoliciesParams) GetDomainid() (string, bool) {
@@ -1912,6 +2212,12 @@ func (p *ListAutoScalePoliciesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1925,6 +2231,12 @@ func (p *ListAutoScalePoliciesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListAutoScalePoliciesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListAutoScalePoliciesParams) GetIsrecursive() (bool, bool) {
@@ -1942,6 +2254,12 @@ func (p *ListAutoScalePoliciesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1955,6 +2273,12 @@ func (p *ListAutoScalePoliciesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListAutoScalePoliciesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListAutoScalePoliciesParams) GetListall() (bool, bool) {
@@ -1972,6 +2296,12 @@ func (p *ListAutoScalePoliciesParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1985,6 +2315,12 @@ func (p *ListAutoScalePoliciesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListAutoScalePoliciesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListAutoScalePoliciesParams) GetPage() (int, bool) {
@@ -2002,6 +2338,12 @@ func (p *ListAutoScalePoliciesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2017,6 +2359,12 @@ func (p *ListAutoScalePoliciesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListAutoScalePoliciesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListAutoScalePoliciesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2030,6 +2378,12 @@ func (p *ListAutoScalePoliciesParams) SetVmgroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmgroupid"] = v
+}
+
+func (p *ListAutoScalePoliciesParams) ResetVmgroupid() {
+	if p.p != nil && p.p["vmgroupid"] != nil {
+		delete(p.p, "vmgroupid")
+	}
 }
 
 func (p *ListAutoScalePoliciesParams) GetVmgroupid() (string, bool) {
@@ -2236,6 +2590,12 @@ func (p *ListAutoScaleVmGroupsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2249,6 +2609,12 @@ func (p *ListAutoScaleVmGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetDomainid() (string, bool) {
@@ -2266,6 +2632,12 @@ func (p *ListAutoScaleVmGroupsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2279,6 +2651,12 @@ func (p *ListAutoScaleVmGroupsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetId() (string, bool) {
@@ -2296,6 +2674,12 @@ func (p *ListAutoScaleVmGroupsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2309,6 +2693,12 @@ func (p *ListAutoScaleVmGroupsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetKeyword() (string, bool) {
@@ -2326,6 +2716,12 @@ func (p *ListAutoScaleVmGroupsParams) SetLbruleid(v string) {
 	p.p["lbruleid"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetLbruleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2339,6 +2735,12 @@ func (p *ListAutoScaleVmGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetListall() (bool, bool) {
@@ -2356,6 +2758,12 @@ func (p *ListAutoScaleVmGroupsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2369,6 +2777,12 @@ func (p *ListAutoScaleVmGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetPage() (int, bool) {
@@ -2386,6 +2800,12 @@ func (p *ListAutoScaleVmGroupsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2399,6 +2819,12 @@ func (p *ListAutoScaleVmGroupsParams) SetPolicyid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["policyid"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetPolicyid() {
+	if p.p != nil && p.p["policyid"] != nil {
+		delete(p.p, "policyid")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetPolicyid() (string, bool) {
@@ -2416,6 +2842,12 @@ func (p *ListAutoScaleVmGroupsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2431,6 +2863,12 @@ func (p *ListAutoScaleVmGroupsParams) SetVmprofileid(v string) {
 	p.p["vmprofileid"] = v
 }
 
+func (p *ListAutoScaleVmGroupsParams) ResetVmprofileid() {
+	if p.p != nil && p.p["vmprofileid"] != nil {
+		delete(p.p, "vmprofileid")
+	}
+}
+
 func (p *ListAutoScaleVmGroupsParams) GetVmprofileid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2444,6 +2882,12 @@ func (p *ListAutoScaleVmGroupsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListAutoScaleVmGroupsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListAutoScaleVmGroupsParams) GetZoneid() (string, bool) {
@@ -2662,6 +3106,12 @@ func (p *ListAutoScaleVmProfilesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2675,6 +3125,12 @@ func (p *ListAutoScaleVmProfilesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetDomainid() (string, bool) {
@@ -2692,6 +3148,12 @@ func (p *ListAutoScaleVmProfilesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2705,6 +3167,12 @@ func (p *ListAutoScaleVmProfilesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetId() (string, bool) {
@@ -2722,6 +3190,12 @@ func (p *ListAutoScaleVmProfilesParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2735,6 +3209,12 @@ func (p *ListAutoScaleVmProfilesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetKeyword() (string, bool) {
@@ -2752,6 +3232,12 @@ func (p *ListAutoScaleVmProfilesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2765,6 +3251,12 @@ func (p *ListAutoScaleVmProfilesParams) SetOtherdeployparams(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["otherdeployparams"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetOtherdeployparams() {
+	if p.p != nil && p.p["otherdeployparams"] != nil {
+		delete(p.p, "otherdeployparams")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetOtherdeployparams() (string, bool) {
@@ -2782,6 +3274,12 @@ func (p *ListAutoScaleVmProfilesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2795,6 +3293,12 @@ func (p *ListAutoScaleVmProfilesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetPagesize() (int, bool) {
@@ -2812,6 +3316,12 @@ func (p *ListAutoScaleVmProfilesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2825,6 +3335,12 @@ func (p *ListAutoScaleVmProfilesParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetServiceofferingid() (string, bool) {
@@ -2842,6 +3358,12 @@ func (p *ListAutoScaleVmProfilesParams) SetTemplateid(v string) {
 	p.p["templateid"] = v
 }
 
+func (p *ListAutoScaleVmProfilesParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
+}
+
 func (p *ListAutoScaleVmProfilesParams) GetTemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2855,6 +3377,12 @@ func (p *ListAutoScaleVmProfilesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListAutoScaleVmProfilesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListAutoScaleVmProfilesParams) GetZoneid() (string, bool) {
@@ -3005,6 +3533,12 @@ func (p *ListConditionsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListConditionsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListConditionsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3018,6 +3552,12 @@ func (p *ListConditionsParams) SetCounterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterid"] = v
+}
+
+func (p *ListConditionsParams) ResetCounterid() {
+	if p.p != nil && p.p["counterid"] != nil {
+		delete(p.p, "counterid")
+	}
 }
 
 func (p *ListConditionsParams) GetCounterid() (string, bool) {
@@ -3035,6 +3575,12 @@ func (p *ListConditionsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListConditionsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListConditionsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3048,6 +3594,12 @@ func (p *ListConditionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListConditionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListConditionsParams) GetId() (string, bool) {
@@ -3065,6 +3617,12 @@ func (p *ListConditionsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListConditionsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListConditionsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3078,6 +3636,12 @@ func (p *ListConditionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListConditionsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListConditionsParams) GetKeyword() (string, bool) {
@@ -3095,6 +3659,12 @@ func (p *ListConditionsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListConditionsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListConditionsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3108,6 +3678,12 @@ func (p *ListConditionsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListConditionsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListConditionsParams) GetPage() (int, bool) {
@@ -3125,6 +3701,12 @@ func (p *ListConditionsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListConditionsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListConditionsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3140,6 +3722,12 @@ func (p *ListConditionsParams) SetPolicyid(v string) {
 	p.p["policyid"] = v
 }
 
+func (p *ListConditionsParams) ResetPolicyid() {
+	if p.p != nil && p.p["policyid"] != nil {
+		delete(p.p, "policyid")
+	}
+}
+
 func (p *ListConditionsParams) GetPolicyid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3153,6 +3741,12 @@ func (p *ListConditionsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListConditionsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListConditionsParams) GetProjectid() (string, bool) {
@@ -3283,6 +3877,12 @@ func (p *ListCountersParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListCountersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListCountersParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3296,6 +3896,12 @@ func (p *ListCountersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListCountersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListCountersParams) GetKeyword() (string, bool) {
@@ -3313,6 +3919,12 @@ func (p *ListCountersParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListCountersParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListCountersParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3326,6 +3938,12 @@ func (p *ListCountersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListCountersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListCountersParams) GetPage() (int, bool) {
@@ -3343,6 +3961,12 @@ func (p *ListCountersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListCountersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListCountersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3358,6 +3982,12 @@ func (p *ListCountersParams) SetProvider(v string) {
 	p.p["provider"] = v
 }
 
+func (p *ListCountersParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
+}
+
 func (p *ListCountersParams) GetProvider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3371,6 +4001,12 @@ func (p *ListCountersParams) SetSource(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["source"] = v
+}
+
+func (p *ListCountersParams) ResetSource() {
+	if p.p != nil && p.p["source"] != nil {
+		delete(p.p, "source")
+	}
 }
 
 func (p *ListCountersParams) GetSource() (string, bool) {
@@ -3540,6 +4176,12 @@ func (p *UpdateAutoScalePolicyParams) SetConditionids(v []string) {
 	p.p["conditionids"] = v
 }
 
+func (p *UpdateAutoScalePolicyParams) ResetConditionids() {
+	if p.p != nil && p.p["conditionids"] != nil {
+		delete(p.p, "conditionids")
+	}
+}
+
 func (p *UpdateAutoScalePolicyParams) GetConditionids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3553,6 +4195,12 @@ func (p *UpdateAutoScalePolicyParams) SetDuration(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["duration"] = v
+}
+
+func (p *UpdateAutoScalePolicyParams) ResetDuration() {
+	if p.p != nil && p.p["duration"] != nil {
+		delete(p.p, "duration")
+	}
 }
 
 func (p *UpdateAutoScalePolicyParams) GetDuration() (int, bool) {
@@ -3570,6 +4218,12 @@ func (p *UpdateAutoScalePolicyParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateAutoScalePolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateAutoScalePolicyParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3585,6 +4239,12 @@ func (p *UpdateAutoScalePolicyParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateAutoScalePolicyParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateAutoScalePolicyParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3598,6 +4258,12 @@ func (p *UpdateAutoScalePolicyParams) SetQuiettime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["quiettime"] = v
+}
+
+func (p *UpdateAutoScalePolicyParams) ResetQuiettime() {
+	if p.p != nil && p.p["quiettime"] != nil {
+		delete(p.p, "quiettime")
+	}
 }
 
 func (p *UpdateAutoScalePolicyParams) GetQuiettime() (int, bool) {
@@ -3720,6 +4386,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateAutoScaleVmGroupParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateAutoScaleVmGroupParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3733,6 +4405,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *UpdateAutoScaleVmGroupParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *UpdateAutoScaleVmGroupParams) GetFordisplay() (bool, bool) {
@@ -3750,6 +4428,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateAutoScaleVmGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateAutoScaleVmGroupParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3763,6 +4447,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetInterval(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["interval"] = v
+}
+
+func (p *UpdateAutoScaleVmGroupParams) ResetInterval() {
+	if p.p != nil && p.p["interval"] != nil {
+		delete(p.p, "interval")
+	}
 }
 
 func (p *UpdateAutoScaleVmGroupParams) GetInterval() (int, bool) {
@@ -3780,6 +4470,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetMaxmembers(v int) {
 	p.p["maxmembers"] = v
 }
 
+func (p *UpdateAutoScaleVmGroupParams) ResetMaxmembers() {
+	if p.p != nil && p.p["maxmembers"] != nil {
+		delete(p.p, "maxmembers")
+	}
+}
+
 func (p *UpdateAutoScaleVmGroupParams) GetMaxmembers() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3793,6 +4489,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetMinmembers(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["minmembers"] = v
+}
+
+func (p *UpdateAutoScaleVmGroupParams) ResetMinmembers() {
+	if p.p != nil && p.p["minmembers"] != nil {
+		delete(p.p, "minmembers")
+	}
 }
 
 func (p *UpdateAutoScaleVmGroupParams) GetMinmembers() (int, bool) {
@@ -3810,6 +4512,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateAutoScaleVmGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateAutoScaleVmGroupParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3825,6 +4533,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetScaledownpolicyids(v []string) {
 	p.p["scaledownpolicyids"] = v
 }
 
+func (p *UpdateAutoScaleVmGroupParams) ResetScaledownpolicyids() {
+	if p.p != nil && p.p["scaledownpolicyids"] != nil {
+		delete(p.p, "scaledownpolicyids")
+	}
+}
+
 func (p *UpdateAutoScaleVmGroupParams) GetScaledownpolicyids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3838,6 +4552,12 @@ func (p *UpdateAutoScaleVmGroupParams) SetScaleuppolicyids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["scaleuppolicyids"] = v
+}
+
+func (p *UpdateAutoScaleVmGroupParams) ResetScaleuppolicyids() {
+	if p.p != nil && p.p["scaleuppolicyids"] != nil {
+		delete(p.p, "scaleuppolicyids")
+	}
 }
 
 func (p *UpdateAutoScaleVmGroupParams) GetScaleuppolicyids() ([]string, bool) {
@@ -3992,6 +4712,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetAutoscaleuserid(v string) {
 	p.p["autoscaleuserid"] = v
 }
 
+func (p *UpdateAutoScaleVmProfileParams) ResetAutoscaleuserid() {
+	if p.p != nil && p.p["autoscaleuserid"] != nil {
+		delete(p.p, "autoscaleuserid")
+	}
+}
+
 func (p *UpdateAutoScaleVmProfileParams) GetAutoscaleuserid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4005,6 +4731,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetCounterparam(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["counterparam"] = v
+}
+
+func (p *UpdateAutoScaleVmProfileParams) ResetCounterparam() {
+	if p.p != nil && p.p["counterparam"] != nil {
+		delete(p.p, "counterparam")
+	}
 }
 
 func (p *UpdateAutoScaleVmProfileParams) GetCounterparam() (map[string]string, bool) {
@@ -4022,6 +4754,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateAutoScaleVmProfileParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateAutoScaleVmProfileParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4035,6 +4773,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetExpungevmgraceperiod(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["expungevmgraceperiod"] = v
+}
+
+func (p *UpdateAutoScaleVmProfileParams) ResetExpungevmgraceperiod() {
+	if p.p != nil && p.p["expungevmgraceperiod"] != nil {
+		delete(p.p, "expungevmgraceperiod")
+	}
 }
 
 func (p *UpdateAutoScaleVmProfileParams) GetExpungevmgraceperiod() (int, bool) {
@@ -4052,6 +4796,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateAutoScaleVmProfileParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateAutoScaleVmProfileParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4065,6 +4815,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateAutoScaleVmProfileParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateAutoScaleVmProfileParams) GetId() (string, bool) {
@@ -4082,6 +4838,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetOtherdeployparams(v map[string]strin
 	p.p["otherdeployparams"] = v
 }
 
+func (p *UpdateAutoScaleVmProfileParams) ResetOtherdeployparams() {
+	if p.p != nil && p.p["otherdeployparams"] != nil {
+		delete(p.p, "otherdeployparams")
+	}
+}
+
 func (p *UpdateAutoScaleVmProfileParams) GetOtherdeployparams() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4095,6 +4857,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *UpdateAutoScaleVmProfileParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *UpdateAutoScaleVmProfileParams) GetServiceofferingid() (string, bool) {
@@ -4112,6 +4880,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetTemplateid(v string) {
 	p.p["templateid"] = v
 }
 
+func (p *UpdateAutoScaleVmProfileParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
+}
+
 func (p *UpdateAutoScaleVmProfileParams) GetTemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4125,6 +4899,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetUserdata(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdata"] = v
+}
+
+func (p *UpdateAutoScaleVmProfileParams) ResetUserdata() {
+	if p.p != nil && p.p["userdata"] != nil {
+		delete(p.p, "userdata")
+	}
 }
 
 func (p *UpdateAutoScaleVmProfileParams) GetUserdata() (string, bool) {
@@ -4142,6 +4922,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetUserdatadetails(v map[string]string)
 	p.p["userdatadetails"] = v
 }
 
+func (p *UpdateAutoScaleVmProfileParams) ResetUserdatadetails() {
+	if p.p != nil && p.p["userdatadetails"] != nil {
+		delete(p.p, "userdatadetails")
+	}
+}
+
 func (p *UpdateAutoScaleVmProfileParams) GetUserdatadetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4155,6 +4941,12 @@ func (p *UpdateAutoScaleVmProfileParams) SetUserdataid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdataid"] = v
+}
+
+func (p *UpdateAutoScaleVmProfileParams) ResetUserdataid() {
+	if p.p != nil && p.p["userdataid"] != nil {
+		delete(p.p, "userdataid")
+	}
 }
 
 func (p *UpdateAutoScaleVmProfileParams) GetUserdataid() (string, bool) {

--- a/cloudstack/BaremetalService.go
+++ b/cloudstack/BaremetalService.go
@@ -80,6 +80,12 @@ func (p *AddBaremetalDhcpParams) SetDhcpservertype(v string) {
 	p.p["dhcpservertype"] = v
 }
 
+func (p *AddBaremetalDhcpParams) ResetDhcpservertype() {
+	if p.p != nil && p.p["dhcpservertype"] != nil {
+		delete(p.p, "dhcpservertype")
+	}
+}
+
 func (p *AddBaremetalDhcpParams) GetDhcpservertype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -93,6 +99,12 @@ func (p *AddBaremetalDhcpParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddBaremetalDhcpParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddBaremetalDhcpParams) GetPassword() (string, bool) {
@@ -110,6 +122,12 @@ func (p *AddBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddBaremetalDhcpParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddBaremetalDhcpParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -125,6 +143,12 @@ func (p *AddBaremetalDhcpParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddBaremetalDhcpParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddBaremetalDhcpParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -138,6 +162,12 @@ func (p *AddBaremetalDhcpParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddBaremetalDhcpParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddBaremetalDhcpParams) GetUsername() (string, bool) {
@@ -246,6 +276,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddBaremetalPxeKickStartServerParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddBaremetalPxeKickStartServerParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -259,6 +295,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) GetPhysicalnetworkid() (string, bool) {
@@ -276,6 +318,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *AddBaremetalPxeKickStartServerParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *AddBaremetalPxeKickStartServerParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -289,6 +337,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetPxeservertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pxeservertype"] = v
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) ResetPxeservertype() {
+	if p.p != nil && p.p["pxeservertype"] != nil {
+		delete(p.p, "pxeservertype")
+	}
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) GetPxeservertype() (string, bool) {
@@ -306,6 +360,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetTftpdir(v string) {
 	p.p["tftpdir"] = v
 }
 
+func (p *AddBaremetalPxeKickStartServerParams) ResetTftpdir() {
+	if p.p != nil && p.p["tftpdir"] != nil {
+		delete(p.p, "tftpdir")
+	}
+}
+
 func (p *AddBaremetalPxeKickStartServerParams) GetTftpdir() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -321,6 +381,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddBaremetalPxeKickStartServerParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddBaremetalPxeKickStartServerParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -334,6 +400,12 @@ func (p *AddBaremetalPxeKickStartServerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddBaremetalPxeKickStartServerParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddBaremetalPxeKickStartServerParams) GetUsername() (string, bool) {
@@ -455,6 +527,12 @@ func (p *AddBaremetalPxePingServerParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddBaremetalPxePingServerParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddBaremetalPxePingServerParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -468,6 +546,12 @@ func (p *AddBaremetalPxePingServerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *AddBaremetalPxePingServerParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *AddBaremetalPxePingServerParams) GetPhysicalnetworkid() (string, bool) {
@@ -485,6 +569,12 @@ func (p *AddBaremetalPxePingServerParams) SetPingcifspassword(v string) {
 	p.p["pingcifspassword"] = v
 }
 
+func (p *AddBaremetalPxePingServerParams) ResetPingcifspassword() {
+	if p.p != nil && p.p["pingcifspassword"] != nil {
+		delete(p.p, "pingcifspassword")
+	}
+}
+
 func (p *AddBaremetalPxePingServerParams) GetPingcifspassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -498,6 +588,12 @@ func (p *AddBaremetalPxePingServerParams) SetPingcifsusername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingcifsusername"] = v
+}
+
+func (p *AddBaremetalPxePingServerParams) ResetPingcifsusername() {
+	if p.p != nil && p.p["pingcifsusername"] != nil {
+		delete(p.p, "pingcifsusername")
+	}
 }
 
 func (p *AddBaremetalPxePingServerParams) GetPingcifsusername() (string, bool) {
@@ -515,6 +611,12 @@ func (p *AddBaremetalPxePingServerParams) SetPingdir(v string) {
 	p.p["pingdir"] = v
 }
 
+func (p *AddBaremetalPxePingServerParams) ResetPingdir() {
+	if p.p != nil && p.p["pingdir"] != nil {
+		delete(p.p, "pingdir")
+	}
+}
+
 func (p *AddBaremetalPxePingServerParams) GetPingdir() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -528,6 +630,12 @@ func (p *AddBaremetalPxePingServerParams) SetPingstorageserverip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingstorageserverip"] = v
+}
+
+func (p *AddBaremetalPxePingServerParams) ResetPingstorageserverip() {
+	if p.p != nil && p.p["pingstorageserverip"] != nil {
+		delete(p.p, "pingstorageserverip")
+	}
 }
 
 func (p *AddBaremetalPxePingServerParams) GetPingstorageserverip() (string, bool) {
@@ -545,6 +653,12 @@ func (p *AddBaremetalPxePingServerParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *AddBaremetalPxePingServerParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *AddBaremetalPxePingServerParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -558,6 +672,12 @@ func (p *AddBaremetalPxePingServerParams) SetPxeservertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pxeservertype"] = v
+}
+
+func (p *AddBaremetalPxePingServerParams) ResetPxeservertype() {
+	if p.p != nil && p.p["pxeservertype"] != nil {
+		delete(p.p, "pxeservertype")
+	}
 }
 
 func (p *AddBaremetalPxePingServerParams) GetPxeservertype() (string, bool) {
@@ -575,6 +695,12 @@ func (p *AddBaremetalPxePingServerParams) SetTftpdir(v string) {
 	p.p["tftpdir"] = v
 }
 
+func (p *AddBaremetalPxePingServerParams) ResetTftpdir() {
+	if p.p != nil && p.p["tftpdir"] != nil {
+		delete(p.p, "tftpdir")
+	}
+}
+
 func (p *AddBaremetalPxePingServerParams) GetTftpdir() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -590,6 +716,12 @@ func (p *AddBaremetalPxePingServerParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddBaremetalPxePingServerParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddBaremetalPxePingServerParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -603,6 +735,12 @@ func (p *AddBaremetalPxePingServerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddBaremetalPxePingServerParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddBaremetalPxePingServerParams) GetUsername() (string, bool) {
@@ -698,6 +836,12 @@ func (p *AddBaremetalRctParams) SetBaremetalrcturl(v string) {
 	p.p["baremetalrcturl"] = v
 }
 
+func (p *AddBaremetalRctParams) ResetBaremetalrcturl() {
+	if p.p != nil && p.p["baremetalrcturl"] != nil {
+		delete(p.p, "baremetalrcturl")
+	}
+}
+
 func (p *AddBaremetalRctParams) GetBaremetalrcturl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -777,6 +921,12 @@ func (p *DeleteBaremetalRctParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteBaremetalRctParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteBaremetalRctParams) GetId() (string, bool) {
@@ -873,6 +1023,12 @@ func (p *ListBaremetalDhcpParams) SetDhcpservertype(v string) {
 	p.p["dhcpservertype"] = v
 }
 
+func (p *ListBaremetalDhcpParams) ResetDhcpservertype() {
+	if p.p != nil && p.p["dhcpservertype"] != nil {
+		delete(p.p, "dhcpservertype")
+	}
+}
+
 func (p *ListBaremetalDhcpParams) GetDhcpservertype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -886,6 +1042,12 @@ func (p *ListBaremetalDhcpParams) SetId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListBaremetalDhcpParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListBaremetalDhcpParams) GetId() (int64, bool) {
@@ -903,6 +1065,12 @@ func (p *ListBaremetalDhcpParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListBaremetalDhcpParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListBaremetalDhcpParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -916,6 +1084,12 @@ func (p *ListBaremetalDhcpParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListBaremetalDhcpParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListBaremetalDhcpParams) GetPage() (int, bool) {
@@ -933,6 +1107,12 @@ func (p *ListBaremetalDhcpParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListBaremetalDhcpParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListBaremetalDhcpParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -946,6 +1126,12 @@ func (p *ListBaremetalDhcpParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListBaremetalDhcpParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListBaremetalDhcpParams) GetPhysicalnetworkid() (string, bool) {
@@ -1032,6 +1218,12 @@ func (p *ListBaremetalPxeServersParams) SetId(v int64) {
 	p.p["id"] = v
 }
 
+func (p *ListBaremetalPxeServersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListBaremetalPxeServersParams) GetId() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1045,6 +1237,12 @@ func (p *ListBaremetalPxeServersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListBaremetalPxeServersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListBaremetalPxeServersParams) GetKeyword() (string, bool) {
@@ -1062,6 +1260,12 @@ func (p *ListBaremetalPxeServersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListBaremetalPxeServersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListBaremetalPxeServersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1077,6 +1281,12 @@ func (p *ListBaremetalPxeServersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListBaremetalPxeServersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListBaremetalPxeServersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1090,6 +1300,12 @@ func (p *ListBaremetalPxeServersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListBaremetalPxeServersParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListBaremetalPxeServersParams) GetPhysicalnetworkid() (string, bool) {
@@ -1168,6 +1384,12 @@ func (p *ListBaremetalRctParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListBaremetalRctParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListBaremetalRctParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1183,6 +1405,12 @@ func (p *ListBaremetalRctParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListBaremetalRctParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListBaremetalRctParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1196,6 +1424,12 @@ func (p *ListBaremetalRctParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListBaremetalRctParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListBaremetalRctParams) GetPagesize() (int, bool) {
@@ -1261,6 +1495,12 @@ func (p *NotifyBaremetalProvisionDoneParams) SetMac(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mac"] = v
+}
+
+func (p *NotifyBaremetalProvisionDoneParams) ResetMac() {
+	if p.p != nil && p.p["mac"] != nil {
+		delete(p.p, "mac")
+	}
 }
 
 func (p *NotifyBaremetalProvisionDoneParams) GetMac() (string, bool) {

--- a/cloudstack/BigSwitchBCFService.go
+++ b/cloudstack/BigSwitchBCFService.go
@@ -69,6 +69,12 @@ func (p *AddBigSwitchBcfDeviceParams) SetHostname(v string) {
 	p.p["hostname"] = v
 }
 
+func (p *AddBigSwitchBcfDeviceParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
+}
+
 func (p *AddBigSwitchBcfDeviceParams) GetHostname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -82,6 +88,12 @@ func (p *AddBigSwitchBcfDeviceParams) SetNat(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nat"] = v
+}
+
+func (p *AddBigSwitchBcfDeviceParams) ResetNat() {
+	if p.p != nil && p.p["nat"] != nil {
+		delete(p.p, "nat")
+	}
 }
 
 func (p *AddBigSwitchBcfDeviceParams) GetNat() (bool, bool) {
@@ -99,6 +111,12 @@ func (p *AddBigSwitchBcfDeviceParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddBigSwitchBcfDeviceParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddBigSwitchBcfDeviceParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -114,6 +132,12 @@ func (p *AddBigSwitchBcfDeviceParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddBigSwitchBcfDeviceParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddBigSwitchBcfDeviceParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -127,6 +151,12 @@ func (p *AddBigSwitchBcfDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddBigSwitchBcfDeviceParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddBigSwitchBcfDeviceParams) GetUsername() (string, bool) {
@@ -220,6 +250,12 @@ func (p *DeleteBigSwitchBcfDeviceParams) SetBcfdeviceid(v string) {
 	p.p["bcfdeviceid"] = v
 }
 
+func (p *DeleteBigSwitchBcfDeviceParams) ResetBcfdeviceid() {
+	if p.p != nil && p.p["bcfdeviceid"] != nil {
+		delete(p.p, "bcfdeviceid")
+	}
+}
+
 func (p *DeleteBigSwitchBcfDeviceParams) GetBcfdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -310,6 +346,12 @@ func (p *ListBigSwitchBcfDevicesParams) SetBcfdeviceid(v string) {
 	p.p["bcfdeviceid"] = v
 }
 
+func (p *ListBigSwitchBcfDevicesParams) ResetBcfdeviceid() {
+	if p.p != nil && p.p["bcfdeviceid"] != nil {
+		delete(p.p, "bcfdeviceid")
+	}
+}
+
 func (p *ListBigSwitchBcfDevicesParams) GetBcfdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -323,6 +365,12 @@ func (p *ListBigSwitchBcfDevicesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListBigSwitchBcfDevicesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListBigSwitchBcfDevicesParams) GetKeyword() (string, bool) {
@@ -340,6 +388,12 @@ func (p *ListBigSwitchBcfDevicesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListBigSwitchBcfDevicesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListBigSwitchBcfDevicesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -355,6 +409,12 @@ func (p *ListBigSwitchBcfDevicesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListBigSwitchBcfDevicesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListBigSwitchBcfDevicesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -368,6 +428,12 @@ func (p *ListBigSwitchBcfDevicesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListBigSwitchBcfDevicesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListBigSwitchBcfDevicesParams) GetPhysicalnetworkid() (string, bool) {

--- a/cloudstack/BrocadeVCSService.go
+++ b/cloudstack/BrocadeVCSService.go
@@ -69,6 +69,12 @@ func (p *AddBrocadeVcsDeviceParams) SetHostname(v string) {
 	p.p["hostname"] = v
 }
 
+func (p *AddBrocadeVcsDeviceParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
+}
+
 func (p *AddBrocadeVcsDeviceParams) GetHostname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -82,6 +88,12 @@ func (p *AddBrocadeVcsDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddBrocadeVcsDeviceParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddBrocadeVcsDeviceParams) GetPassword() (string, bool) {
@@ -99,6 +111,12 @@ func (p *AddBrocadeVcsDeviceParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddBrocadeVcsDeviceParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddBrocadeVcsDeviceParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -112,6 +130,12 @@ func (p *AddBrocadeVcsDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddBrocadeVcsDeviceParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddBrocadeVcsDeviceParams) GetUsername() (string, bool) {
@@ -201,6 +225,12 @@ func (p *DeleteBrocadeVcsDeviceParams) SetVcsdeviceid(v string) {
 	p.p["vcsdeviceid"] = v
 }
 
+func (p *DeleteBrocadeVcsDeviceParams) ResetVcsdeviceid() {
+	if p.p != nil && p.p["vcsdeviceid"] != nil {
+		delete(p.p, "vcsdeviceid")
+	}
+}
+
 func (p *DeleteBrocadeVcsDeviceParams) GetVcsdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -288,6 +318,12 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListBrocadeVcsDeviceNetworksParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListBrocadeVcsDeviceNetworksParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -301,6 +337,12 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListBrocadeVcsDeviceNetworksParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListBrocadeVcsDeviceNetworksParams) GetPage() (int, bool) {
@@ -318,6 +360,12 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListBrocadeVcsDeviceNetworksParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListBrocadeVcsDeviceNetworksParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -331,6 +379,12 @@ func (p *ListBrocadeVcsDeviceNetworksParams) SetVcsdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vcsdeviceid"] = v
+}
+
+func (p *ListBrocadeVcsDeviceNetworksParams) ResetVcsdeviceid() {
+	if p.p != nil && p.p["vcsdeviceid"] != nil {
+		delete(p.p, "vcsdeviceid")
+	}
 }
 
 func (p *ListBrocadeVcsDeviceNetworksParams) GetVcsdeviceid() (string, bool) {
@@ -541,6 +595,12 @@ func (p *ListBrocadeVcsDevicesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListBrocadeVcsDevicesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListBrocadeVcsDevicesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -554,6 +614,12 @@ func (p *ListBrocadeVcsDevicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListBrocadeVcsDevicesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListBrocadeVcsDevicesParams) GetPage() (int, bool) {
@@ -571,6 +637,12 @@ func (p *ListBrocadeVcsDevicesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListBrocadeVcsDevicesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListBrocadeVcsDevicesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -586,6 +658,12 @@ func (p *ListBrocadeVcsDevicesParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *ListBrocadeVcsDevicesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *ListBrocadeVcsDevicesParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -599,6 +677,12 @@ func (p *ListBrocadeVcsDevicesParams) SetVcsdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vcsdeviceid"] = v
+}
+
+func (p *ListBrocadeVcsDevicesParams) ResetVcsdeviceid() {
+	if p.p != nil && p.p["vcsdeviceid"] != nil {
+		delete(p.p, "vcsdeviceid")
+	}
 }
 
 func (p *ListBrocadeVcsDevicesParams) GetVcsdeviceid() (string, bool) {

--- a/cloudstack/CertificateService.go
+++ b/cloudstack/CertificateService.go
@@ -65,6 +65,12 @@ func (p *UploadCustomCertificateParams) SetCertificate(v string) {
 	p.p["certificate"] = v
 }
 
+func (p *UploadCustomCertificateParams) ResetCertificate() {
+	if p.p != nil && p.p["certificate"] != nil {
+		delete(p.p, "certificate")
+	}
+}
+
 func (p *UploadCustomCertificateParams) GetCertificate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -78,6 +84,12 @@ func (p *UploadCustomCertificateParams) SetDomainsuffix(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainsuffix"] = v
+}
+
+func (p *UploadCustomCertificateParams) ResetDomainsuffix() {
+	if p.p != nil && p.p["domainsuffix"] != nil {
+		delete(p.p, "domainsuffix")
+	}
 }
 
 func (p *UploadCustomCertificateParams) GetDomainsuffix() (string, bool) {
@@ -95,6 +107,12 @@ func (p *UploadCustomCertificateParams) SetId(v int) {
 	p.p["id"] = v
 }
 
+func (p *UploadCustomCertificateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UploadCustomCertificateParams) GetId() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -110,6 +128,12 @@ func (p *UploadCustomCertificateParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UploadCustomCertificateParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UploadCustomCertificateParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -123,6 +147,12 @@ func (p *UploadCustomCertificateParams) SetPrivatekey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privatekey"] = v
+}
+
+func (p *UploadCustomCertificateParams) ResetPrivatekey() {
+	if p.p != nil && p.p["privatekey"] != nil {
+		delete(p.p, "privatekey")
+	}
 }
 
 func (p *UploadCustomCertificateParams) GetPrivatekey() (string, bool) {

--- a/cloudstack/CloudIdentifierService.go
+++ b/cloudstack/CloudIdentifierService.go
@@ -51,6 +51,12 @@ func (p *GetCloudIdentifierParams) SetUserid(v string) {
 	p.p["userid"] = v
 }
 
+func (p *GetCloudIdentifierParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
+}
+
 func (p *GetCloudIdentifierParams) GetUserid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})

--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -136,6 +136,12 @@ func (p *AddClusterParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *AddClusterParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *AddClusterParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -149,6 +155,12 @@ func (p *AddClusterParams) SetClustername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustername"] = v
+}
+
+func (p *AddClusterParams) ResetClustername() {
+	if p.p != nil && p.p["clustername"] != nil {
+		delete(p.p, "clustername")
+	}
 }
 
 func (p *AddClusterParams) GetClustername() (string, bool) {
@@ -166,6 +178,12 @@ func (p *AddClusterParams) SetClustertype(v string) {
 	p.p["clustertype"] = v
 }
 
+func (p *AddClusterParams) ResetClustertype() {
+	if p.p != nil && p.p["clustertype"] != nil {
+		delete(p.p, "clustertype")
+	}
+}
+
 func (p *AddClusterParams) GetClustertype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -179,6 +197,12 @@ func (p *AddClusterParams) SetGuestvswitchname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestvswitchname"] = v
+}
+
+func (p *AddClusterParams) ResetGuestvswitchname() {
+	if p.p != nil && p.p["guestvswitchname"] != nil {
+		delete(p.p, "guestvswitchname")
+	}
 }
 
 func (p *AddClusterParams) GetGuestvswitchname() (string, bool) {
@@ -196,6 +220,12 @@ func (p *AddClusterParams) SetGuestvswitchtype(v string) {
 	p.p["guestvswitchtype"] = v
 }
 
+func (p *AddClusterParams) ResetGuestvswitchtype() {
+	if p.p != nil && p.p["guestvswitchtype"] != nil {
+		delete(p.p, "guestvswitchtype")
+	}
+}
+
 func (p *AddClusterParams) GetGuestvswitchtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -209,6 +239,12 @@ func (p *AddClusterParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *AddClusterParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *AddClusterParams) GetHypervisor() (string, bool) {
@@ -226,6 +262,12 @@ func (p *AddClusterParams) SetOvm3cluster(v string) {
 	p.p["ovm3cluster"] = v
 }
 
+func (p *AddClusterParams) ResetOvm3cluster() {
+	if p.p != nil && p.p["ovm3cluster"] != nil {
+		delete(p.p, "ovm3cluster")
+	}
+}
+
 func (p *AddClusterParams) GetOvm3cluster() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -239,6 +281,12 @@ func (p *AddClusterParams) SetOvm3pool(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3pool"] = v
+}
+
+func (p *AddClusterParams) ResetOvm3pool() {
+	if p.p != nil && p.p["ovm3pool"] != nil {
+		delete(p.p, "ovm3pool")
+	}
 }
 
 func (p *AddClusterParams) GetOvm3pool() (string, bool) {
@@ -256,6 +304,12 @@ func (p *AddClusterParams) SetOvm3vip(v string) {
 	p.p["ovm3vip"] = v
 }
 
+func (p *AddClusterParams) ResetOvm3vip() {
+	if p.p != nil && p.p["ovm3vip"] != nil {
+		delete(p.p, "ovm3vip")
+	}
+}
+
 func (p *AddClusterParams) GetOvm3vip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -269,6 +323,12 @@ func (p *AddClusterParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddClusterParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddClusterParams) GetPassword() (string, bool) {
@@ -286,6 +346,12 @@ func (p *AddClusterParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *AddClusterParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *AddClusterParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -299,6 +365,12 @@ func (p *AddClusterParams) SetPublicvswitchname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicvswitchname"] = v
+}
+
+func (p *AddClusterParams) ResetPublicvswitchname() {
+	if p.p != nil && p.p["publicvswitchname"] != nil {
+		delete(p.p, "publicvswitchname")
+	}
 }
 
 func (p *AddClusterParams) GetPublicvswitchname() (string, bool) {
@@ -316,6 +388,12 @@ func (p *AddClusterParams) SetPublicvswitchtype(v string) {
 	p.p["publicvswitchtype"] = v
 }
 
+func (p *AddClusterParams) ResetPublicvswitchtype() {
+	if p.p != nil && p.p["publicvswitchtype"] != nil {
+		delete(p.p, "publicvswitchtype")
+	}
+}
+
 func (p *AddClusterParams) GetPublicvswitchtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -329,6 +407,12 @@ func (p *AddClusterParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *AddClusterParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *AddClusterParams) GetUrl() (string, bool) {
@@ -346,6 +430,12 @@ func (p *AddClusterParams) SetUsername(v string) {
 	p.p["username"] = v
 }
 
+func (p *AddClusterParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
+}
+
 func (p *AddClusterParams) GetUsername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -359,6 +449,12 @@ func (p *AddClusterParams) SetVsmipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vsmipaddress"] = v
+}
+
+func (p *AddClusterParams) ResetVsmipaddress() {
+	if p.p != nil && p.p["vsmipaddress"] != nil {
+		delete(p.p, "vsmipaddress")
+	}
 }
 
 func (p *AddClusterParams) GetVsmipaddress() (string, bool) {
@@ -376,6 +472,12 @@ func (p *AddClusterParams) SetVsmpassword(v string) {
 	p.p["vsmpassword"] = v
 }
 
+func (p *AddClusterParams) ResetVsmpassword() {
+	if p.p != nil && p.p["vsmpassword"] != nil {
+		delete(p.p, "vsmpassword")
+	}
+}
+
 func (p *AddClusterParams) GetVsmpassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -391,6 +493,12 @@ func (p *AddClusterParams) SetVsmusername(v string) {
 	p.p["vsmusername"] = v
 }
 
+func (p *AddClusterParams) ResetVsmusername() {
+	if p.p != nil && p.p["vsmusername"] != nil {
+		delete(p.p, "vsmusername")
+	}
+}
+
 func (p *AddClusterParams) GetVsmusername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -404,6 +512,12 @@ func (p *AddClusterParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddClusterParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddClusterParams) GetZoneid() (string, bool) {
@@ -510,6 +624,12 @@ func (p *DedicateClusterParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DedicateClusterParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DedicateClusterParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -525,6 +645,12 @@ func (p *DedicateClusterParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *DedicateClusterParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *DedicateClusterParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -538,6 +664,12 @@ func (p *DedicateClusterParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DedicateClusterParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DedicateClusterParams) GetDomainid() (string, bool) {
@@ -626,6 +758,12 @@ func (p *DeleteClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -712,6 +850,12 @@ func (p *DisableOutOfBandManagementForClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *DisableOutOfBandManagementForClusterParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *DisableOutOfBandManagementForClusterParams) GetClusterid() (string, bool) {
@@ -804,6 +948,12 @@ func (p *EnableOutOfBandManagementForClusterParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *EnableOutOfBandManagementForClusterParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *EnableOutOfBandManagementForClusterParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -894,6 +1044,12 @@ func (p *EnableHAForClusterParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *EnableHAForClusterParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *EnableHAForClusterParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -968,6 +1124,12 @@ func (p *DisableHAForClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *DisableHAForClusterParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *DisableHAForClusterParams) GetClusterid() (string, bool) {
@@ -1082,6 +1244,12 @@ func (p *ListClustersParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *ListClustersParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *ListClustersParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1095,6 +1263,12 @@ func (p *ListClustersParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
+}
+
+func (p *ListClustersParams) ResetClustertype() {
+	if p.p != nil && p.p["clustertype"] != nil {
+		delete(p.p, "clustertype")
+	}
 }
 
 func (p *ListClustersParams) GetClustertype() (string, bool) {
@@ -1112,6 +1286,12 @@ func (p *ListClustersParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *ListClustersParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *ListClustersParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1125,6 +1305,12 @@ func (p *ListClustersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListClustersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListClustersParams) GetId() (string, bool) {
@@ -1142,6 +1328,12 @@ func (p *ListClustersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListClustersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListClustersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1155,6 +1347,12 @@ func (p *ListClustersParams) SetManagedstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managedstate"] = v
+}
+
+func (p *ListClustersParams) ResetManagedstate() {
+	if p.p != nil && p.p["managedstate"] != nil {
+		delete(p.p, "managedstate")
+	}
 }
 
 func (p *ListClustersParams) GetManagedstate() (string, bool) {
@@ -1172,6 +1370,12 @@ func (p *ListClustersParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListClustersParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListClustersParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1185,6 +1389,12 @@ func (p *ListClustersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListClustersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListClustersParams) GetPage() (int, bool) {
@@ -1202,6 +1412,12 @@ func (p *ListClustersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListClustersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListClustersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1215,6 +1431,12 @@ func (p *ListClustersParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListClustersParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListClustersParams) GetPodid() (string, bool) {
@@ -1232,6 +1454,12 @@ func (p *ListClustersParams) SetShowcapacities(v bool) {
 	p.p["showcapacities"] = v
 }
 
+func (p *ListClustersParams) ResetShowcapacities() {
+	if p.p != nil && p.p["showcapacities"] != nil {
+		delete(p.p, "showcapacities")
+	}
+}
+
 func (p *ListClustersParams) GetShowcapacities() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1245,6 +1473,12 @@ func (p *ListClustersParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListClustersParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListClustersParams) GetZoneid() (string, bool) {
@@ -1460,6 +1694,12 @@ func (p *ListClustersMetricsParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *ListClustersMetricsParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *ListClustersMetricsParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1473,6 +1713,12 @@ func (p *ListClustersMetricsParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
+}
+
+func (p *ListClustersMetricsParams) ResetClustertype() {
+	if p.p != nil && p.p["clustertype"] != nil {
+		delete(p.p, "clustertype")
+	}
 }
 
 func (p *ListClustersMetricsParams) GetClustertype() (string, bool) {
@@ -1490,6 +1736,12 @@ func (p *ListClustersMetricsParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *ListClustersMetricsParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *ListClustersMetricsParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1503,6 +1755,12 @@ func (p *ListClustersMetricsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListClustersMetricsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListClustersMetricsParams) GetId() (string, bool) {
@@ -1520,6 +1778,12 @@ func (p *ListClustersMetricsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListClustersMetricsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListClustersMetricsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1533,6 +1797,12 @@ func (p *ListClustersMetricsParams) SetManagedstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managedstate"] = v
+}
+
+func (p *ListClustersMetricsParams) ResetManagedstate() {
+	if p.p != nil && p.p["managedstate"] != nil {
+		delete(p.p, "managedstate")
+	}
 }
 
 func (p *ListClustersMetricsParams) GetManagedstate() (string, bool) {
@@ -1550,6 +1820,12 @@ func (p *ListClustersMetricsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListClustersMetricsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListClustersMetricsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1563,6 +1839,12 @@ func (p *ListClustersMetricsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListClustersMetricsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListClustersMetricsParams) GetPage() (int, bool) {
@@ -1580,6 +1862,12 @@ func (p *ListClustersMetricsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListClustersMetricsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListClustersMetricsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1593,6 +1881,12 @@ func (p *ListClustersMetricsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListClustersMetricsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListClustersMetricsParams) GetPodid() (string, bool) {
@@ -1610,6 +1904,12 @@ func (p *ListClustersMetricsParams) SetShowcapacities(v bool) {
 	p.p["showcapacities"] = v
 }
 
+func (p *ListClustersMetricsParams) ResetShowcapacities() {
+	if p.p != nil && p.p["showcapacities"] != nil {
+		delete(p.p, "showcapacities")
+	}
+}
+
 func (p *ListClustersMetricsParams) GetShowcapacities() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1623,6 +1923,12 @@ func (p *ListClustersMetricsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListClustersMetricsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListClustersMetricsParams) GetZoneid() (string, bool) {
@@ -1840,6 +2146,12 @@ func (p *ListDedicatedClustersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListDedicatedClustersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListDedicatedClustersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1853,6 +2165,12 @@ func (p *ListDedicatedClustersParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
+}
+
+func (p *ListDedicatedClustersParams) ResetAffinitygroupid() {
+	if p.p != nil && p.p["affinitygroupid"] != nil {
+		delete(p.p, "affinitygroupid")
+	}
 }
 
 func (p *ListDedicatedClustersParams) GetAffinitygroupid() (string, bool) {
@@ -1870,6 +2188,12 @@ func (p *ListDedicatedClustersParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *ListDedicatedClustersParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *ListDedicatedClustersParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1883,6 +2207,12 @@ func (p *ListDedicatedClustersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListDedicatedClustersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListDedicatedClustersParams) GetDomainid() (string, bool) {
@@ -1900,6 +2230,12 @@ func (p *ListDedicatedClustersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListDedicatedClustersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListDedicatedClustersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1915,6 +2251,12 @@ func (p *ListDedicatedClustersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDedicatedClustersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDedicatedClustersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1928,6 +2270,12 @@ func (p *ListDedicatedClustersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListDedicatedClustersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListDedicatedClustersParams) GetPagesize() (int, bool) {
@@ -1997,6 +2345,12 @@ func (p *ReleaseDedicatedClusterParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ReleaseDedicatedClusterParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ReleaseDedicatedClusterParams) GetClusterid() (string, bool) {
@@ -2090,6 +2444,12 @@ func (p *UpdateClusterParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *UpdateClusterParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *UpdateClusterParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2103,6 +2463,12 @@ func (p *UpdateClusterParams) SetClustername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustername"] = v
+}
+
+func (p *UpdateClusterParams) ResetClustername() {
+	if p.p != nil && p.p["clustername"] != nil {
+		delete(p.p, "clustername")
+	}
 }
 
 func (p *UpdateClusterParams) GetClustername() (string, bool) {
@@ -2120,6 +2486,12 @@ func (p *UpdateClusterParams) SetClustertype(v string) {
 	p.p["clustertype"] = v
 }
 
+func (p *UpdateClusterParams) ResetClustertype() {
+	if p.p != nil && p.p["clustertype"] != nil {
+		delete(p.p, "clustertype")
+	}
+}
+
 func (p *UpdateClusterParams) GetClustertype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2133,6 +2505,12 @@ func (p *UpdateClusterParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *UpdateClusterParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *UpdateClusterParams) GetHypervisor() (string, bool) {
@@ -2150,6 +2528,12 @@ func (p *UpdateClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2163,6 +2547,12 @@ func (p *UpdateClusterParams) SetManagedstate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["managedstate"] = v
+}
+
+func (p *UpdateClusterParams) ResetManagedstate() {
+	if p.p != nil && p.p["managedstate"] != nil {
+		delete(p.p, "managedstate")
+	}
 }
 
 func (p *UpdateClusterParams) GetManagedstate() (string, bool) {

--- a/cloudstack/ConfigurationService.go
+++ b/cloudstack/ConfigurationService.go
@@ -170,6 +170,12 @@ func (p *ListConfigurationsParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *ListConfigurationsParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *ListConfigurationsParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -183,6 +189,12 @@ func (p *ListConfigurationsParams) SetCategory(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["category"] = v
+}
+
+func (p *ListConfigurationsParams) ResetCategory() {
+	if p.p != nil && p.p["category"] != nil {
+		delete(p.p, "category")
+	}
 }
 
 func (p *ListConfigurationsParams) GetCategory() (string, bool) {
@@ -200,6 +212,12 @@ func (p *ListConfigurationsParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *ListConfigurationsParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *ListConfigurationsParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -213,6 +231,12 @@ func (p *ListConfigurationsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListConfigurationsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListConfigurationsParams) GetDomainid() (string, bool) {
@@ -230,6 +254,12 @@ func (p *ListConfigurationsParams) SetGroup(v string) {
 	p.p["group"] = v
 }
 
+func (p *ListConfigurationsParams) ResetGroup() {
+	if p.p != nil && p.p["group"] != nil {
+		delete(p.p, "group")
+	}
+}
+
 func (p *ListConfigurationsParams) GetGroup() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -243,6 +273,12 @@ func (p *ListConfigurationsParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
+}
+
+func (p *ListConfigurationsParams) ResetImagestoreuuid() {
+	if p.p != nil && p.p["imagestoreuuid"] != nil {
+		delete(p.p, "imagestoreuuid")
+	}
 }
 
 func (p *ListConfigurationsParams) GetImagestoreuuid() (string, bool) {
@@ -260,6 +296,12 @@ func (p *ListConfigurationsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListConfigurationsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListConfigurationsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -273,6 +315,12 @@ func (p *ListConfigurationsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListConfigurationsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListConfigurationsParams) GetName() (string, bool) {
@@ -290,6 +338,12 @@ func (p *ListConfigurationsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListConfigurationsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListConfigurationsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -303,6 +357,12 @@ func (p *ListConfigurationsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListConfigurationsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListConfigurationsParams) GetPagesize() (int, bool) {
@@ -320,6 +380,12 @@ func (p *ListConfigurationsParams) SetParent(v string) {
 	p.p["parent"] = v
 }
 
+func (p *ListConfigurationsParams) ResetParent() {
+	if p.p != nil && p.p["parent"] != nil {
+		delete(p.p, "parent")
+	}
+}
+
 func (p *ListConfigurationsParams) GetParent() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -333,6 +399,12 @@ func (p *ListConfigurationsParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListConfigurationsParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListConfigurationsParams) GetStorageid() (string, bool) {
@@ -350,6 +422,12 @@ func (p *ListConfigurationsParams) SetSubgroup(v string) {
 	p.p["subgroup"] = v
 }
 
+func (p *ListConfigurationsParams) ResetSubgroup() {
+	if p.p != nil && p.p["subgroup"] != nil {
+		delete(p.p, "subgroup")
+	}
+}
+
 func (p *ListConfigurationsParams) GetSubgroup() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -363,6 +441,12 @@ func (p *ListConfigurationsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListConfigurationsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListConfigurationsParams) GetZoneid() (string, bool) {
@@ -451,6 +535,12 @@ func (p *ListDeploymentPlannersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListDeploymentPlannersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListDeploymentPlannersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -466,6 +556,12 @@ func (p *ListDeploymentPlannersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDeploymentPlannersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDeploymentPlannersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -479,6 +575,12 @@ func (p *ListDeploymentPlannersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListDeploymentPlannersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListDeploymentPlannersParams) GetPagesize() (int, bool) {
@@ -566,6 +668,12 @@ func (p *UpdateConfigurationParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *UpdateConfigurationParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *UpdateConfigurationParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -579,6 +687,12 @@ func (p *UpdateConfigurationParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *UpdateConfigurationParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *UpdateConfigurationParams) GetClusterid() (string, bool) {
@@ -596,6 +710,12 @@ func (p *UpdateConfigurationParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *UpdateConfigurationParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *UpdateConfigurationParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -609,6 +729,12 @@ func (p *UpdateConfigurationParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
+}
+
+func (p *UpdateConfigurationParams) ResetImagestoreuuid() {
+	if p.p != nil && p.p["imagestoreuuid"] != nil {
+		delete(p.p, "imagestoreuuid")
+	}
 }
 
 func (p *UpdateConfigurationParams) GetImagestoreuuid() (string, bool) {
@@ -626,6 +752,12 @@ func (p *UpdateConfigurationParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateConfigurationParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateConfigurationParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -639,6 +771,12 @@ func (p *UpdateConfigurationParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *UpdateConfigurationParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *UpdateConfigurationParams) GetStorageid() (string, bool) {
@@ -656,6 +794,12 @@ func (p *UpdateConfigurationParams) SetValue(v string) {
 	p.p["value"] = v
 }
 
+func (p *UpdateConfigurationParams) ResetValue() {
+	if p.p != nil && p.p["value"] != nil {
+		delete(p.p, "value")
+	}
+}
+
 func (p *UpdateConfigurationParams) GetValue() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -669,6 +813,12 @@ func (p *UpdateConfigurationParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UpdateConfigurationParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UpdateConfigurationParams) GetZoneid() (string, bool) {
@@ -767,6 +917,12 @@ func (p *ResetConfigurationParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *ResetConfigurationParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *ResetConfigurationParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -780,6 +936,12 @@ func (p *ResetConfigurationParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ResetConfigurationParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ResetConfigurationParams) GetClusterid() (string, bool) {
@@ -797,6 +959,12 @@ func (p *ResetConfigurationParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ResetConfigurationParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ResetConfigurationParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -810,6 +978,12 @@ func (p *ResetConfigurationParams) SetImagestoreid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreid"] = v
+}
+
+func (p *ResetConfigurationParams) ResetImagestoreid() {
+	if p.p != nil && p.p["imagestoreid"] != nil {
+		delete(p.p, "imagestoreid")
+	}
 }
 
 func (p *ResetConfigurationParams) GetImagestoreid() (string, bool) {
@@ -827,6 +1001,12 @@ func (p *ResetConfigurationParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ResetConfigurationParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ResetConfigurationParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -842,6 +1022,12 @@ func (p *ResetConfigurationParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *ResetConfigurationParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *ResetConfigurationParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -855,6 +1041,12 @@ func (p *ResetConfigurationParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ResetConfigurationParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ResetConfigurationParams) GetZoneid() (string, bool) {

--- a/cloudstack/ConsoleEndpointService.go
+++ b/cloudstack/ConsoleEndpointService.go
@@ -55,6 +55,12 @@ func (p *CreateConsoleEndpointParams) SetToken(v string) {
 	p.p["token"] = v
 }
 
+func (p *CreateConsoleEndpointParams) ResetToken() {
+	if p.p != nil && p.p["token"] != nil {
+		delete(p.p, "token")
+	}
+}
+
 func (p *CreateConsoleEndpointParams) GetToken() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -68,6 +74,12 @@ func (p *CreateConsoleEndpointParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *CreateConsoleEndpointParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *CreateConsoleEndpointParams) GetVirtualmachineid() (string, bool) {

--- a/cloudstack/DiskOfferingService.go
+++ b/cloudstack/DiskOfferingService.go
@@ -179,6 +179,12 @@ func (p *CreateDiskOfferingParams) SetBytesreadrate(v int64) {
 	p.p["bytesreadrate"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetBytesreadrate() {
+	if p.p != nil && p.p["bytesreadrate"] != nil {
+		delete(p.p, "bytesreadrate")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetBytesreadrate() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -192,6 +198,12 @@ func (p *CreateDiskOfferingParams) SetBytesreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemax"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetBytesreadratemax() {
+	if p.p != nil && p.p["bytesreadratemax"] != nil {
+		delete(p.p, "bytesreadratemax")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetBytesreadratemax() (int64, bool) {
@@ -209,6 +221,12 @@ func (p *CreateDiskOfferingParams) SetBytesreadratemaxlength(v int64) {
 	p.p["bytesreadratemaxlength"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetBytesreadratemaxlength() {
+	if p.p != nil && p.p["bytesreadratemaxlength"] != nil {
+		delete(p.p, "bytesreadratemaxlength")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetBytesreadratemaxlength() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -222,6 +240,12 @@ func (p *CreateDiskOfferingParams) SetByteswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriterate"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetByteswriterate() {
+	if p.p != nil && p.p["byteswriterate"] != nil {
+		delete(p.p, "byteswriterate")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetByteswriterate() (int64, bool) {
@@ -239,6 +263,12 @@ func (p *CreateDiskOfferingParams) SetByteswriteratemax(v int64) {
 	p.p["byteswriteratemax"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetByteswriteratemax() {
+	if p.p != nil && p.p["byteswriteratemax"] != nil {
+		delete(p.p, "byteswriteratemax")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetByteswriteratemax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -252,6 +282,12 @@ func (p *CreateDiskOfferingParams) SetByteswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemaxlength"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetByteswriteratemaxlength() {
+	if p.p != nil && p.p["byteswriteratemaxlength"] != nil {
+		delete(p.p, "byteswriteratemaxlength")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetByteswriteratemaxlength() (int64, bool) {
@@ -269,6 +305,12 @@ func (p *CreateDiskOfferingParams) SetCachemode(v string) {
 	p.p["cachemode"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetCachemode() {
+	if p.p != nil && p.p["cachemode"] != nil {
+		delete(p.p, "cachemode")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetCachemode() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -282,6 +324,12 @@ func (p *CreateDiskOfferingParams) SetCustomized(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customized"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetCustomized() {
+	if p.p != nil && p.p["customized"] != nil {
+		delete(p.p, "customized")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetCustomized() (bool, bool) {
@@ -299,6 +347,12 @@ func (p *CreateDiskOfferingParams) SetCustomizediops(v bool) {
 	p.p["customizediops"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetCustomizediops() {
+	if p.p != nil && p.p["customizediops"] != nil {
+		delete(p.p, "customizediops")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetCustomizediops() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -312,6 +366,12 @@ func (p *CreateDiskOfferingParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetDetails() (map[string]string, bool) {
@@ -329,6 +389,12 @@ func (p *CreateDiskOfferingParams) SetDisksize(v int64) {
 	p.p["disksize"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetDisksize() {
+	if p.p != nil && p.p["disksize"] != nil {
+		delete(p.p, "disksize")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetDisksize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -342,6 +408,12 @@ func (p *CreateDiskOfferingParams) SetDisksizestrictness(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["disksizestrictness"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetDisksizestrictness() {
+	if p.p != nil && p.p["disksizestrictness"] != nil {
+		delete(p.p, "disksizestrictness")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetDisksizestrictness() (bool, bool) {
@@ -359,6 +431,12 @@ func (p *CreateDiskOfferingParams) SetDisplayoffering(v bool) {
 	p.p["displayoffering"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetDisplayoffering() {
+	if p.p != nil && p.p["displayoffering"] != nil {
+		delete(p.p, "displayoffering")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetDisplayoffering() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -372,6 +450,12 @@ func (p *CreateDiskOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetDisplaytext() (string, bool) {
@@ -389,6 +473,12 @@ func (p *CreateDiskOfferingParams) SetDomainid(v []string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetDomainid() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -402,6 +492,12 @@ func (p *CreateDiskOfferingParams) SetEncrypt(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["encrypt"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetEncrypt() {
+	if p.p != nil && p.p["encrypt"] != nil {
+		delete(p.p, "encrypt")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetEncrypt() (bool, bool) {
@@ -419,6 +515,12 @@ func (p *CreateDiskOfferingParams) SetHypervisorsnapshotreserve(v int) {
 	p.p["hypervisorsnapshotreserve"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetHypervisorsnapshotreserve() {
+	if p.p != nil && p.p["hypervisorsnapshotreserve"] != nil {
+		delete(p.p, "hypervisorsnapshotreserve")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetHypervisorsnapshotreserve() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -432,6 +534,12 @@ func (p *CreateDiskOfferingParams) SetIopsreadrate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadrate"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetIopsreadrate() {
+	if p.p != nil && p.p["iopsreadrate"] != nil {
+		delete(p.p, "iopsreadrate")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetIopsreadrate() (int64, bool) {
@@ -449,6 +557,12 @@ func (p *CreateDiskOfferingParams) SetIopsreadratemax(v int64) {
 	p.p["iopsreadratemax"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetIopsreadratemax() {
+	if p.p != nil && p.p["iopsreadratemax"] != nil {
+		delete(p.p, "iopsreadratemax")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetIopsreadratemax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -462,6 +576,12 @@ func (p *CreateDiskOfferingParams) SetIopsreadratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemaxlength"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetIopsreadratemaxlength() {
+	if p.p != nil && p.p["iopsreadratemaxlength"] != nil {
+		delete(p.p, "iopsreadratemaxlength")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetIopsreadratemaxlength() (int64, bool) {
@@ -479,6 +599,12 @@ func (p *CreateDiskOfferingParams) SetIopswriterate(v int64) {
 	p.p["iopswriterate"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetIopswriterate() {
+	if p.p != nil && p.p["iopswriterate"] != nil {
+		delete(p.p, "iopswriterate")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetIopswriterate() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -492,6 +618,12 @@ func (p *CreateDiskOfferingParams) SetIopswriteratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemax"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetIopswriteratemax() {
+	if p.p != nil && p.p["iopswriteratemax"] != nil {
+		delete(p.p, "iopswriteratemax")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetIopswriteratemax() (int64, bool) {
@@ -509,6 +641,12 @@ func (p *CreateDiskOfferingParams) SetIopswriteratemaxlength(v int64) {
 	p.p["iopswriteratemaxlength"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetIopswriteratemaxlength() {
+	if p.p != nil && p.p["iopswriteratemaxlength"] != nil {
+		delete(p.p, "iopswriteratemaxlength")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetIopswriteratemaxlength() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -522,6 +660,12 @@ func (p *CreateDiskOfferingParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetMaxiops() (int64, bool) {
@@ -539,6 +683,12 @@ func (p *CreateDiskOfferingParams) SetMiniops(v int64) {
 	p.p["miniops"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetMiniops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -552,6 +702,12 @@ func (p *CreateDiskOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetName() (string, bool) {
@@ -569,6 +725,12 @@ func (p *CreateDiskOfferingParams) SetProvisioningtype(v string) {
 	p.p["provisioningtype"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetProvisioningtype() {
+	if p.p != nil && p.p["provisioningtype"] != nil {
+		delete(p.p, "provisioningtype")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetProvisioningtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -582,6 +744,12 @@ func (p *CreateDiskOfferingParams) SetStoragepolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storagepolicy"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetStoragepolicy() {
+	if p.p != nil && p.p["storagepolicy"] != nil {
+		delete(p.p, "storagepolicy")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetStoragepolicy() (string, bool) {
@@ -599,6 +767,12 @@ func (p *CreateDiskOfferingParams) SetStoragetype(v string) {
 	p.p["storagetype"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetStoragetype() {
+	if p.p != nil && p.p["storagetype"] != nil {
+		delete(p.p, "storagetype")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetStoragetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -614,6 +788,12 @@ func (p *CreateDiskOfferingParams) SetTags(v string) {
 	p.p["tags"] = v
 }
 
+func (p *CreateDiskOfferingParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *CreateDiskOfferingParams) GetTags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -627,6 +807,12 @@ func (p *CreateDiskOfferingParams) SetZoneid(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateDiskOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateDiskOfferingParams) GetZoneid() ([]string, bool) {
@@ -727,6 +913,12 @@ func (p *DeleteDiskOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteDiskOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteDiskOfferingParams) GetId() (string, bool) {
@@ -864,6 +1056,12 @@ func (p *ListDiskOfferingsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -877,6 +1075,12 @@ func (p *ListDiskOfferingsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetDomainid() (string, bool) {
@@ -894,6 +1098,12 @@ func (p *ListDiskOfferingsParams) SetEncrypt(v bool) {
 	p.p["encrypt"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetEncrypt() {
+	if p.p != nil && p.p["encrypt"] != nil {
+		delete(p.p, "encrypt")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetEncrypt() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -907,6 +1117,12 @@ func (p *ListDiskOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetId() (string, bool) {
@@ -924,6 +1140,12 @@ func (p *ListDiskOfferingsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -937,6 +1159,12 @@ func (p *ListDiskOfferingsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetKeyword() (string, bool) {
@@ -954,6 +1182,12 @@ func (p *ListDiskOfferingsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -967,6 +1201,12 @@ func (p *ListDiskOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetName() (string, bool) {
@@ -984,6 +1224,12 @@ func (p *ListDiskOfferingsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -997,6 +1243,12 @@ func (p *ListDiskOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetPagesize() (int, bool) {
@@ -1014,6 +1266,12 @@ func (p *ListDiskOfferingsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1027,6 +1285,12 @@ func (p *ListDiskOfferingsParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetStorageid() (string, bool) {
@@ -1044,6 +1308,12 @@ func (p *ListDiskOfferingsParams) SetStoragetype(v string) {
 	p.p["storagetype"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetStoragetype() {
+	if p.p != nil && p.p["storagetype"] != nil {
+		delete(p.p, "storagetype")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetStoragetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1059,6 +1329,12 @@ func (p *ListDiskOfferingsParams) SetVolumeid(v string) {
 	p.p["volumeid"] = v
 }
 
+func (p *ListDiskOfferingsParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
+}
+
 func (p *ListDiskOfferingsParams) GetVolumeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1072,6 +1348,12 @@ func (p *ListDiskOfferingsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListDiskOfferingsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListDiskOfferingsParams) GetZoneid() (string, bool) {
@@ -1330,6 +1612,12 @@ func (p *UpdateDiskOfferingParams) SetBytesreadrate(v int64) {
 	p.p["bytesreadrate"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetBytesreadrate() {
+	if p.p != nil && p.p["bytesreadrate"] != nil {
+		delete(p.p, "bytesreadrate")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetBytesreadrate() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1343,6 +1631,12 @@ func (p *UpdateDiskOfferingParams) SetBytesreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemax"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetBytesreadratemax() {
+	if p.p != nil && p.p["bytesreadratemax"] != nil {
+		delete(p.p, "bytesreadratemax")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetBytesreadratemax() (int64, bool) {
@@ -1360,6 +1654,12 @@ func (p *UpdateDiskOfferingParams) SetBytesreadratemaxlength(v int64) {
 	p.p["bytesreadratemaxlength"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetBytesreadratemaxlength() {
+	if p.p != nil && p.p["bytesreadratemaxlength"] != nil {
+		delete(p.p, "bytesreadratemaxlength")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetBytesreadratemaxlength() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1373,6 +1673,12 @@ func (p *UpdateDiskOfferingParams) SetByteswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriterate"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetByteswriterate() {
+	if p.p != nil && p.p["byteswriterate"] != nil {
+		delete(p.p, "byteswriterate")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetByteswriterate() (int64, bool) {
@@ -1390,6 +1696,12 @@ func (p *UpdateDiskOfferingParams) SetByteswriteratemax(v int64) {
 	p.p["byteswriteratemax"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetByteswriteratemax() {
+	if p.p != nil && p.p["byteswriteratemax"] != nil {
+		delete(p.p, "byteswriteratemax")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetByteswriteratemax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1403,6 +1715,12 @@ func (p *UpdateDiskOfferingParams) SetByteswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemaxlength"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetByteswriteratemaxlength() {
+	if p.p != nil && p.p["byteswriteratemaxlength"] != nil {
+		delete(p.p, "byteswriteratemaxlength")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetByteswriteratemaxlength() (int64, bool) {
@@ -1420,6 +1738,12 @@ func (p *UpdateDiskOfferingParams) SetCachemode(v string) {
 	p.p["cachemode"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetCachemode() {
+	if p.p != nil && p.p["cachemode"] != nil {
+		delete(p.p, "cachemode")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetCachemode() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1433,6 +1757,12 @@ func (p *UpdateDiskOfferingParams) SetDisplayoffering(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayoffering"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetDisplayoffering() {
+	if p.p != nil && p.p["displayoffering"] != nil {
+		delete(p.p, "displayoffering")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetDisplayoffering() (bool, bool) {
@@ -1450,6 +1780,12 @@ func (p *UpdateDiskOfferingParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1463,6 +1799,12 @@ func (p *UpdateDiskOfferingParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetDomainid() (string, bool) {
@@ -1480,6 +1822,12 @@ func (p *UpdateDiskOfferingParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1493,6 +1841,12 @@ func (p *UpdateDiskOfferingParams) SetIopsreadrate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadrate"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetIopsreadrate() {
+	if p.p != nil && p.p["iopsreadrate"] != nil {
+		delete(p.p, "iopsreadrate")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetIopsreadrate() (int64, bool) {
@@ -1510,6 +1864,12 @@ func (p *UpdateDiskOfferingParams) SetIopsreadratemax(v int64) {
 	p.p["iopsreadratemax"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetIopsreadratemax() {
+	if p.p != nil && p.p["iopsreadratemax"] != nil {
+		delete(p.p, "iopsreadratemax")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetIopsreadratemax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1523,6 +1883,12 @@ func (p *UpdateDiskOfferingParams) SetIopsreadratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemaxlength"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetIopsreadratemaxlength() {
+	if p.p != nil && p.p["iopsreadratemaxlength"] != nil {
+		delete(p.p, "iopsreadratemaxlength")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetIopsreadratemaxlength() (int64, bool) {
@@ -1540,6 +1906,12 @@ func (p *UpdateDiskOfferingParams) SetIopswriterate(v int64) {
 	p.p["iopswriterate"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetIopswriterate() {
+	if p.p != nil && p.p["iopswriterate"] != nil {
+		delete(p.p, "iopswriterate")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetIopswriterate() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1553,6 +1925,12 @@ func (p *UpdateDiskOfferingParams) SetIopswriteratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemax"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetIopswriteratemax() {
+	if p.p != nil && p.p["iopswriteratemax"] != nil {
+		delete(p.p, "iopswriteratemax")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetIopswriteratemax() (int64, bool) {
@@ -1570,6 +1948,12 @@ func (p *UpdateDiskOfferingParams) SetIopswriteratemaxlength(v int64) {
 	p.p["iopswriteratemaxlength"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetIopswriteratemaxlength() {
+	if p.p != nil && p.p["iopswriteratemaxlength"] != nil {
+		delete(p.p, "iopswriteratemaxlength")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetIopswriteratemaxlength() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1583,6 +1967,12 @@ func (p *UpdateDiskOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetName() (string, bool) {
@@ -1600,6 +1990,12 @@ func (p *UpdateDiskOfferingParams) SetSortkey(v int) {
 	p.p["sortkey"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetSortkey() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1615,6 +2011,12 @@ func (p *UpdateDiskOfferingParams) SetTags(v string) {
 	p.p["tags"] = v
 }
 
+func (p *UpdateDiskOfferingParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *UpdateDiskOfferingParams) GetTags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1628,6 +2030,12 @@ func (p *UpdateDiskOfferingParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UpdateDiskOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UpdateDiskOfferingParams) GetZoneid() (string, bool) {

--- a/cloudstack/DomainService.go
+++ b/cloudstack/DomainService.go
@@ -77,6 +77,12 @@ func (p *CreateDomainParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateDomainParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateDomainParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -90,6 +96,12 @@ func (p *CreateDomainParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateDomainParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateDomainParams) GetName() (string, bool) {
@@ -107,6 +119,12 @@ func (p *CreateDomainParams) SetNetworkdomain(v string) {
 	p.p["networkdomain"] = v
 }
 
+func (p *CreateDomainParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
+}
+
 func (p *CreateDomainParams) GetNetworkdomain() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -120,6 +138,12 @@ func (p *CreateDomainParams) SetParentdomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["parentdomainid"] = v
+}
+
+func (p *CreateDomainParams) ResetParentdomainid() {
+	if p.p != nil && p.p["parentdomainid"] != nil {
+		delete(p.p, "parentdomainid")
+	}
 }
 
 func (p *CreateDomainParams) GetParentdomainid() (string, bool) {
@@ -238,6 +262,12 @@ func (p *DeleteDomainParams) SetCleanup(v bool) {
 	p.p["cleanup"] = v
 }
 
+func (p *DeleteDomainParams) ResetCleanup() {
+	if p.p != nil && p.p["cleanup"] != nil {
+		delete(p.p, "cleanup")
+	}
+}
+
 func (p *DeleteDomainParams) GetCleanup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -251,6 +281,12 @@ func (p *DeleteDomainParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteDomainParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteDomainParams) GetId() (string, bool) {
@@ -355,6 +391,12 @@ func (p *ListDomainChildrenParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListDomainChildrenParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListDomainChildrenParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -368,6 +410,12 @@ func (p *ListDomainChildrenParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListDomainChildrenParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListDomainChildrenParams) GetIsrecursive() (bool, bool) {
@@ -385,6 +433,12 @@ func (p *ListDomainChildrenParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListDomainChildrenParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListDomainChildrenParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -398,6 +452,12 @@ func (p *ListDomainChildrenParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListDomainChildrenParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListDomainChildrenParams) GetListall() (bool, bool) {
@@ -415,6 +475,12 @@ func (p *ListDomainChildrenParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListDomainChildrenParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListDomainChildrenParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -428,6 +494,12 @@ func (p *ListDomainChildrenParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListDomainChildrenParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListDomainChildrenParams) GetPage() (int, bool) {
@@ -445,6 +517,12 @@ func (p *ListDomainChildrenParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListDomainChildrenParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListDomainChildrenParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -458,6 +536,12 @@ func (p *ListDomainChildrenParams) SetShowicon(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showicon"] = v
+}
+
+func (p *ListDomainChildrenParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
 }
 
 func (p *ListDomainChildrenParams) GetShowicon() (bool, bool) {
@@ -685,6 +769,12 @@ func (p *ListDomainsParams) SetDetails(v []string) {
 	p.p["details"] = v
 }
 
+func (p *ListDomainsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *ListDomainsParams) GetDetails() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -698,6 +788,12 @@ func (p *ListDomainsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListDomainsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListDomainsParams) GetId() (string, bool) {
@@ -715,6 +811,12 @@ func (p *ListDomainsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListDomainsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListDomainsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -728,6 +830,12 @@ func (p *ListDomainsParams) SetLevel(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["level"] = v
+}
+
+func (p *ListDomainsParams) ResetLevel() {
+	if p.p != nil && p.p["level"] != nil {
+		delete(p.p, "level")
+	}
 }
 
 func (p *ListDomainsParams) GetLevel() (int, bool) {
@@ -745,6 +853,12 @@ func (p *ListDomainsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListDomainsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListDomainsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -758,6 +872,12 @@ func (p *ListDomainsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListDomainsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListDomainsParams) GetName() (string, bool) {
@@ -775,6 +895,12 @@ func (p *ListDomainsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDomainsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDomainsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -790,6 +916,12 @@ func (p *ListDomainsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListDomainsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListDomainsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -803,6 +935,12 @@ func (p *ListDomainsParams) SetShowicon(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showicon"] = v
+}
+
+func (p *ListDomainsParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
 }
 
 func (p *ListDomainsParams) GetShowicon() (bool, bool) {
@@ -1006,6 +1144,12 @@ func (p *UpdateDomainParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateDomainParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateDomainParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1021,6 +1165,12 @@ func (p *UpdateDomainParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateDomainParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateDomainParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1034,6 +1184,12 @@ func (p *UpdateDomainParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
+}
+
+func (p *UpdateDomainParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
 }
 
 func (p *UpdateDomainParams) GetNetworkdomain() (string, bool) {

--- a/cloudstack/EventService.go
+++ b/cloudstack/EventService.go
@@ -71,6 +71,12 @@ func (p *ArchiveEventsParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *ArchiveEventsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *ArchiveEventsParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -84,6 +90,12 @@ func (p *ArchiveEventsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ArchiveEventsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ArchiveEventsParams) GetIds() ([]string, bool) {
@@ -101,6 +113,12 @@ func (p *ArchiveEventsParams) SetStartdate(v string) {
 	p.p["startdate"] = v
 }
 
+func (p *ArchiveEventsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
+}
+
 func (p *ArchiveEventsParams) GetStartdate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -114,6 +132,12 @@ func (p *ArchiveEventsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ArchiveEventsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ArchiveEventsParams) GetType() (string, bool) {
@@ -213,6 +237,12 @@ func (p *DeleteEventsParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *DeleteEventsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *DeleteEventsParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -226,6 +256,12 @@ func (p *DeleteEventsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *DeleteEventsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *DeleteEventsParams) GetIds() ([]string, bool) {
@@ -243,6 +279,12 @@ func (p *DeleteEventsParams) SetStartdate(v string) {
 	p.p["startdate"] = v
 }
 
+func (p *DeleteEventsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
+}
+
 func (p *DeleteEventsParams) GetStartdate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -256,6 +298,12 @@ func (p *DeleteEventsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *DeleteEventsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *DeleteEventsParams) GetType() (string, bool) {
@@ -452,6 +500,12 @@ func (p *ListEventsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListEventsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListEventsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -465,6 +519,12 @@ func (p *ListEventsParams) SetArchived(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["archived"] = v
+}
+
+func (p *ListEventsParams) ResetArchived() {
+	if p.p != nil && p.p["archived"] != nil {
+		delete(p.p, "archived")
+	}
 }
 
 func (p *ListEventsParams) GetArchived() (bool, bool) {
@@ -482,6 +542,12 @@ func (p *ListEventsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListEventsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListEventsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -495,6 +561,12 @@ func (p *ListEventsParams) SetDuration(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["duration"] = v
+}
+
+func (p *ListEventsParams) ResetDuration() {
+	if p.p != nil && p.p["duration"] != nil {
+		delete(p.p, "duration")
+	}
 }
 
 func (p *ListEventsParams) GetDuration() (int, bool) {
@@ -512,6 +584,12 @@ func (p *ListEventsParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *ListEventsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *ListEventsParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -525,6 +603,12 @@ func (p *ListEventsParams) SetEntrytime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["entrytime"] = v
+}
+
+func (p *ListEventsParams) ResetEntrytime() {
+	if p.p != nil && p.p["entrytime"] != nil {
+		delete(p.p, "entrytime")
+	}
 }
 
 func (p *ListEventsParams) GetEntrytime() (int, bool) {
@@ -542,6 +626,12 @@ func (p *ListEventsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListEventsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListEventsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -555,6 +645,12 @@ func (p *ListEventsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListEventsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListEventsParams) GetIsrecursive() (bool, bool) {
@@ -572,6 +668,12 @@ func (p *ListEventsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListEventsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListEventsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -585,6 +687,12 @@ func (p *ListEventsParams) SetLevel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["level"] = v
+}
+
+func (p *ListEventsParams) ResetLevel() {
+	if p.p != nil && p.p["level"] != nil {
+		delete(p.p, "level")
+	}
 }
 
 func (p *ListEventsParams) GetLevel() (string, bool) {
@@ -602,6 +710,12 @@ func (p *ListEventsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListEventsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListEventsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -615,6 +729,12 @@ func (p *ListEventsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListEventsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListEventsParams) GetPage() (int, bool) {
@@ -632,6 +752,12 @@ func (p *ListEventsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListEventsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListEventsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -645,6 +771,12 @@ func (p *ListEventsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListEventsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListEventsParams) GetProjectid() (string, bool) {
@@ -662,6 +794,12 @@ func (p *ListEventsParams) SetResourceid(v string) {
 	p.p["resourceid"] = v
 }
 
+func (p *ListEventsParams) ResetResourceid() {
+	if p.p != nil && p.p["resourceid"] != nil {
+		delete(p.p, "resourceid")
+	}
+}
+
 func (p *ListEventsParams) GetResourceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -675,6 +813,12 @@ func (p *ListEventsParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
+}
+
+func (p *ListEventsParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
 }
 
 func (p *ListEventsParams) GetResourcetype() (string, bool) {
@@ -692,6 +836,12 @@ func (p *ListEventsParams) SetStartdate(v string) {
 	p.p["startdate"] = v
 }
 
+func (p *ListEventsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
+}
+
 func (p *ListEventsParams) GetStartdate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -707,6 +857,12 @@ func (p *ListEventsParams) SetStartid(v string) {
 	p.p["startid"] = v
 }
 
+func (p *ListEventsParams) ResetStartid() {
+	if p.p != nil && p.p["startid"] != nil {
+		delete(p.p, "startid")
+	}
+}
+
 func (p *ListEventsParams) GetStartid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -720,6 +876,12 @@ func (p *ListEventsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListEventsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListEventsParams) GetType() (string, bool) {

--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -158,6 +158,12 @@ func (p *AddPaloAltoFirewallParams) SetNetworkdevicetype(v string) {
 	p.p["networkdevicetype"] = v
 }
 
+func (p *AddPaloAltoFirewallParams) ResetNetworkdevicetype() {
+	if p.p != nil && p.p["networkdevicetype"] != nil {
+		delete(p.p, "networkdevicetype")
+	}
+}
+
 func (p *AddPaloAltoFirewallParams) GetNetworkdevicetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -171,6 +177,12 @@ func (p *AddPaloAltoFirewallParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddPaloAltoFirewallParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddPaloAltoFirewallParams) GetPassword() (string, bool) {
@@ -188,6 +200,12 @@ func (p *AddPaloAltoFirewallParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddPaloAltoFirewallParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddPaloAltoFirewallParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -203,6 +221,12 @@ func (p *AddPaloAltoFirewallParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddPaloAltoFirewallParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddPaloAltoFirewallParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -216,6 +240,12 @@ func (p *AddPaloAltoFirewallParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddPaloAltoFirewallParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddPaloAltoFirewallParams) GetUsername() (string, bool) {
@@ -326,6 +356,12 @@ func (p *ConfigurePaloAltoFirewallParams) SetFwdevicecapacity(v int64) {
 	p.p["fwdevicecapacity"] = v
 }
 
+func (p *ConfigurePaloAltoFirewallParams) ResetFwdevicecapacity() {
+	if p.p != nil && p.p["fwdevicecapacity"] != nil {
+		delete(p.p, "fwdevicecapacity")
+	}
+}
+
 func (p *ConfigurePaloAltoFirewallParams) GetFwdevicecapacity() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -339,6 +375,12 @@ func (p *ConfigurePaloAltoFirewallParams) SetFwdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fwdeviceid"] = v
+}
+
+func (p *ConfigurePaloAltoFirewallParams) ResetFwdeviceid() {
+	if p.p != nil && p.p["fwdeviceid"] != nil {
+		delete(p.p, "fwdeviceid")
+	}
 }
 
 func (p *ConfigurePaloAltoFirewallParams) GetFwdeviceid() (string, bool) {
@@ -475,6 +517,12 @@ func (p *CreateEgressFirewallRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreateEgressFirewallRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreateEgressFirewallRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -488,6 +536,12 @@ func (p *CreateEgressFirewallRuleParams) SetDestcidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destcidrlist"] = v
+}
+
+func (p *CreateEgressFirewallRuleParams) ResetDestcidrlist() {
+	if p.p != nil && p.p["destcidrlist"] != nil {
+		delete(p.p, "destcidrlist")
+	}
 }
 
 func (p *CreateEgressFirewallRuleParams) GetDestcidrlist() ([]string, bool) {
@@ -505,6 +559,12 @@ func (p *CreateEgressFirewallRuleParams) SetEndport(v int) {
 	p.p["endport"] = v
 }
 
+func (p *CreateEgressFirewallRuleParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
+}
+
 func (p *CreateEgressFirewallRuleParams) GetEndport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -518,6 +578,12 @@ func (p *CreateEgressFirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateEgressFirewallRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateEgressFirewallRuleParams) GetFordisplay() (bool, bool) {
@@ -535,6 +601,12 @@ func (p *CreateEgressFirewallRuleParams) SetIcmpcode(v int) {
 	p.p["icmpcode"] = v
 }
 
+func (p *CreateEgressFirewallRuleParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
+}
+
 func (p *CreateEgressFirewallRuleParams) GetIcmpcode() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -548,6 +620,12 @@ func (p *CreateEgressFirewallRuleParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
+}
+
+func (p *CreateEgressFirewallRuleParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
 }
 
 func (p *CreateEgressFirewallRuleParams) GetIcmptype() (int, bool) {
@@ -565,6 +643,12 @@ func (p *CreateEgressFirewallRuleParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *CreateEgressFirewallRuleParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *CreateEgressFirewallRuleParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -578,6 +662,12 @@ func (p *CreateEgressFirewallRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *CreateEgressFirewallRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *CreateEgressFirewallRuleParams) GetProtocol() (string, bool) {
@@ -595,6 +685,12 @@ func (p *CreateEgressFirewallRuleParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *CreateEgressFirewallRuleParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *CreateEgressFirewallRuleParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -608,6 +704,12 @@ func (p *CreateEgressFirewallRuleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *CreateEgressFirewallRuleParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *CreateEgressFirewallRuleParams) GetType() (string, bool) {
@@ -740,6 +842,12 @@ func (p *CreateFirewallRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreateFirewallRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreateFirewallRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -753,6 +861,12 @@ func (p *CreateFirewallRuleParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
+}
+
+func (p *CreateFirewallRuleParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
 }
 
 func (p *CreateFirewallRuleParams) GetEndport() (int, bool) {
@@ -770,6 +884,12 @@ func (p *CreateFirewallRuleParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateFirewallRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateFirewallRuleParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -783,6 +903,12 @@ func (p *CreateFirewallRuleParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
+}
+
+func (p *CreateFirewallRuleParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
 }
 
 func (p *CreateFirewallRuleParams) GetIcmpcode() (int, bool) {
@@ -800,6 +926,12 @@ func (p *CreateFirewallRuleParams) SetIcmptype(v int) {
 	p.p["icmptype"] = v
 }
 
+func (p *CreateFirewallRuleParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
+}
+
 func (p *CreateFirewallRuleParams) GetIcmptype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -813,6 +945,12 @@ func (p *CreateFirewallRuleParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
+}
+
+func (p *CreateFirewallRuleParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
 }
 
 func (p *CreateFirewallRuleParams) GetIpaddressid() (string, bool) {
@@ -830,6 +968,12 @@ func (p *CreateFirewallRuleParams) SetProtocol(v string) {
 	p.p["protocol"] = v
 }
 
+func (p *CreateFirewallRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
+}
+
 func (p *CreateFirewallRuleParams) GetProtocol() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -845,6 +989,12 @@ func (p *CreateFirewallRuleParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *CreateFirewallRuleParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *CreateFirewallRuleParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -858,6 +1008,12 @@ func (p *CreateFirewallRuleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *CreateFirewallRuleParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *CreateFirewallRuleParams) GetType() (string, bool) {
@@ -1000,6 +1156,12 @@ func (p *CreatePortForwardingRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreatePortForwardingRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreatePortForwardingRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1013,6 +1175,12 @@ func (p *CreatePortForwardingRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreatePortForwardingRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreatePortForwardingRuleParams) GetFordisplay() (bool, bool) {
@@ -1030,6 +1198,12 @@ func (p *CreatePortForwardingRuleParams) SetIpaddressid(v string) {
 	p.p["ipaddressid"] = v
 }
 
+func (p *CreatePortForwardingRuleParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
+}
+
 func (p *CreatePortForwardingRuleParams) GetIpaddressid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1043,6 +1217,12 @@ func (p *CreatePortForwardingRuleParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *CreatePortForwardingRuleParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *CreatePortForwardingRuleParams) GetNetworkid() (string, bool) {
@@ -1060,6 +1240,12 @@ func (p *CreatePortForwardingRuleParams) SetOpenfirewall(v bool) {
 	p.p["openfirewall"] = v
 }
 
+func (p *CreatePortForwardingRuleParams) ResetOpenfirewall() {
+	if p.p != nil && p.p["openfirewall"] != nil {
+		delete(p.p, "openfirewall")
+	}
+}
+
 func (p *CreatePortForwardingRuleParams) GetOpenfirewall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1073,6 +1259,12 @@ func (p *CreatePortForwardingRuleParams) SetPrivateendport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateendport"] = v
+}
+
+func (p *CreatePortForwardingRuleParams) ResetPrivateendport() {
+	if p.p != nil && p.p["privateendport"] != nil {
+		delete(p.p, "privateendport")
+	}
 }
 
 func (p *CreatePortForwardingRuleParams) GetPrivateendport() (int, bool) {
@@ -1090,6 +1282,12 @@ func (p *CreatePortForwardingRuleParams) SetPrivateport(v int) {
 	p.p["privateport"] = v
 }
 
+func (p *CreatePortForwardingRuleParams) ResetPrivateport() {
+	if p.p != nil && p.p["privateport"] != nil {
+		delete(p.p, "privateport")
+	}
+}
+
 func (p *CreatePortForwardingRuleParams) GetPrivateport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1103,6 +1301,12 @@ func (p *CreatePortForwardingRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *CreatePortForwardingRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *CreatePortForwardingRuleParams) GetProtocol() (string, bool) {
@@ -1120,6 +1324,12 @@ func (p *CreatePortForwardingRuleParams) SetPublicendport(v int) {
 	p.p["publicendport"] = v
 }
 
+func (p *CreatePortForwardingRuleParams) ResetPublicendport() {
+	if p.p != nil && p.p["publicendport"] != nil {
+		delete(p.p, "publicendport")
+	}
+}
+
 func (p *CreatePortForwardingRuleParams) GetPublicendport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1133,6 +1343,12 @@ func (p *CreatePortForwardingRuleParams) SetPublicport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicport"] = v
+}
+
+func (p *CreatePortForwardingRuleParams) ResetPublicport() {
+	if p.p != nil && p.p["publicport"] != nil {
+		delete(p.p, "publicport")
+	}
 }
 
 func (p *CreatePortForwardingRuleParams) GetPublicport() (int, bool) {
@@ -1150,6 +1366,12 @@ func (p *CreatePortForwardingRuleParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *CreatePortForwardingRuleParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *CreatePortForwardingRuleParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1163,6 +1385,12 @@ func (p *CreatePortForwardingRuleParams) SetVmguestip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmguestip"] = v
+}
+
+func (p *CreatePortForwardingRuleParams) ResetVmguestip() {
+	if p.p != nil && p.p["vmguestip"] != nil {
+		delete(p.p, "vmguestip")
+	}
 }
 
 func (p *CreatePortForwardingRuleParams) GetVmguestip() (string, bool) {
@@ -1270,6 +1498,12 @@ func (p *DeleteEgressFirewallRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteEgressFirewallRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteEgressFirewallRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1349,6 +1583,12 @@ func (p *DeleteFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteFirewallRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteFirewallRuleParams) GetId() (string, bool) {
@@ -1432,6 +1672,12 @@ func (p *DeletePaloAltoFirewallParams) SetFwdeviceid(v string) {
 	p.p["fwdeviceid"] = v
 }
 
+func (p *DeletePaloAltoFirewallParams) ResetFwdeviceid() {
+	if p.p != nil && p.p["fwdeviceid"] != nil {
+		delete(p.p, "fwdeviceid")
+	}
+}
+
 func (p *DeletePaloAltoFirewallParams) GetFwdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1511,6 +1757,12 @@ func (p *DeletePortForwardingRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeletePortForwardingRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeletePortForwardingRuleParams) GetId() (string, bool) {
@@ -1639,6 +1891,12 @@ func (p *ListEgressFirewallRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1652,6 +1910,12 @@ func (p *ListEgressFirewallRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListEgressFirewallRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListEgressFirewallRulesParams) GetDomainid() (string, bool) {
@@ -1669,6 +1933,12 @@ func (p *ListEgressFirewallRulesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1682,6 +1952,12 @@ func (p *ListEgressFirewallRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListEgressFirewallRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListEgressFirewallRulesParams) GetId() (string, bool) {
@@ -1699,6 +1975,12 @@ func (p *ListEgressFirewallRulesParams) SetIpaddressid(v string) {
 	p.p["ipaddressid"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetIpaddressid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1712,6 +1994,12 @@ func (p *ListEgressFirewallRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListEgressFirewallRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListEgressFirewallRulesParams) GetIsrecursive() (bool, bool) {
@@ -1729,6 +2017,12 @@ func (p *ListEgressFirewallRulesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1742,6 +2036,12 @@ func (p *ListEgressFirewallRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListEgressFirewallRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListEgressFirewallRulesParams) GetListall() (bool, bool) {
@@ -1759,6 +2059,12 @@ func (p *ListEgressFirewallRulesParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1772,6 +2078,12 @@ func (p *ListEgressFirewallRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListEgressFirewallRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListEgressFirewallRulesParams) GetPage() (int, bool) {
@@ -1789,6 +2101,12 @@ func (p *ListEgressFirewallRulesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1804,6 +2122,12 @@ func (p *ListEgressFirewallRulesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListEgressFirewallRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListEgressFirewallRulesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1817,6 +2141,12 @@ func (p *ListEgressFirewallRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListEgressFirewallRulesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListEgressFirewallRulesParams) GetTags() (map[string]string, bool) {
@@ -1980,6 +2310,12 @@ func (p *ListFirewallRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1993,6 +2329,12 @@ func (p *ListFirewallRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListFirewallRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListFirewallRulesParams) GetDomainid() (string, bool) {
@@ -2010,6 +2352,12 @@ func (p *ListFirewallRulesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2023,6 +2371,12 @@ func (p *ListFirewallRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListFirewallRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListFirewallRulesParams) GetId() (string, bool) {
@@ -2040,6 +2394,12 @@ func (p *ListFirewallRulesParams) SetIpaddressid(v string) {
 	p.p["ipaddressid"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetIpaddressid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2053,6 +2413,12 @@ func (p *ListFirewallRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListFirewallRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListFirewallRulesParams) GetIsrecursive() (bool, bool) {
@@ -2070,6 +2436,12 @@ func (p *ListFirewallRulesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2083,6 +2455,12 @@ func (p *ListFirewallRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListFirewallRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListFirewallRulesParams) GetListall() (bool, bool) {
@@ -2100,6 +2478,12 @@ func (p *ListFirewallRulesParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2113,6 +2497,12 @@ func (p *ListFirewallRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListFirewallRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListFirewallRulesParams) GetPage() (int, bool) {
@@ -2130,6 +2520,12 @@ func (p *ListFirewallRulesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2145,6 +2541,12 @@ func (p *ListFirewallRulesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListFirewallRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListFirewallRulesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2158,6 +2560,12 @@ func (p *ListFirewallRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListFirewallRulesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListFirewallRulesParams) GetTags() (map[string]string, bool) {
@@ -2290,6 +2698,12 @@ func (p *ListPaloAltoFirewallsParams) SetFwdeviceid(v string) {
 	p.p["fwdeviceid"] = v
 }
 
+func (p *ListPaloAltoFirewallsParams) ResetFwdeviceid() {
+	if p.p != nil && p.p["fwdeviceid"] != nil {
+		delete(p.p, "fwdeviceid")
+	}
+}
+
 func (p *ListPaloAltoFirewallsParams) GetFwdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2303,6 +2717,12 @@ func (p *ListPaloAltoFirewallsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListPaloAltoFirewallsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListPaloAltoFirewallsParams) GetKeyword() (string, bool) {
@@ -2320,6 +2740,12 @@ func (p *ListPaloAltoFirewallsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListPaloAltoFirewallsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListPaloAltoFirewallsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2335,6 +2761,12 @@ func (p *ListPaloAltoFirewallsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListPaloAltoFirewallsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListPaloAltoFirewallsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2348,6 +2780,12 @@ func (p *ListPaloAltoFirewallsParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListPaloAltoFirewallsParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListPaloAltoFirewallsParams) GetPhysicalnetworkid() (string, bool) {
@@ -2479,6 +2917,12 @@ func (p *ListPortForwardingRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2492,6 +2936,12 @@ func (p *ListPortForwardingRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListPortForwardingRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListPortForwardingRulesParams) GetDomainid() (string, bool) {
@@ -2509,6 +2959,12 @@ func (p *ListPortForwardingRulesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2522,6 +2978,12 @@ func (p *ListPortForwardingRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListPortForwardingRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListPortForwardingRulesParams) GetId() (string, bool) {
@@ -2539,6 +3001,12 @@ func (p *ListPortForwardingRulesParams) SetIpaddressid(v string) {
 	p.p["ipaddressid"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetIpaddressid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2552,6 +3020,12 @@ func (p *ListPortForwardingRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListPortForwardingRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListPortForwardingRulesParams) GetIsrecursive() (bool, bool) {
@@ -2569,6 +3043,12 @@ func (p *ListPortForwardingRulesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2582,6 +3062,12 @@ func (p *ListPortForwardingRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListPortForwardingRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListPortForwardingRulesParams) GetListall() (bool, bool) {
@@ -2599,6 +3085,12 @@ func (p *ListPortForwardingRulesParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2612,6 +3104,12 @@ func (p *ListPortForwardingRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListPortForwardingRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListPortForwardingRulesParams) GetPage() (int, bool) {
@@ -2629,6 +3127,12 @@ func (p *ListPortForwardingRulesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2644,6 +3148,12 @@ func (p *ListPortForwardingRulesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListPortForwardingRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListPortForwardingRulesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2657,6 +3167,12 @@ func (p *ListPortForwardingRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListPortForwardingRulesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListPortForwardingRulesParams) GetTags() (map[string]string, bool) {
@@ -2784,6 +3300,12 @@ func (p *UpdateEgressFirewallRuleParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateEgressFirewallRuleParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateEgressFirewallRuleParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2799,6 +3321,12 @@ func (p *UpdateEgressFirewallRuleParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateEgressFirewallRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateEgressFirewallRuleParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2812,6 +3340,12 @@ func (p *UpdateEgressFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateEgressFirewallRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateEgressFirewallRuleParams) GetId() (string, bool) {
@@ -2920,6 +3454,12 @@ func (p *UpdateFirewallRuleParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateFirewallRuleParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateFirewallRuleParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2935,6 +3475,12 @@ func (p *UpdateFirewallRuleParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateFirewallRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateFirewallRuleParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2948,6 +3494,12 @@ func (p *UpdateFirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateFirewallRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateFirewallRuleParams) GetId() (string, bool) {
@@ -3070,6 +3622,12 @@ func (p *UpdatePortForwardingRuleParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdatePortForwardingRuleParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdatePortForwardingRuleParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3083,6 +3641,12 @@ func (p *UpdatePortForwardingRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *UpdatePortForwardingRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *UpdatePortForwardingRuleParams) GetFordisplay() (bool, bool) {
@@ -3100,6 +3664,12 @@ func (p *UpdatePortForwardingRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdatePortForwardingRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdatePortForwardingRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3113,6 +3683,12 @@ func (p *UpdatePortForwardingRuleParams) SetPrivateendport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateendport"] = v
+}
+
+func (p *UpdatePortForwardingRuleParams) ResetPrivateendport() {
+	if p.p != nil && p.p["privateendport"] != nil {
+		delete(p.p, "privateendport")
+	}
 }
 
 func (p *UpdatePortForwardingRuleParams) GetPrivateendport() (int, bool) {
@@ -3130,6 +3706,12 @@ func (p *UpdatePortForwardingRuleParams) SetPrivateport(v int) {
 	p.p["privateport"] = v
 }
 
+func (p *UpdatePortForwardingRuleParams) ResetPrivateport() {
+	if p.p != nil && p.p["privateport"] != nil {
+		delete(p.p, "privateport")
+	}
+}
+
 func (p *UpdatePortForwardingRuleParams) GetPrivateport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3145,6 +3727,12 @@ func (p *UpdatePortForwardingRuleParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *UpdatePortForwardingRuleParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *UpdatePortForwardingRuleParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3158,6 +3746,12 @@ func (p *UpdatePortForwardingRuleParams) SetVmguestip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmguestip"] = v
+}
+
+func (p *UpdatePortForwardingRuleParams) ResetVmguestip() {
+	if p.p != nil && p.p["vmguestip"] != nil {
+		delete(p.p, "vmguestip")
+	}
 }
 
 func (p *UpdatePortForwardingRuleParams) GetVmguestip() (string, bool) {
@@ -3306,6 +3900,12 @@ func (p *ListIpv6FirewallRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3319,6 +3919,12 @@ func (p *ListIpv6FirewallRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListIpv6FirewallRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListIpv6FirewallRulesParams) GetDomainid() (string, bool) {
@@ -3336,6 +3942,12 @@ func (p *ListIpv6FirewallRulesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3349,6 +3961,12 @@ func (p *ListIpv6FirewallRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListIpv6FirewallRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListIpv6FirewallRulesParams) GetId() (string, bool) {
@@ -3366,6 +3984,12 @@ func (p *ListIpv6FirewallRulesParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3379,6 +4003,12 @@ func (p *ListIpv6FirewallRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListIpv6FirewallRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListIpv6FirewallRulesParams) GetKeyword() (string, bool) {
@@ -3396,6 +4026,12 @@ func (p *ListIpv6FirewallRulesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3409,6 +4045,12 @@ func (p *ListIpv6FirewallRulesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ListIpv6FirewallRulesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ListIpv6FirewallRulesParams) GetNetworkid() (string, bool) {
@@ -3426,6 +4068,12 @@ func (p *ListIpv6FirewallRulesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3439,6 +4087,12 @@ func (p *ListIpv6FirewallRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListIpv6FirewallRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListIpv6FirewallRulesParams) GetPagesize() (int, bool) {
@@ -3456,6 +4110,12 @@ func (p *ListIpv6FirewallRulesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3471,6 +4131,12 @@ func (p *ListIpv6FirewallRulesParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListIpv6FirewallRulesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListIpv6FirewallRulesParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3484,6 +4150,12 @@ func (p *ListIpv6FirewallRulesParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *ListIpv6FirewallRulesParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *ListIpv6FirewallRulesParams) GetTraffictype() (string, bool) {
@@ -3638,6 +4310,12 @@ func (p *CreateIpv6FirewallRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreateIpv6FirewallRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreateIpv6FirewallRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3651,6 +4329,12 @@ func (p *CreateIpv6FirewallRuleParams) SetDestcidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destcidrlist"] = v
+}
+
+func (p *CreateIpv6FirewallRuleParams) ResetDestcidrlist() {
+	if p.p != nil && p.p["destcidrlist"] != nil {
+		delete(p.p, "destcidrlist")
+	}
 }
 
 func (p *CreateIpv6FirewallRuleParams) GetDestcidrlist() ([]string, bool) {
@@ -3668,6 +4352,12 @@ func (p *CreateIpv6FirewallRuleParams) SetEndport(v int) {
 	p.p["endport"] = v
 }
 
+func (p *CreateIpv6FirewallRuleParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
+}
+
 func (p *CreateIpv6FirewallRuleParams) GetEndport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3681,6 +4371,12 @@ func (p *CreateIpv6FirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateIpv6FirewallRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateIpv6FirewallRuleParams) GetFordisplay() (bool, bool) {
@@ -3698,6 +4394,12 @@ func (p *CreateIpv6FirewallRuleParams) SetIcmpcode(v int) {
 	p.p["icmpcode"] = v
 }
 
+func (p *CreateIpv6FirewallRuleParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
+}
+
 func (p *CreateIpv6FirewallRuleParams) GetIcmpcode() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3711,6 +4413,12 @@ func (p *CreateIpv6FirewallRuleParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
+}
+
+func (p *CreateIpv6FirewallRuleParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
 }
 
 func (p *CreateIpv6FirewallRuleParams) GetIcmptype() (int, bool) {
@@ -3728,6 +4436,12 @@ func (p *CreateIpv6FirewallRuleParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *CreateIpv6FirewallRuleParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *CreateIpv6FirewallRuleParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3741,6 +4455,12 @@ func (p *CreateIpv6FirewallRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *CreateIpv6FirewallRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *CreateIpv6FirewallRuleParams) GetProtocol() (string, bool) {
@@ -3758,6 +4478,12 @@ func (p *CreateIpv6FirewallRuleParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *CreateIpv6FirewallRuleParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *CreateIpv6FirewallRuleParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3771,6 +4497,12 @@ func (p *CreateIpv6FirewallRuleParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *CreateIpv6FirewallRuleParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *CreateIpv6FirewallRuleParams) GetTraffictype() (string, bool) {
@@ -3908,6 +4640,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *UpdateIpv6FirewallRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *UpdateIpv6FirewallRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3921,6 +4659,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
+}
+
+func (p *UpdateIpv6FirewallRuleParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
 }
 
 func (p *UpdateIpv6FirewallRuleParams) GetCustomid() (string, bool) {
@@ -3938,6 +4682,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetEndport(v int) {
 	p.p["endport"] = v
 }
 
+func (p *UpdateIpv6FirewallRuleParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
+}
+
 func (p *UpdateIpv6FirewallRuleParams) GetEndport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3951,6 +4701,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *UpdateIpv6FirewallRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *UpdateIpv6FirewallRuleParams) GetFordisplay() (bool, bool) {
@@ -3968,6 +4724,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetIcmpcode(v int) {
 	p.p["icmpcode"] = v
 }
 
+func (p *UpdateIpv6FirewallRuleParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
+}
+
 func (p *UpdateIpv6FirewallRuleParams) GetIcmpcode() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3981,6 +4743,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
+}
+
+func (p *UpdateIpv6FirewallRuleParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
 }
 
 func (p *UpdateIpv6FirewallRuleParams) GetIcmptype() (int, bool) {
@@ -3998,6 +4766,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateIpv6FirewallRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateIpv6FirewallRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4011,6 +4785,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *UpdateIpv6FirewallRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *UpdateIpv6FirewallRuleParams) GetProtocol() (string, bool) {
@@ -4028,6 +4808,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *UpdateIpv6FirewallRuleParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *UpdateIpv6FirewallRuleParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4041,6 +4827,12 @@ func (p *UpdateIpv6FirewallRuleParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *UpdateIpv6FirewallRuleParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *UpdateIpv6FirewallRuleParams) GetTraffictype() (string, bool) {
@@ -4142,6 +4934,12 @@ func (p *DeleteIpv6FirewallRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteIpv6FirewallRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteIpv6FirewallRuleParams) GetId() (string, bool) {

--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -94,6 +94,12 @@ func (p *AddGuestOsParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *AddGuestOsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *AddGuestOsParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -107,6 +113,12 @@ func (p *AddGuestOsParams) SetForDisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forDisplay"] = v
+}
+
+func (p *AddGuestOsParams) ResetForDisplay() {
+	if p.p != nil && p.p["forDisplay"] != nil {
+		delete(p.p, "forDisplay")
+	}
 }
 
 func (p *AddGuestOsParams) GetForDisplay() (bool, bool) {
@@ -124,6 +136,12 @@ func (p *AddGuestOsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *AddGuestOsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *AddGuestOsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -139,6 +157,12 @@ func (p *AddGuestOsParams) SetOscategoryid(v string) {
 	p.p["oscategoryid"] = v
 }
 
+func (p *AddGuestOsParams) ResetOscategoryid() {
+	if p.p != nil && p.p["oscategoryid"] != nil {
+		delete(p.p, "oscategoryid")
+	}
+}
+
 func (p *AddGuestOsParams) GetOscategoryid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -152,6 +176,12 @@ func (p *AddGuestOsParams) SetOsdisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osdisplayname"] = v
+}
+
+func (p *AddGuestOsParams) ResetOsdisplayname() {
+	if p.p != nil && p.p["osdisplayname"] != nil {
+		delete(p.p, "osdisplayname")
+	}
 }
 
 func (p *AddGuestOsParams) GetOsdisplayname() (string, bool) {
@@ -261,6 +291,12 @@ func (p *AddGuestOsMappingParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *AddGuestOsMappingParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *AddGuestOsMappingParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -274,6 +310,12 @@ func (p *AddGuestOsMappingParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *AddGuestOsMappingParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *AddGuestOsMappingParams) GetHypervisor() (string, bool) {
@@ -291,6 +333,12 @@ func (p *AddGuestOsMappingParams) SetHypervisorversion(v string) {
 	p.p["hypervisorversion"] = v
 }
 
+func (p *AddGuestOsMappingParams) ResetHypervisorversion() {
+	if p.p != nil && p.p["hypervisorversion"] != nil {
+		delete(p.p, "hypervisorversion")
+	}
+}
+
 func (p *AddGuestOsMappingParams) GetHypervisorversion() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -304,6 +352,12 @@ func (p *AddGuestOsMappingParams) SetOsdisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osdisplayname"] = v
+}
+
+func (p *AddGuestOsMappingParams) ResetOsdisplayname() {
+	if p.p != nil && p.p["osdisplayname"] != nil {
+		delete(p.p, "osdisplayname")
+	}
 }
 
 func (p *AddGuestOsMappingParams) GetOsdisplayname() (string, bool) {
@@ -321,6 +375,12 @@ func (p *AddGuestOsMappingParams) SetOsmappingcheckenabled(v bool) {
 	p.p["osmappingcheckenabled"] = v
 }
 
+func (p *AddGuestOsMappingParams) ResetOsmappingcheckenabled() {
+	if p.p != nil && p.p["osmappingcheckenabled"] != nil {
+		delete(p.p, "osmappingcheckenabled")
+	}
+}
+
 func (p *AddGuestOsMappingParams) GetOsmappingcheckenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -336,6 +396,12 @@ func (p *AddGuestOsMappingParams) SetOsnameforhypervisor(v string) {
 	p.p["osnameforhypervisor"] = v
 }
 
+func (p *AddGuestOsMappingParams) ResetOsnameforhypervisor() {
+	if p.p != nil && p.p["osnameforhypervisor"] != nil {
+		delete(p.p, "osnameforhypervisor")
+	}
+}
+
 func (p *AddGuestOsMappingParams) GetOsnameforhypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -349,6 +415,12 @@ func (p *AddGuestOsMappingParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
+}
+
+func (p *AddGuestOsMappingParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
 }
 
 func (p *AddGuestOsMappingParams) GetOstypeid() (string, bool) {
@@ -492,6 +564,12 @@ func (p *ListGuestOsMappingParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *ListGuestOsMappingParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *ListGuestOsMappingParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -505,6 +583,12 @@ func (p *ListGuestOsMappingParams) SetHypervisorversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisorversion"] = v
+}
+
+func (p *ListGuestOsMappingParams) ResetHypervisorversion() {
+	if p.p != nil && p.p["hypervisorversion"] != nil {
+		delete(p.p, "hypervisorversion")
+	}
 }
 
 func (p *ListGuestOsMappingParams) GetHypervisorversion() (string, bool) {
@@ -522,6 +606,12 @@ func (p *ListGuestOsMappingParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListGuestOsMappingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListGuestOsMappingParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -535,6 +625,12 @@ func (p *ListGuestOsMappingParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListGuestOsMappingParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListGuestOsMappingParams) GetKeyword() (string, bool) {
@@ -552,6 +648,12 @@ func (p *ListGuestOsMappingParams) SetOsdisplayname(v string) {
 	p.p["osdisplayname"] = v
 }
 
+func (p *ListGuestOsMappingParams) ResetOsdisplayname() {
+	if p.p != nil && p.p["osdisplayname"] != nil {
+		delete(p.p, "osdisplayname")
+	}
+}
+
 func (p *ListGuestOsMappingParams) GetOsdisplayname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -565,6 +667,12 @@ func (p *ListGuestOsMappingParams) SetOsnameforhypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osnameforhypervisor"] = v
+}
+
+func (p *ListGuestOsMappingParams) ResetOsnameforhypervisor() {
+	if p.p != nil && p.p["osnameforhypervisor"] != nil {
+		delete(p.p, "osnameforhypervisor")
+	}
 }
 
 func (p *ListGuestOsMappingParams) GetOsnameforhypervisor() (string, bool) {
@@ -582,6 +690,12 @@ func (p *ListGuestOsMappingParams) SetOstypeid(v string) {
 	p.p["ostypeid"] = v
 }
 
+func (p *ListGuestOsMappingParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
+}
+
 func (p *ListGuestOsMappingParams) GetOstypeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -597,6 +711,12 @@ func (p *ListGuestOsMappingParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListGuestOsMappingParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListGuestOsMappingParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -610,6 +730,12 @@ func (p *ListGuestOsMappingParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListGuestOsMappingParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListGuestOsMappingParams) GetPagesize() (int, bool) {
@@ -756,6 +882,12 @@ func (p *ListOsCategoriesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListOsCategoriesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListOsCategoriesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -769,6 +901,12 @@ func (p *ListOsCategoriesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListOsCategoriesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListOsCategoriesParams) GetKeyword() (string, bool) {
@@ -786,6 +924,12 @@ func (p *ListOsCategoriesParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListOsCategoriesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListOsCategoriesParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -801,6 +945,12 @@ func (p *ListOsCategoriesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListOsCategoriesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListOsCategoriesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -814,6 +964,12 @@ func (p *ListOsCategoriesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListOsCategoriesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListOsCategoriesParams) GetPagesize() (int, bool) {
@@ -985,6 +1141,12 @@ func (p *ListOsTypesParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *ListOsTypesParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *ListOsTypesParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -998,6 +1160,12 @@ func (p *ListOsTypesParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *ListOsTypesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *ListOsTypesParams) GetFordisplay() (bool, bool) {
@@ -1015,6 +1183,12 @@ func (p *ListOsTypesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListOsTypesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListOsTypesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1028,6 +1202,12 @@ func (p *ListOsTypesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListOsTypesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListOsTypesParams) GetKeyword() (string, bool) {
@@ -1045,6 +1225,12 @@ func (p *ListOsTypesParams) SetOscategoryid(v string) {
 	p.p["oscategoryid"] = v
 }
 
+func (p *ListOsTypesParams) ResetOscategoryid() {
+	if p.p != nil && p.p["oscategoryid"] != nil {
+		delete(p.p, "oscategoryid")
+	}
+}
+
 func (p *ListOsTypesParams) GetOscategoryid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1060,6 +1246,12 @@ func (p *ListOsTypesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListOsTypesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListOsTypesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1073,6 +1265,12 @@ func (p *ListOsTypesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListOsTypesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListOsTypesParams) GetPagesize() (int, bool) {
@@ -1228,6 +1426,12 @@ func (p *RemoveGuestOsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RemoveGuestOsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RemoveGuestOsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1302,6 +1506,12 @@ func (p *RemoveGuestOsMappingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RemoveGuestOsMappingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RemoveGuestOsMappingParams) GetId() (string, bool) {
@@ -1394,6 +1604,12 @@ func (p *UpdateGuestOsParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *UpdateGuestOsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *UpdateGuestOsParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1407,6 +1623,12 @@ func (p *UpdateGuestOsParams) SetForDisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forDisplay"] = v
+}
+
+func (p *UpdateGuestOsParams) ResetForDisplay() {
+	if p.p != nil && p.p["forDisplay"] != nil {
+		delete(p.p, "forDisplay")
+	}
 }
 
 func (p *UpdateGuestOsParams) GetForDisplay() (bool, bool) {
@@ -1424,6 +1646,12 @@ func (p *UpdateGuestOsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateGuestOsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateGuestOsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1437,6 +1665,12 @@ func (p *UpdateGuestOsParams) SetOsdisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osdisplayname"] = v
+}
+
+func (p *UpdateGuestOsParams) ResetOsdisplayname() {
+	if p.p != nil && p.p["osdisplayname"] != nil {
+		delete(p.p, "osdisplayname")
+	}
 }
 
 func (p *UpdateGuestOsParams) GetOsdisplayname() (string, bool) {
@@ -1533,6 +1767,12 @@ func (p *UpdateGuestOsMappingParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateGuestOsMappingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateGuestOsMappingParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1548,6 +1788,12 @@ func (p *UpdateGuestOsMappingParams) SetOsmappingcheckenabled(v bool) {
 	p.p["osmappingcheckenabled"] = v
 }
 
+func (p *UpdateGuestOsMappingParams) ResetOsmappingcheckenabled() {
+	if p.p != nil && p.p["osmappingcheckenabled"] != nil {
+		delete(p.p, "osmappingcheckenabled")
+	}
+}
+
 func (p *UpdateGuestOsMappingParams) GetOsmappingcheckenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1561,6 +1807,12 @@ func (p *UpdateGuestOsMappingParams) SetOsnameforhypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["osnameforhypervisor"] = v
+}
+
+func (p *UpdateGuestOsMappingParams) ResetOsnameforhypervisor() {
+	if p.p != nil && p.p["osnameforhypervisor"] != nil {
+		delete(p.p, "osnameforhypervisor")
+	}
 }
 
 func (p *UpdateGuestOsMappingParams) GetOsnameforhypervisor() (string, bool) {

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -134,6 +134,12 @@ func (p *AddBaremetalHostParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *AddBaremetalHostParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *AddBaremetalHostParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -147,6 +153,12 @@ func (p *AddBaremetalHostParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *AddBaremetalHostParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *AddBaremetalHostParams) GetClusterid() (string, bool) {
@@ -164,6 +176,12 @@ func (p *AddBaremetalHostParams) SetClustername(v string) {
 	p.p["clustername"] = v
 }
 
+func (p *AddBaremetalHostParams) ResetClustername() {
+	if p.p != nil && p.p["clustername"] != nil {
+		delete(p.p, "clustername")
+	}
+}
+
 func (p *AddBaremetalHostParams) GetClustername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -177,6 +195,12 @@ func (p *AddBaremetalHostParams) SetHosttags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hosttags"] = v
+}
+
+func (p *AddBaremetalHostParams) ResetHosttags() {
+	if p.p != nil && p.p["hosttags"] != nil {
+		delete(p.p, "hosttags")
+	}
 }
 
 func (p *AddBaremetalHostParams) GetHosttags() ([]string, bool) {
@@ -194,6 +218,12 @@ func (p *AddBaremetalHostParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *AddBaremetalHostParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *AddBaremetalHostParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -207,6 +237,12 @@ func (p *AddBaremetalHostParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+}
+
+func (p *AddBaremetalHostParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
 }
 
 func (p *AddBaremetalHostParams) GetIpaddress() (string, bool) {
@@ -224,6 +260,12 @@ func (p *AddBaremetalHostParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddBaremetalHostParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddBaremetalHostParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -237,6 +279,12 @@ func (p *AddBaremetalHostParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *AddBaremetalHostParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *AddBaremetalHostParams) GetPodid() (string, bool) {
@@ -254,6 +302,12 @@ func (p *AddBaremetalHostParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddBaremetalHostParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddBaremetalHostParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -269,6 +323,12 @@ func (p *AddBaremetalHostParams) SetUsername(v string) {
 	p.p["username"] = v
 }
 
+func (p *AddBaremetalHostParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
+}
+
 func (p *AddBaremetalHostParams) GetUsername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -282,6 +342,12 @@ func (p *AddBaremetalHostParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddBaremetalHostParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddBaremetalHostParams) GetZoneid() (string, bool) {
@@ -432,6 +498,12 @@ func (p *AddGloboDnsHostParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddGloboDnsHostParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddGloboDnsHostParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -445,6 +517,12 @@ func (p *AddGloboDnsHostParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *AddGloboDnsHostParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *AddGloboDnsHostParams) GetPhysicalnetworkid() (string, bool) {
@@ -462,6 +540,12 @@ func (p *AddGloboDnsHostParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddGloboDnsHostParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddGloboDnsHostParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -475,6 +559,12 @@ func (p *AddGloboDnsHostParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddGloboDnsHostParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddGloboDnsHostParams) GetUsername() (string, bool) {
@@ -584,6 +674,12 @@ func (p *AddHostParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *AddHostParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *AddHostParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -597,6 +693,12 @@ func (p *AddHostParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *AddHostParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *AddHostParams) GetClusterid() (string, bool) {
@@ -614,6 +716,12 @@ func (p *AddHostParams) SetClustername(v string) {
 	p.p["clustername"] = v
 }
 
+func (p *AddHostParams) ResetClustername() {
+	if p.p != nil && p.p["clustername"] != nil {
+		delete(p.p, "clustername")
+	}
+}
+
 func (p *AddHostParams) GetClustername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -627,6 +735,12 @@ func (p *AddHostParams) SetHosttags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hosttags"] = v
+}
+
+func (p *AddHostParams) ResetHosttags() {
+	if p.p != nil && p.p["hosttags"] != nil {
+		delete(p.p, "hosttags")
+	}
 }
 
 func (p *AddHostParams) GetHosttags() ([]string, bool) {
@@ -644,6 +758,12 @@ func (p *AddHostParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *AddHostParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *AddHostParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -657,6 +777,12 @@ func (p *AddHostParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddHostParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddHostParams) GetPassword() (string, bool) {
@@ -674,6 +800,12 @@ func (p *AddHostParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *AddHostParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *AddHostParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -687,6 +819,12 @@ func (p *AddHostParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *AddHostParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *AddHostParams) GetUrl() (string, bool) {
@@ -704,6 +842,12 @@ func (p *AddHostParams) SetUsername(v string) {
 	p.p["username"] = v
 }
 
+func (p *AddHostParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
+}
+
 func (p *AddHostParams) GetUsername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -717,6 +861,12 @@ func (p *AddHostParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddHostParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddHostParams) GetZoneid() (string, bool) {
@@ -865,6 +1015,12 @@ func (p *AddSecondaryStorageParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddSecondaryStorageParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddSecondaryStorageParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -878,6 +1034,12 @@ func (p *AddSecondaryStorageParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddSecondaryStorageParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddSecondaryStorageParams) GetZoneid() (string, bool) {
@@ -949,6 +1111,12 @@ func (p *CancelHostMaintenanceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *CancelHostMaintenanceParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *CancelHostMaintenanceParams) GetId() (string, bool) {
@@ -1110,6 +1278,12 @@ func (p *ConfigureHAForHostParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ConfigureHAForHostParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ConfigureHAForHostParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1123,6 +1297,12 @@ func (p *ConfigureHAForHostParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
+}
+
+func (p *ConfigureHAForHostParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
 }
 
 func (p *ConfigureHAForHostParams) GetProvider() (string, bool) {
@@ -1208,6 +1388,12 @@ func (p *EnableHAForHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *EnableHAForHostParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *EnableHAForHostParams) GetHostid() (string, bool) {
@@ -1300,6 +1486,12 @@ func (p *DedicateHostParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DedicateHostParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DedicateHostParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1315,6 +1507,12 @@ func (p *DedicateHostParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *DedicateHostParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *DedicateHostParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1328,6 +1526,12 @@ func (p *DedicateHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *DedicateHostParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *DedicateHostParams) GetHostid() (string, bool) {
@@ -1424,6 +1628,12 @@ func (p *DeleteHostParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *DeleteHostParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *DeleteHostParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1439,6 +1649,12 @@ func (p *DeleteHostParams) SetForcedestroylocalstorage(v bool) {
 	p.p["forcedestroylocalstorage"] = v
 }
 
+func (p *DeleteHostParams) ResetForcedestroylocalstorage() {
+	if p.p != nil && p.p["forcedestroylocalstorage"] != nil {
+		delete(p.p, "forcedestroylocalstorage")
+	}
+}
+
 func (p *DeleteHostParams) GetForcedestroylocalstorage() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1452,6 +1668,12 @@ func (p *DeleteHostParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteHostParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteHostParams) GetId() (string, bool) {
@@ -1542,6 +1764,12 @@ func (p *DisableOutOfBandManagementForHostParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *DisableOutOfBandManagementForHostParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *DisableOutOfBandManagementForHostParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1630,6 +1858,12 @@ func (p *EnableOutOfBandManagementForHostParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *EnableOutOfBandManagementForHostParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *EnableOutOfBandManagementForHostParams) GetHostid() (string, bool) {
@@ -1733,6 +1967,12 @@ func (p *FindHostsForMigrationParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *FindHostsForMigrationParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *FindHostsForMigrationParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1746,6 +1986,12 @@ func (p *FindHostsForMigrationParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *FindHostsForMigrationParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *FindHostsForMigrationParams) GetPage() (int, bool) {
@@ -1763,6 +2009,12 @@ func (p *FindHostsForMigrationParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *FindHostsForMigrationParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *FindHostsForMigrationParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1776,6 +2028,12 @@ func (p *FindHostsForMigrationParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *FindHostsForMigrationParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *FindHostsForMigrationParams) GetVirtualmachineid() (string, bool) {
@@ -1912,6 +2170,12 @@ func (p *ListDedicatedHostsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListDedicatedHostsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListDedicatedHostsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1925,6 +2189,12 @@ func (p *ListDedicatedHostsParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
+}
+
+func (p *ListDedicatedHostsParams) ResetAffinitygroupid() {
+	if p.p != nil && p.p["affinitygroupid"] != nil {
+		delete(p.p, "affinitygroupid")
+	}
 }
 
 func (p *ListDedicatedHostsParams) GetAffinitygroupid() (string, bool) {
@@ -1942,6 +2212,12 @@ func (p *ListDedicatedHostsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListDedicatedHostsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListDedicatedHostsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1955,6 +2231,12 @@ func (p *ListDedicatedHostsParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *ListDedicatedHostsParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *ListDedicatedHostsParams) GetHostid() (string, bool) {
@@ -1972,6 +2254,12 @@ func (p *ListDedicatedHostsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListDedicatedHostsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListDedicatedHostsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1987,6 +2275,12 @@ func (p *ListDedicatedHostsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDedicatedHostsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDedicatedHostsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2000,6 +2294,12 @@ func (p *ListDedicatedHostsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListDedicatedHostsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListDedicatedHostsParams) GetPagesize() (int, bool) {
@@ -2079,6 +2379,12 @@ func (p *ListHostTagsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListHostTagsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListHostTagsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2094,6 +2400,12 @@ func (p *ListHostTagsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListHostTagsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListHostTagsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2107,6 +2419,12 @@ func (p *ListHostTagsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListHostTagsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListHostTagsParams) GetPagesize() (int, bool) {
@@ -2264,6 +2582,12 @@ func (p *ListHostsParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *ListHostsParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *ListHostsParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2277,6 +2601,12 @@ func (p *ListHostsParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ListHostsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ListHostsParams) GetDetails() ([]string, bool) {
@@ -2294,6 +2624,12 @@ func (p *ListHostsParams) SetHahost(v bool) {
 	p.p["hahost"] = v
 }
 
+func (p *ListHostsParams) ResetHahost() {
+	if p.p != nil && p.p["hahost"] != nil {
+		delete(p.p, "hahost")
+	}
+}
+
 func (p *ListHostsParams) GetHahost() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2307,6 +2643,12 @@ func (p *ListHostsParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *ListHostsParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *ListHostsParams) GetHypervisor() (string, bool) {
@@ -2324,6 +2666,12 @@ func (p *ListHostsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListHostsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListHostsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2337,6 +2685,12 @@ func (p *ListHostsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListHostsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListHostsParams) GetKeyword() (string, bool) {
@@ -2354,6 +2708,12 @@ func (p *ListHostsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListHostsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListHostsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2367,6 +2727,12 @@ func (p *ListHostsParams) SetOutofbandmanagementenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["outofbandmanagementenabled"] = v
+}
+
+func (p *ListHostsParams) ResetOutofbandmanagementenabled() {
+	if p.p != nil && p.p["outofbandmanagementenabled"] != nil {
+		delete(p.p, "outofbandmanagementenabled")
+	}
 }
 
 func (p *ListHostsParams) GetOutofbandmanagementenabled() (bool, bool) {
@@ -2384,6 +2750,12 @@ func (p *ListHostsParams) SetOutofbandmanagementpowerstate(v string) {
 	p.p["outofbandmanagementpowerstate"] = v
 }
 
+func (p *ListHostsParams) ResetOutofbandmanagementpowerstate() {
+	if p.p != nil && p.p["outofbandmanagementpowerstate"] != nil {
+		delete(p.p, "outofbandmanagementpowerstate")
+	}
+}
+
 func (p *ListHostsParams) GetOutofbandmanagementpowerstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2397,6 +2769,12 @@ func (p *ListHostsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListHostsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListHostsParams) GetPage() (int, bool) {
@@ -2414,6 +2792,12 @@ func (p *ListHostsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListHostsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListHostsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2427,6 +2811,12 @@ func (p *ListHostsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListHostsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListHostsParams) GetPodid() (string, bool) {
@@ -2444,6 +2834,12 @@ func (p *ListHostsParams) SetResourcestate(v string) {
 	p.p["resourcestate"] = v
 }
 
+func (p *ListHostsParams) ResetResourcestate() {
+	if p.p != nil && p.p["resourcestate"] != nil {
+		delete(p.p, "resourcestate")
+	}
+}
+
 func (p *ListHostsParams) GetResourcestate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2457,6 +2853,12 @@ func (p *ListHostsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListHostsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListHostsParams) GetState() (string, bool) {
@@ -2474,6 +2876,12 @@ func (p *ListHostsParams) SetType(v string) {
 	p.p["type"] = v
 }
 
+func (p *ListHostsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
+}
+
 func (p *ListHostsParams) GetType() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2489,6 +2897,12 @@ func (p *ListHostsParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *ListHostsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *ListHostsParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2502,6 +2916,12 @@ func (p *ListHostsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListHostsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListHostsParams) GetZoneid() (string, bool) {
@@ -2780,6 +3200,12 @@ func (p *ListHostsMetricsParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2793,6 +3219,12 @@ func (p *ListHostsMetricsParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetDetails() ([]string, bool) {
@@ -2810,6 +3242,12 @@ func (p *ListHostsMetricsParams) SetHahost(v bool) {
 	p.p["hahost"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetHahost() {
+	if p.p != nil && p.p["hahost"] != nil {
+		delete(p.p, "hahost")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetHahost() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2823,6 +3261,12 @@ func (p *ListHostsMetricsParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetHypervisor() (string, bool) {
@@ -2840,6 +3284,12 @@ func (p *ListHostsMetricsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2853,6 +3303,12 @@ func (p *ListHostsMetricsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetKeyword() (string, bool) {
@@ -2870,6 +3326,12 @@ func (p *ListHostsMetricsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2883,6 +3345,12 @@ func (p *ListHostsMetricsParams) SetOutofbandmanagementenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["outofbandmanagementenabled"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetOutofbandmanagementenabled() {
+	if p.p != nil && p.p["outofbandmanagementenabled"] != nil {
+		delete(p.p, "outofbandmanagementenabled")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetOutofbandmanagementenabled() (bool, bool) {
@@ -2900,6 +3368,12 @@ func (p *ListHostsMetricsParams) SetOutofbandmanagementpowerstate(v string) {
 	p.p["outofbandmanagementpowerstate"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetOutofbandmanagementpowerstate() {
+	if p.p != nil && p.p["outofbandmanagementpowerstate"] != nil {
+		delete(p.p, "outofbandmanagementpowerstate")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetOutofbandmanagementpowerstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2913,6 +3387,12 @@ func (p *ListHostsMetricsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetPage() (int, bool) {
@@ -2930,6 +3410,12 @@ func (p *ListHostsMetricsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2943,6 +3429,12 @@ func (p *ListHostsMetricsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetPodid() (string, bool) {
@@ -2960,6 +3452,12 @@ func (p *ListHostsMetricsParams) SetResourcestate(v string) {
 	p.p["resourcestate"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetResourcestate() {
+	if p.p != nil && p.p["resourcestate"] != nil {
+		delete(p.p, "resourcestate")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetResourcestate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2973,6 +3471,12 @@ func (p *ListHostsMetricsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetState() (string, bool) {
@@ -2990,6 +3494,12 @@ func (p *ListHostsMetricsParams) SetType(v string) {
 	p.p["type"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetType() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3005,6 +3515,12 @@ func (p *ListHostsMetricsParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *ListHostsMetricsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *ListHostsMetricsParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3018,6 +3534,12 @@ func (p *ListHostsMetricsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListHostsMetricsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListHostsMetricsParams) GetZoneid() (string, bool) {
@@ -3262,6 +3784,12 @@ func (p *PrepareHostForMaintenanceParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *PrepareHostForMaintenanceParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *PrepareHostForMaintenanceParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3416,6 +3944,12 @@ func (p *ReconnectHostParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ReconnectHostParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ReconnectHostParams) GetId() (string, bool) {
@@ -3574,6 +4108,12 @@ func (p *ReleaseDedicatedHostParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ReleaseDedicatedHostParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ReleaseDedicatedHostParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3648,6 +4188,12 @@ func (p *ReleaseHostReservationParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ReleaseHostReservationParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ReleaseHostReservationParams) GetId() (string, bool) {
@@ -3749,6 +4295,12 @@ func (p *UpdateHostParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *UpdateHostParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *UpdateHostParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3762,6 +4314,12 @@ func (p *UpdateHostParams) SetAnnotation(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["annotation"] = v
+}
+
+func (p *UpdateHostParams) ResetAnnotation() {
+	if p.p != nil && p.p["annotation"] != nil {
+		delete(p.p, "annotation")
+	}
 }
 
 func (p *UpdateHostParams) GetAnnotation() (string, bool) {
@@ -3779,6 +4337,12 @@ func (p *UpdateHostParams) SetHosttags(v []string) {
 	p.p["hosttags"] = v
 }
 
+func (p *UpdateHostParams) ResetHosttags() {
+	if p.p != nil && p.p["hosttags"] != nil {
+		delete(p.p, "hosttags")
+	}
+}
+
 func (p *UpdateHostParams) GetHosttags() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3792,6 +4356,12 @@ func (p *UpdateHostParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateHostParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateHostParams) GetId() (string, bool) {
@@ -3809,6 +4379,12 @@ func (p *UpdateHostParams) SetIstagarule(v bool) {
 	p.p["istagarule"] = v
 }
 
+func (p *UpdateHostParams) ResetIstagarule() {
+	if p.p != nil && p.p["istagarule"] != nil {
+		delete(p.p, "istagarule")
+	}
+}
+
 func (p *UpdateHostParams) GetIstagarule() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3822,6 +4398,12 @@ func (p *UpdateHostParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateHostParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateHostParams) GetName() (string, bool) {
@@ -3839,6 +4421,12 @@ func (p *UpdateHostParams) SetOscategoryid(v string) {
 	p.p["oscategoryid"] = v
 }
 
+func (p *UpdateHostParams) ResetOscategoryid() {
+	if p.p != nil && p.p["oscategoryid"] != nil {
+		delete(p.p, "oscategoryid")
+	}
+}
+
 func (p *UpdateHostParams) GetOscategoryid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3852,6 +4440,12 @@ func (p *UpdateHostParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *UpdateHostParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *UpdateHostParams) GetUrl() (string, bool) {
@@ -4003,6 +4597,12 @@ func (p *UpdateHostPasswordParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *UpdateHostPasswordParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *UpdateHostPasswordParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4016,6 +4616,12 @@ func (p *UpdateHostPasswordParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *UpdateHostPasswordParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *UpdateHostPasswordParams) GetHostid() (string, bool) {
@@ -4033,6 +4639,12 @@ func (p *UpdateHostPasswordParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *UpdateHostPasswordParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *UpdateHostPasswordParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4048,6 +4660,12 @@ func (p *UpdateHostPasswordParams) SetUpdate_passwd_on_host(v bool) {
 	p.p["update_passwd_on_host"] = v
 }
 
+func (p *UpdateHostPasswordParams) ResetUpdate_passwd_on_host() {
+	if p.p != nil && p.p["update_passwd_on_host"] != nil {
+		delete(p.p, "update_passwd_on_host")
+	}
+}
+
 func (p *UpdateHostPasswordParams) GetUpdate_passwd_on_host() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4061,6 +4679,12 @@ func (p *UpdateHostPasswordParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *UpdateHostPasswordParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *UpdateHostPasswordParams) GetUsername() (string, bool) {

--- a/cloudstack/HypervisorService.go
+++ b/cloudstack/HypervisorService.go
@@ -73,6 +73,12 @@ func (p *ListHypervisorCapabilitiesParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *ListHypervisorCapabilitiesParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *ListHypervisorCapabilitiesParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -86,6 +92,12 @@ func (p *ListHypervisorCapabilitiesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListHypervisorCapabilitiesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListHypervisorCapabilitiesParams) GetId() (string, bool) {
@@ -103,6 +115,12 @@ func (p *ListHypervisorCapabilitiesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListHypervisorCapabilitiesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListHypervisorCapabilitiesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -118,6 +136,12 @@ func (p *ListHypervisorCapabilitiesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListHypervisorCapabilitiesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListHypervisorCapabilitiesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -131,6 +155,12 @@ func (p *ListHypervisorCapabilitiesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListHypervisorCapabilitiesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListHypervisorCapabilitiesParams) GetPagesize() (int, bool) {
@@ -238,6 +268,12 @@ func (p *ListHypervisorsParams) SetZoneid(v string) {
 	p.p["zoneid"] = v
 }
 
+func (p *ListHypervisorsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
+}
+
 func (p *ListHypervisorsParams) GetZoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -326,6 +362,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateHypervisorCapabilitiesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateHypervisorCapabilitiesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -339,6 +381,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetMaxdatavolumeslimit(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxdatavolumeslimit"] = v
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) ResetMaxdatavolumeslimit() {
+	if p.p != nil && p.p["maxdatavolumeslimit"] != nil {
+		delete(p.p, "maxdatavolumeslimit")
+	}
 }
 
 func (p *UpdateHypervisorCapabilitiesParams) GetMaxdatavolumeslimit() (int, bool) {
@@ -356,6 +404,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetMaxguestslimit(v int64) {
 	p.p["maxguestslimit"] = v
 }
 
+func (p *UpdateHypervisorCapabilitiesParams) ResetMaxguestslimit() {
+	if p.p != nil && p.p["maxguestslimit"] != nil {
+		delete(p.p, "maxguestslimit")
+	}
+}
+
 func (p *UpdateHypervisorCapabilitiesParams) GetMaxguestslimit() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -369,6 +423,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetMaxhostspercluster(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxhostspercluster"] = v
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) ResetMaxhostspercluster() {
+	if p.p != nil && p.p["maxhostspercluster"] != nil {
+		delete(p.p, "maxhostspercluster")
+	}
 }
 
 func (p *UpdateHypervisorCapabilitiesParams) GetMaxhostspercluster() (int, bool) {
@@ -386,6 +446,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetSecuritygroupenabled(v bool) {
 	p.p["securitygroupenabled"] = v
 }
 
+func (p *UpdateHypervisorCapabilitiesParams) ResetSecuritygroupenabled() {
+	if p.p != nil && p.p["securitygroupenabled"] != nil {
+		delete(p.p, "securitygroupenabled")
+	}
+}
+
 func (p *UpdateHypervisorCapabilitiesParams) GetSecuritygroupenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -401,6 +467,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetStoragemotionenabled(v bool) {
 	p.p["storagemotionenabled"] = v
 }
 
+func (p *UpdateHypervisorCapabilitiesParams) ResetStoragemotionenabled() {
+	if p.p != nil && p.p["storagemotionenabled"] != nil {
+		delete(p.p, "storagemotionenabled")
+	}
+}
+
 func (p *UpdateHypervisorCapabilitiesParams) GetStoragemotionenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -414,6 +486,12 @@ func (p *UpdateHypervisorCapabilitiesParams) SetVmsnapshotenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotenabled"] = v
+}
+
+func (p *UpdateHypervisorCapabilitiesParams) ResetVmsnapshotenabled() {
+	if p.p != nil && p.p["vmsnapshotenabled"] != nil {
+		delete(p.p, "vmsnapshotenabled")
+	}
 }
 
 func (p *UpdateHypervisorCapabilitiesParams) GetVmsnapshotenabled() (bool, bool) {

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -83,6 +83,12 @@ func (p *AttachIsoParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *AttachIsoParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *AttachIsoParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -98,6 +104,12 @@ func (p *AttachIsoParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *AttachIsoParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *AttachIsoParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -111,6 +123,12 @@ func (p *AttachIsoParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *AttachIsoParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *AttachIsoParams) GetVirtualmachineid() (string, bool) {
@@ -358,6 +376,12 @@ func (p *CopyIsoParams) SetDestzoneid(v string) {
 	p.p["destzoneid"] = v
 }
 
+func (p *CopyIsoParams) ResetDestzoneid() {
+	if p.p != nil && p.p["destzoneid"] != nil {
+		delete(p.p, "destzoneid")
+	}
+}
+
 func (p *CopyIsoParams) GetDestzoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -371,6 +395,12 @@ func (p *CopyIsoParams) SetDestzoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destzoneids"] = v
+}
+
+func (p *CopyIsoParams) ResetDestzoneids() {
+	if p.p != nil && p.p["destzoneids"] != nil {
+		delete(p.p, "destzoneids")
+	}
 }
 
 func (p *CopyIsoParams) GetDestzoneids() ([]string, bool) {
@@ -388,6 +418,12 @@ func (p *CopyIsoParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *CopyIsoParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *CopyIsoParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -401,6 +437,12 @@ func (p *CopyIsoParams) SetSourcezoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcezoneid"] = v
+}
+
+func (p *CopyIsoParams) ResetSourcezoneid() {
+	if p.p != nil && p.p["sourcezoneid"] != nil {
+		delete(p.p, "sourcezoneid")
+	}
 }
 
 func (p *CopyIsoParams) GetSourcezoneid() (string, bool) {
@@ -564,6 +606,12 @@ func (p *DeleteIsoParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteIsoParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteIsoParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -577,6 +625,12 @@ func (p *DeleteIsoParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *DeleteIsoParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *DeleteIsoParams) GetZoneid() (string, bool) {
@@ -659,6 +713,12 @@ func (p *DetachIsoParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *DetachIsoParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *DetachIsoParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -672,6 +732,12 @@ func (p *DetachIsoParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *DetachIsoParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *DetachIsoParams) GetVirtualmachineid() (string, bool) {
@@ -917,6 +983,12 @@ func (p *ExtractIsoParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ExtractIsoParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ExtractIsoParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -930,6 +1002,12 @@ func (p *ExtractIsoParams) SetMode(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mode"] = v
+}
+
+func (p *ExtractIsoParams) ResetMode() {
+	if p.p != nil && p.p["mode"] != nil {
+		delete(p.p, "mode")
+	}
 }
 
 func (p *ExtractIsoParams) GetMode() (string, bool) {
@@ -947,6 +1025,12 @@ func (p *ExtractIsoParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *ExtractIsoParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *ExtractIsoParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -960,6 +1044,12 @@ func (p *ExtractIsoParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ExtractIsoParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ExtractIsoParams) GetZoneid() (string, bool) {
@@ -1054,6 +1144,12 @@ func (p *ListIsoPermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListIsoPermissionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListIsoPermissionsParams) GetId() (string, bool) {
@@ -1235,6 +1331,12 @@ func (p *ListIsosParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListIsosParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListIsosParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1248,6 +1350,12 @@ func (p *ListIsosParams) SetBootable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootable"] = v
+}
+
+func (p *ListIsosParams) ResetBootable() {
+	if p.p != nil && p.p["bootable"] != nil {
+		delete(p.p, "bootable")
+	}
 }
 
 func (p *ListIsosParams) GetBootable() (bool, bool) {
@@ -1265,6 +1373,12 @@ func (p *ListIsosParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListIsosParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListIsosParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1278,6 +1392,12 @@ func (p *ListIsosParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *ListIsosParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *ListIsosParams) GetHypervisor() (string, bool) {
@@ -1295,6 +1415,12 @@ func (p *ListIsosParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListIsosParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListIsosParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1308,6 +1434,12 @@ func (p *ListIsosParams) SetImagestoreid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreid"] = v
+}
+
+func (p *ListIsosParams) ResetImagestoreid() {
+	if p.p != nil && p.p["imagestoreid"] != nil {
+		delete(p.p, "imagestoreid")
+	}
 }
 
 func (p *ListIsosParams) GetImagestoreid() (string, bool) {
@@ -1325,6 +1457,12 @@ func (p *ListIsosParams) SetIsofilter(v string) {
 	p.p["isofilter"] = v
 }
 
+func (p *ListIsosParams) ResetIsofilter() {
+	if p.p != nil && p.p["isofilter"] != nil {
+		delete(p.p, "isofilter")
+	}
+}
+
 func (p *ListIsosParams) GetIsofilter() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1338,6 +1476,12 @@ func (p *ListIsosParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
+}
+
+func (p *ListIsosParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
 }
 
 func (p *ListIsosParams) GetIspublic() (bool, bool) {
@@ -1355,6 +1499,12 @@ func (p *ListIsosParams) SetIsready(v bool) {
 	p.p["isready"] = v
 }
 
+func (p *ListIsosParams) ResetIsready() {
+	if p.p != nil && p.p["isready"] != nil {
+		delete(p.p, "isready")
+	}
+}
+
 func (p *ListIsosParams) GetIsready() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1368,6 +1518,12 @@ func (p *ListIsosParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListIsosParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListIsosParams) GetIsrecursive() (bool, bool) {
@@ -1385,6 +1541,12 @@ func (p *ListIsosParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListIsosParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListIsosParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1398,6 +1560,12 @@ func (p *ListIsosParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListIsosParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListIsosParams) GetListall() (bool, bool) {
@@ -1415,6 +1583,12 @@ func (p *ListIsosParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListIsosParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListIsosParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1428,6 +1602,12 @@ func (p *ListIsosParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListIsosParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListIsosParams) GetPage() (int, bool) {
@@ -1445,6 +1625,12 @@ func (p *ListIsosParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListIsosParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListIsosParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1458,6 +1644,12 @@ func (p *ListIsosParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListIsosParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListIsosParams) GetProjectid() (string, bool) {
@@ -1475,6 +1667,12 @@ func (p *ListIsosParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListIsosParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListIsosParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1488,6 +1686,12 @@ func (p *ListIsosParams) SetShowremoved(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showremoved"] = v
+}
+
+func (p *ListIsosParams) ResetShowremoved() {
+	if p.p != nil && p.p["showremoved"] != nil {
+		delete(p.p, "showremoved")
+	}
 }
 
 func (p *ListIsosParams) GetShowremoved() (bool, bool) {
@@ -1505,6 +1709,12 @@ func (p *ListIsosParams) SetShowunique(v bool) {
 	p.p["showunique"] = v
 }
 
+func (p *ListIsosParams) ResetShowunique() {
+	if p.p != nil && p.p["showunique"] != nil {
+		delete(p.p, "showunique")
+	}
+}
+
 func (p *ListIsosParams) GetShowunique() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1518,6 +1728,12 @@ func (p *ListIsosParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListIsosParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListIsosParams) GetStorageid() (string, bool) {
@@ -1535,6 +1751,12 @@ func (p *ListIsosParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListIsosParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListIsosParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1548,6 +1770,12 @@ func (p *ListIsosParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListIsosParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListIsosParams) GetZoneid() (string, bool) {
@@ -1832,6 +2060,12 @@ func (p *RegisterIsoParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *RegisterIsoParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *RegisterIsoParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1845,6 +2079,12 @@ func (p *RegisterIsoParams) SetBootable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootable"] = v
+}
+
+func (p *RegisterIsoParams) ResetBootable() {
+	if p.p != nil && p.p["bootable"] != nil {
+		delete(p.p, "bootable")
+	}
 }
 
 func (p *RegisterIsoParams) GetBootable() (bool, bool) {
@@ -1862,6 +2102,12 @@ func (p *RegisterIsoParams) SetChecksum(v string) {
 	p.p["checksum"] = v
 }
 
+func (p *RegisterIsoParams) ResetChecksum() {
+	if p.p != nil && p.p["checksum"] != nil {
+		delete(p.p, "checksum")
+	}
+}
+
 func (p *RegisterIsoParams) GetChecksum() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1875,6 +2121,12 @@ func (p *RegisterIsoParams) SetDirectdownload(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["directdownload"] = v
+}
+
+func (p *RegisterIsoParams) ResetDirectdownload() {
+	if p.p != nil && p.p["directdownload"] != nil {
+		delete(p.p, "directdownload")
+	}
 }
 
 func (p *RegisterIsoParams) GetDirectdownload() (bool, bool) {
@@ -1892,6 +2144,12 @@ func (p *RegisterIsoParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *RegisterIsoParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *RegisterIsoParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1905,6 +2163,12 @@ func (p *RegisterIsoParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *RegisterIsoParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *RegisterIsoParams) GetDomainid() (string, bool) {
@@ -1922,6 +2186,12 @@ func (p *RegisterIsoParams) SetImagestoreuuid(v string) {
 	p.p["imagestoreuuid"] = v
 }
 
+func (p *RegisterIsoParams) ResetImagestoreuuid() {
+	if p.p != nil && p.p["imagestoreuuid"] != nil {
+		delete(p.p, "imagestoreuuid")
+	}
+}
+
 func (p *RegisterIsoParams) GetImagestoreuuid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1935,6 +2205,12 @@ func (p *RegisterIsoParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
+}
+
+func (p *RegisterIsoParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
 }
 
 func (p *RegisterIsoParams) GetIsdynamicallyscalable() (bool, bool) {
@@ -1952,6 +2228,12 @@ func (p *RegisterIsoParams) SetIsextractable(v bool) {
 	p.p["isextractable"] = v
 }
 
+func (p *RegisterIsoParams) ResetIsextractable() {
+	if p.p != nil && p.p["isextractable"] != nil {
+		delete(p.p, "isextractable")
+	}
+}
+
 func (p *RegisterIsoParams) GetIsextractable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1965,6 +2247,12 @@ func (p *RegisterIsoParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
+}
+
+func (p *RegisterIsoParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
 }
 
 func (p *RegisterIsoParams) GetIsfeatured() (bool, bool) {
@@ -1982,6 +2270,12 @@ func (p *RegisterIsoParams) SetIspublic(v bool) {
 	p.p["ispublic"] = v
 }
 
+func (p *RegisterIsoParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
+}
+
 func (p *RegisterIsoParams) GetIspublic() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1995,6 +2289,12 @@ func (p *RegisterIsoParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *RegisterIsoParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *RegisterIsoParams) GetName() (string, bool) {
@@ -2012,6 +2312,12 @@ func (p *RegisterIsoParams) SetOstypeid(v string) {
 	p.p["ostypeid"] = v
 }
 
+func (p *RegisterIsoParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
+}
+
 func (p *RegisterIsoParams) GetOstypeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2025,6 +2331,12 @@ func (p *RegisterIsoParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
+}
+
+func (p *RegisterIsoParams) ResetPasswordenabled() {
+	if p.p != nil && p.p["passwordenabled"] != nil {
+		delete(p.p, "passwordenabled")
+	}
 }
 
 func (p *RegisterIsoParams) GetPasswordenabled() (bool, bool) {
@@ -2042,6 +2354,12 @@ func (p *RegisterIsoParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *RegisterIsoParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *RegisterIsoParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2057,6 +2375,12 @@ func (p *RegisterIsoParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *RegisterIsoParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *RegisterIsoParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2070,6 +2394,12 @@ func (p *RegisterIsoParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *RegisterIsoParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *RegisterIsoParams) GetZoneid() (string, bool) {
@@ -2267,6 +2597,12 @@ func (p *UpdateIsoParams) SetBootable(v bool) {
 	p.p["bootable"] = v
 }
 
+func (p *UpdateIsoParams) ResetBootable() {
+	if p.p != nil && p.p["bootable"] != nil {
+		delete(p.p, "bootable")
+	}
+}
+
 func (p *UpdateIsoParams) GetBootable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2280,6 +2616,12 @@ func (p *UpdateIsoParams) SetCleanupdetails(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanupdetails"] = v
+}
+
+func (p *UpdateIsoParams) ResetCleanupdetails() {
+	if p.p != nil && p.p["cleanupdetails"] != nil {
+		delete(p.p, "cleanupdetails")
+	}
 }
 
 func (p *UpdateIsoParams) GetCleanupdetails() (bool, bool) {
@@ -2297,6 +2639,12 @@ func (p *UpdateIsoParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *UpdateIsoParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *UpdateIsoParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2310,6 +2658,12 @@ func (p *UpdateIsoParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *UpdateIsoParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *UpdateIsoParams) GetDisplaytext() (string, bool) {
@@ -2327,6 +2681,12 @@ func (p *UpdateIsoParams) SetFormat(v string) {
 	p.p["format"] = v
 }
 
+func (p *UpdateIsoParams) ResetFormat() {
+	if p.p != nil && p.p["format"] != nil {
+		delete(p.p, "format")
+	}
+}
+
 func (p *UpdateIsoParams) GetFormat() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2340,6 +2700,12 @@ func (p *UpdateIsoParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateIsoParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateIsoParams) GetId() (string, bool) {
@@ -2357,6 +2723,12 @@ func (p *UpdateIsoParams) SetIsdynamicallyscalable(v bool) {
 	p.p["isdynamicallyscalable"] = v
 }
 
+func (p *UpdateIsoParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
+}
+
 func (p *UpdateIsoParams) GetIsdynamicallyscalable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2370,6 +2742,12 @@ func (p *UpdateIsoParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
+}
+
+func (p *UpdateIsoParams) ResetIsrouting() {
+	if p.p != nil && p.p["isrouting"] != nil {
+		delete(p.p, "isrouting")
+	}
 }
 
 func (p *UpdateIsoParams) GetIsrouting() (bool, bool) {
@@ -2387,6 +2765,12 @@ func (p *UpdateIsoParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateIsoParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateIsoParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2400,6 +2784,12 @@ func (p *UpdateIsoParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
+}
+
+func (p *UpdateIsoParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
 }
 
 func (p *UpdateIsoParams) GetOstypeid() (string, bool) {
@@ -2417,6 +2807,12 @@ func (p *UpdateIsoParams) SetPasswordenabled(v bool) {
 	p.p["passwordenabled"] = v
 }
 
+func (p *UpdateIsoParams) ResetPasswordenabled() {
+	if p.p != nil && p.p["passwordenabled"] != nil {
+		delete(p.p, "passwordenabled")
+	}
+}
+
 func (p *UpdateIsoParams) GetPasswordenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2430,6 +2826,12 @@ func (p *UpdateIsoParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
+}
+
+func (p *UpdateIsoParams) ResetRequireshvm() {
+	if p.p != nil && p.p["requireshvm"] != nil {
+		delete(p.p, "requireshvm")
+	}
 }
 
 func (p *UpdateIsoParams) GetRequireshvm() (bool, bool) {
@@ -2447,6 +2849,12 @@ func (p *UpdateIsoParams) SetSortkey(v int) {
 	p.p["sortkey"] = v
 }
 
+func (p *UpdateIsoParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
+}
+
 func (p *UpdateIsoParams) GetSortkey() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2460,6 +2868,12 @@ func (p *UpdateIsoParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
+}
+
+func (p *UpdateIsoParams) ResetSshkeyenabled() {
+	if p.p != nil && p.p["sshkeyenabled"] != nil {
+		delete(p.p, "sshkeyenabled")
+	}
 }
 
 func (p *UpdateIsoParams) GetSshkeyenabled() (bool, bool) {
@@ -2623,6 +3037,12 @@ func (p *UpdateIsoPermissionsParams) SetAccounts(v []string) {
 	p.p["accounts"] = v
 }
 
+func (p *UpdateIsoPermissionsParams) ResetAccounts() {
+	if p.p != nil && p.p["accounts"] != nil {
+		delete(p.p, "accounts")
+	}
+}
+
 func (p *UpdateIsoPermissionsParams) GetAccounts() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2636,6 +3056,12 @@ func (p *UpdateIsoPermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateIsoPermissionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateIsoPermissionsParams) GetId() (string, bool) {
@@ -2653,6 +3079,12 @@ func (p *UpdateIsoPermissionsParams) SetIsextractable(v bool) {
 	p.p["isextractable"] = v
 }
 
+func (p *UpdateIsoPermissionsParams) ResetIsextractable() {
+	if p.p != nil && p.p["isextractable"] != nil {
+		delete(p.p, "isextractable")
+	}
+}
+
 func (p *UpdateIsoPermissionsParams) GetIsextractable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2666,6 +3098,12 @@ func (p *UpdateIsoPermissionsParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
+}
+
+func (p *UpdateIsoPermissionsParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
 }
 
 func (p *UpdateIsoPermissionsParams) GetIsfeatured() (bool, bool) {
@@ -2683,6 +3121,12 @@ func (p *UpdateIsoPermissionsParams) SetIspublic(v bool) {
 	p.p["ispublic"] = v
 }
 
+func (p *UpdateIsoPermissionsParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
+}
+
 func (p *UpdateIsoPermissionsParams) GetIspublic() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2698,6 +3142,12 @@ func (p *UpdateIsoPermissionsParams) SetOp(v string) {
 	p.p["op"] = v
 }
 
+func (p *UpdateIsoPermissionsParams) ResetOp() {
+	if p.p != nil && p.p["op"] != nil {
+		delete(p.p, "op")
+	}
+}
+
 func (p *UpdateIsoPermissionsParams) GetOp() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2711,6 +3161,12 @@ func (p *UpdateIsoPermissionsParams) SetProjectids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectids"] = v
+}
+
+func (p *UpdateIsoPermissionsParams) ResetProjectids() {
+	if p.p != nil && p.p["projectids"] != nil {
+		delete(p.p, "projectids")
+	}
 }
 
 func (p *UpdateIsoPermissionsParams) GetProjectids() ([]string, bool) {

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -90,6 +90,12 @@ func (p *AddImageStoreParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *AddImageStoreParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *AddImageStoreParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -103,6 +109,12 @@ func (p *AddImageStoreParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *AddImageStoreParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *AddImageStoreParams) GetName() (string, bool) {
@@ -120,6 +132,12 @@ func (p *AddImageStoreParams) SetProvider(v string) {
 	p.p["provider"] = v
 }
 
+func (p *AddImageStoreParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
+}
+
 func (p *AddImageStoreParams) GetProvider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -135,6 +153,12 @@ func (p *AddImageStoreParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddImageStoreParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddImageStoreParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -148,6 +172,12 @@ func (p *AddImageStoreParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddImageStoreParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddImageStoreParams) GetZoneid() (string, bool) {
@@ -261,6 +291,12 @@ func (p *AddImageStoreS3Params) SetAccesskey(v string) {
 	p.p["accesskey"] = v
 }
 
+func (p *AddImageStoreS3Params) ResetAccesskey() {
+	if p.p != nil && p.p["accesskey"] != nil {
+		delete(p.p, "accesskey")
+	}
+}
+
 func (p *AddImageStoreS3Params) GetAccesskey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -274,6 +310,12 @@ func (p *AddImageStoreS3Params) SetBucket(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bucket"] = v
+}
+
+func (p *AddImageStoreS3Params) ResetBucket() {
+	if p.p != nil && p.p["bucket"] != nil {
+		delete(p.p, "bucket")
+	}
 }
 
 func (p *AddImageStoreS3Params) GetBucket() (string, bool) {
@@ -291,6 +333,12 @@ func (p *AddImageStoreS3Params) SetConnectiontimeout(v int) {
 	p.p["connectiontimeout"] = v
 }
 
+func (p *AddImageStoreS3Params) ResetConnectiontimeout() {
+	if p.p != nil && p.p["connectiontimeout"] != nil {
+		delete(p.p, "connectiontimeout")
+	}
+}
+
 func (p *AddImageStoreS3Params) GetConnectiontimeout() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -304,6 +352,12 @@ func (p *AddImageStoreS3Params) SetConnectionttl(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["connectionttl"] = v
+}
+
+func (p *AddImageStoreS3Params) ResetConnectionttl() {
+	if p.p != nil && p.p["connectionttl"] != nil {
+		delete(p.p, "connectionttl")
+	}
 }
 
 func (p *AddImageStoreS3Params) GetConnectionttl() (int, bool) {
@@ -321,6 +375,12 @@ func (p *AddImageStoreS3Params) SetEndpoint(v string) {
 	p.p["endpoint"] = v
 }
 
+func (p *AddImageStoreS3Params) ResetEndpoint() {
+	if p.p != nil && p.p["endpoint"] != nil {
+		delete(p.p, "endpoint")
+	}
+}
+
 func (p *AddImageStoreS3Params) GetEndpoint() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -334,6 +394,12 @@ func (p *AddImageStoreS3Params) SetMaxerrorretry(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxerrorretry"] = v
+}
+
+func (p *AddImageStoreS3Params) ResetMaxerrorretry() {
+	if p.p != nil && p.p["maxerrorretry"] != nil {
+		delete(p.p, "maxerrorretry")
+	}
 }
 
 func (p *AddImageStoreS3Params) GetMaxerrorretry() (int, bool) {
@@ -351,6 +417,12 @@ func (p *AddImageStoreS3Params) SetS3signer(v string) {
 	p.p["s3signer"] = v
 }
 
+func (p *AddImageStoreS3Params) ResetS3signer() {
+	if p.p != nil && p.p["s3signer"] != nil {
+		delete(p.p, "s3signer")
+	}
+}
+
 func (p *AddImageStoreS3Params) GetS3signer() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -364,6 +436,12 @@ func (p *AddImageStoreS3Params) SetSecretkey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["secretkey"] = v
+}
+
+func (p *AddImageStoreS3Params) ResetSecretkey() {
+	if p.p != nil && p.p["secretkey"] != nil {
+		delete(p.p, "secretkey")
+	}
 }
 
 func (p *AddImageStoreS3Params) GetSecretkey() (string, bool) {
@@ -381,6 +459,12 @@ func (p *AddImageStoreS3Params) SetSockettimeout(v int) {
 	p.p["sockettimeout"] = v
 }
 
+func (p *AddImageStoreS3Params) ResetSockettimeout() {
+	if p.p != nil && p.p["sockettimeout"] != nil {
+		delete(p.p, "sockettimeout")
+	}
+}
+
 func (p *AddImageStoreS3Params) GetSockettimeout() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -396,6 +480,12 @@ func (p *AddImageStoreS3Params) SetUsehttps(v bool) {
 	p.p["usehttps"] = v
 }
 
+func (p *AddImageStoreS3Params) ResetUsehttps() {
+	if p.p != nil && p.p["usehttps"] != nil {
+		delete(p.p, "usehttps")
+	}
+}
+
 func (p *AddImageStoreS3Params) GetUsehttps() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -409,6 +499,12 @@ func (p *AddImageStoreS3Params) SetUsetcpkeepalive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usetcpkeepalive"] = v
+}
+
+func (p *AddImageStoreS3Params) ResetUsetcpkeepalive() {
+	if p.p != nil && p.p["usetcpkeepalive"] != nil {
+		delete(p.p, "usetcpkeepalive")
+	}
 }
 
 func (p *AddImageStoreS3Params) GetUsetcpkeepalive() (bool, bool) {
@@ -501,6 +597,12 @@ func (p *CreateSecondaryStagingStoreParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *CreateSecondaryStagingStoreParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *CreateSecondaryStagingStoreParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -514,6 +616,12 @@ func (p *CreateSecondaryStagingStoreParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
+}
+
+func (p *CreateSecondaryStagingStoreParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
 }
 
 func (p *CreateSecondaryStagingStoreParams) GetProvider() (string, bool) {
@@ -531,6 +639,12 @@ func (p *CreateSecondaryStagingStoreParams) SetScope(v string) {
 	p.p["scope"] = v
 }
 
+func (p *CreateSecondaryStagingStoreParams) ResetScope() {
+	if p.p != nil && p.p["scope"] != nil {
+		delete(p.p, "scope")
+	}
+}
+
 func (p *CreateSecondaryStagingStoreParams) GetScope() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -546,6 +660,12 @@ func (p *CreateSecondaryStagingStoreParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *CreateSecondaryStagingStoreParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *CreateSecondaryStagingStoreParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -559,6 +679,12 @@ func (p *CreateSecondaryStagingStoreParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateSecondaryStagingStoreParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateSecondaryStagingStoreParams) GetZoneid() (string, bool) {
@@ -630,6 +756,12 @@ func (p *DeleteImageStoreParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteImageStoreParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteImageStoreParams) GetId() (string, bool) {
@@ -718,6 +850,12 @@ func (p *DeleteSecondaryStagingStoreParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteSecondaryStagingStoreParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteSecondaryStagingStoreParams) GetId() (string, bool) {
@@ -835,6 +973,12 @@ func (p *ListImageStoresParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListImageStoresParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListImageStoresParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -848,6 +992,12 @@ func (p *ListImageStoresParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListImageStoresParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListImageStoresParams) GetKeyword() (string, bool) {
@@ -865,6 +1015,12 @@ func (p *ListImageStoresParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListImageStoresParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListImageStoresParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -878,6 +1034,12 @@ func (p *ListImageStoresParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListImageStoresParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListImageStoresParams) GetPage() (int, bool) {
@@ -895,6 +1057,12 @@ func (p *ListImageStoresParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListImageStoresParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListImageStoresParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -908,6 +1076,12 @@ func (p *ListImageStoresParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *ListImageStoresParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *ListImageStoresParams) GetProtocol() (string, bool) {
@@ -925,6 +1099,12 @@ func (p *ListImageStoresParams) SetProvider(v string) {
 	p.p["provider"] = v
 }
 
+func (p *ListImageStoresParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
+}
+
 func (p *ListImageStoresParams) GetProvider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -940,6 +1120,12 @@ func (p *ListImageStoresParams) SetReadonly(v bool) {
 	p.p["readonly"] = v
 }
 
+func (p *ListImageStoresParams) ResetReadonly() {
+	if p.p != nil && p.p["readonly"] != nil {
+		delete(p.p, "readonly")
+	}
+}
+
 func (p *ListImageStoresParams) GetReadonly() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -953,6 +1139,12 @@ func (p *ListImageStoresParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListImageStoresParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListImageStoresParams) GetZoneid() (string, bool) {
@@ -1136,6 +1328,12 @@ func (p *ListSecondaryStagingStoresParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListSecondaryStagingStoresParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListSecondaryStagingStoresParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1149,6 +1347,12 @@ func (p *ListSecondaryStagingStoresParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListSecondaryStagingStoresParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListSecondaryStagingStoresParams) GetKeyword() (string, bool) {
@@ -1166,6 +1370,12 @@ func (p *ListSecondaryStagingStoresParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListSecondaryStagingStoresParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListSecondaryStagingStoresParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1179,6 +1389,12 @@ func (p *ListSecondaryStagingStoresParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListSecondaryStagingStoresParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListSecondaryStagingStoresParams) GetPage() (int, bool) {
@@ -1196,6 +1412,12 @@ func (p *ListSecondaryStagingStoresParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListSecondaryStagingStoresParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListSecondaryStagingStoresParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1209,6 +1431,12 @@ func (p *ListSecondaryStagingStoresParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *ListSecondaryStagingStoresParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *ListSecondaryStagingStoresParams) GetProtocol() (string, bool) {
@@ -1226,6 +1454,12 @@ func (p *ListSecondaryStagingStoresParams) SetProvider(v string) {
 	p.p["provider"] = v
 }
 
+func (p *ListSecondaryStagingStoresParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
+}
+
 func (p *ListSecondaryStagingStoresParams) GetProvider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1239,6 +1473,12 @@ func (p *ListSecondaryStagingStoresParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListSecondaryStagingStoresParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListSecondaryStagingStoresParams) GetZoneid() (string, bool) {
@@ -1412,6 +1652,12 @@ func (p *UpdateCloudToUseObjectStoreParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *UpdateCloudToUseObjectStoreParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *UpdateCloudToUseObjectStoreParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1425,6 +1671,12 @@ func (p *UpdateCloudToUseObjectStoreParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateCloudToUseObjectStoreParams) GetName() (string, bool) {
@@ -1442,6 +1694,12 @@ func (p *UpdateCloudToUseObjectStoreParams) SetProvider(v string) {
 	p.p["provider"] = v
 }
 
+func (p *UpdateCloudToUseObjectStoreParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
+}
+
 func (p *UpdateCloudToUseObjectStoreParams) GetProvider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1455,6 +1713,12 @@ func (p *UpdateCloudToUseObjectStoreParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *UpdateCloudToUseObjectStoreParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *UpdateCloudToUseObjectStoreParams) GetUrl() (string, bool) {

--- a/cloudstack/InfrastructureUsageService.go
+++ b/cloudstack/InfrastructureUsageService.go
@@ -77,6 +77,12 @@ func (p *ListManagementServersMetricsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListManagementServersMetricsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListManagementServersMetricsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -90,6 +96,12 @@ func (p *ListManagementServersMetricsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListManagementServersMetricsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListManagementServersMetricsParams) GetKeyword() (string, bool) {
@@ -107,6 +119,12 @@ func (p *ListManagementServersMetricsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListManagementServersMetricsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListManagementServersMetricsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -120,6 +138,12 @@ func (p *ListManagementServersMetricsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListManagementServersMetricsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListManagementServersMetricsParams) GetPage() (int, bool) {
@@ -137,6 +161,12 @@ func (p *ListManagementServersMetricsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListManagementServersMetricsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListManagementServersMetricsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -150,6 +180,12 @@ func (p *ListManagementServersMetricsParams) SetSystem(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["system"] = v
+}
+
+func (p *ListManagementServersMetricsParams) ResetSystem() {
+	if p.p != nil && p.p["system"] != nil {
+		delete(p.p, "system")
+	}
 }
 
 func (p *ListManagementServersMetricsParams) GetSystem() (bool, bool) {

--- a/cloudstack/InternalLBService.go
+++ b/cloudstack/InternalLBService.go
@@ -72,6 +72,12 @@ func (p *ConfigureInternalLoadBalancerElementParams) SetEnabled(v bool) {
 	p.p["enabled"] = v
 }
 
+func (p *ConfigureInternalLoadBalancerElementParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
+}
+
 func (p *ConfigureInternalLoadBalancerElementParams) GetEnabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -85,6 +91,12 @@ func (p *ConfigureInternalLoadBalancerElementParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ConfigureInternalLoadBalancerElementParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ConfigureInternalLoadBalancerElementParams) GetId() (string, bool) {
@@ -168,6 +180,12 @@ func (p *CreateInternalLoadBalancerElementParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
+}
+
+func (p *CreateInternalLoadBalancerElementParams) ResetNspid() {
+	if p.p != nil && p.p["nspid"] != nil {
+		delete(p.p, "nspid")
+	}
 }
 
 func (p *CreateInternalLoadBalancerElementParams) GetNspid() (string, bool) {
@@ -270,6 +288,12 @@ func (p *ListInternalLoadBalancerElementsParams) SetEnabled(v bool) {
 	p.p["enabled"] = v
 }
 
+func (p *ListInternalLoadBalancerElementsParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
+}
+
 func (p *ListInternalLoadBalancerElementsParams) GetEnabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -283,6 +307,12 @@ func (p *ListInternalLoadBalancerElementsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListInternalLoadBalancerElementsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListInternalLoadBalancerElementsParams) GetId() (string, bool) {
@@ -300,6 +330,12 @@ func (p *ListInternalLoadBalancerElementsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListInternalLoadBalancerElementsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListInternalLoadBalancerElementsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -313,6 +349,12 @@ func (p *ListInternalLoadBalancerElementsParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
+}
+
+func (p *ListInternalLoadBalancerElementsParams) ResetNspid() {
+	if p.p != nil && p.p["nspid"] != nil {
+		delete(p.p, "nspid")
+	}
 }
 
 func (p *ListInternalLoadBalancerElementsParams) GetNspid() (string, bool) {
@@ -330,6 +372,12 @@ func (p *ListInternalLoadBalancerElementsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListInternalLoadBalancerElementsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListInternalLoadBalancerElementsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -343,6 +391,12 @@ func (p *ListInternalLoadBalancerElementsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListInternalLoadBalancerElementsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListInternalLoadBalancerElementsParams) GetPagesize() (int, bool) {
@@ -501,6 +555,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -514,6 +574,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetDomainid() (string, bool) {
@@ -531,6 +597,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetFetchhealthcheckresults(v bool) {
 	p.p["fetchhealthcheckresults"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetFetchhealthcheckresults() {
+	if p.p != nil && p.p["fetchhealthcheckresults"] != nil {
+		delete(p.p, "fetchhealthcheckresults")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetFetchhealthcheckresults() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -544,6 +616,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetForvpc() {
+	if p.p != nil && p.p["forvpc"] != nil {
+		delete(p.p, "forvpc")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetForvpc() (bool, bool) {
@@ -561,6 +639,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -574,6 +658,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetId() (string, bool) {
@@ -591,6 +681,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -604,6 +700,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetKeyword() (string, bool) {
@@ -621,6 +723,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -634,6 +742,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetName() (string, bool) {
@@ -651,6 +765,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -664,6 +784,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetPage() (int, bool) {
@@ -681,6 +807,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -694,6 +826,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetPodid() (string, bool) {
@@ -711,6 +849,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -724,6 +868,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetState() (string, bool) {
@@ -741,6 +891,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *ListInternalLoadBalancerVMsParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *ListInternalLoadBalancerVMsParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -754,6 +910,12 @@ func (p *ListInternalLoadBalancerVMsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListInternalLoadBalancerVMsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListInternalLoadBalancerVMsParams) GetZoneid() (string, bool) {
@@ -963,6 +1125,12 @@ func (p *StartInternalLoadBalancerVMParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *StartInternalLoadBalancerVMParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *StartInternalLoadBalancerVMParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1107,6 +1275,12 @@ func (p *StopInternalLoadBalancerVMParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *StopInternalLoadBalancerVMParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *StopInternalLoadBalancerVMParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1120,6 +1294,12 @@ func (p *StopInternalLoadBalancerVMParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *StopInternalLoadBalancerVMParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *StopInternalLoadBalancerVMParams) GetId() (string, bool) {

--- a/cloudstack/KubernetesService.go
+++ b/cloudstack/KubernetesService.go
@@ -110,6 +110,12 @@ func (p *AddKubernetesSupportedVersionParams) SetChecksum(v string) {
 	p.p["checksum"] = v
 }
 
+func (p *AddKubernetesSupportedVersionParams) ResetChecksum() {
+	if p.p != nil && p.p["checksum"] != nil {
+		delete(p.p, "checksum")
+	}
+}
+
 func (p *AddKubernetesSupportedVersionParams) GetChecksum() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -123,6 +129,12 @@ func (p *AddKubernetesSupportedVersionParams) SetDirectdownload(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["directdownload"] = v
+}
+
+func (p *AddKubernetesSupportedVersionParams) ResetDirectdownload() {
+	if p.p != nil && p.p["directdownload"] != nil {
+		delete(p.p, "directdownload")
+	}
 }
 
 func (p *AddKubernetesSupportedVersionParams) GetDirectdownload() (bool, bool) {
@@ -140,6 +152,12 @@ func (p *AddKubernetesSupportedVersionParams) SetMincpunumber(v int) {
 	p.p["mincpunumber"] = v
 }
 
+func (p *AddKubernetesSupportedVersionParams) ResetMincpunumber() {
+	if p.p != nil && p.p["mincpunumber"] != nil {
+		delete(p.p, "mincpunumber")
+	}
+}
+
 func (p *AddKubernetesSupportedVersionParams) GetMincpunumber() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -153,6 +171,12 @@ func (p *AddKubernetesSupportedVersionParams) SetMinmemory(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["minmemory"] = v
+}
+
+func (p *AddKubernetesSupportedVersionParams) ResetMinmemory() {
+	if p.p != nil && p.p["minmemory"] != nil {
+		delete(p.p, "minmemory")
+	}
 }
 
 func (p *AddKubernetesSupportedVersionParams) GetMinmemory() (int, bool) {
@@ -170,6 +194,12 @@ func (p *AddKubernetesSupportedVersionParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *AddKubernetesSupportedVersionParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *AddKubernetesSupportedVersionParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -183,6 +213,12 @@ func (p *AddKubernetesSupportedVersionParams) SetSemanticversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["semanticversion"] = v
+}
+
+func (p *AddKubernetesSupportedVersionParams) ResetSemanticversion() {
+	if p.p != nil && p.p["semanticversion"] != nil {
+		delete(p.p, "semanticversion")
+	}
 }
 
 func (p *AddKubernetesSupportedVersionParams) GetSemanticversion() (string, bool) {
@@ -200,6 +236,12 @@ func (p *AddKubernetesSupportedVersionParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddKubernetesSupportedVersionParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddKubernetesSupportedVersionParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -213,6 +255,12 @@ func (p *AddKubernetesSupportedVersionParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddKubernetesSupportedVersionParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddKubernetesSupportedVersionParams) GetZoneid() (string, bool) {
@@ -353,6 +401,12 @@ func (p *CreateKubernetesClusterParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -366,6 +420,12 @@ func (p *CreateKubernetesClusterParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetClustertype() {
+	if p.p != nil && p.p["clustertype"] != nil {
+		delete(p.p, "clustertype")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetClustertype() (string, bool) {
@@ -383,6 +443,12 @@ func (p *CreateKubernetesClusterParams) SetControlnodes(v int64) {
 	p.p["controlnodes"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetControlnodes() {
+	if p.p != nil && p.p["controlnodes"] != nil {
+		delete(p.p, "controlnodes")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetControlnodes() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -396,6 +462,12 @@ func (p *CreateKubernetesClusterParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetDescription() (string, bool) {
@@ -413,6 +485,12 @@ func (p *CreateKubernetesClusterParams) SetDockerregistrypassword(v string) {
 	p.p["dockerregistrypassword"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetDockerregistrypassword() {
+	if p.p != nil && p.p["dockerregistrypassword"] != nil {
+		delete(p.p, "dockerregistrypassword")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetDockerregistrypassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -426,6 +504,12 @@ func (p *CreateKubernetesClusterParams) SetDockerregistryurl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dockerregistryurl"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetDockerregistryurl() {
+	if p.p != nil && p.p["dockerregistryurl"] != nil {
+		delete(p.p, "dockerregistryurl")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetDockerregistryurl() (string, bool) {
@@ -443,6 +527,12 @@ func (p *CreateKubernetesClusterParams) SetDockerregistryusername(v string) {
 	p.p["dockerregistryusername"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetDockerregistryusername() {
+	if p.p != nil && p.p["dockerregistryusername"] != nil {
+		delete(p.p, "dockerregistryusername")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetDockerregistryusername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -456,6 +546,12 @@ func (p *CreateKubernetesClusterParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetDomainid() (string, bool) {
@@ -473,6 +569,12 @@ func (p *CreateKubernetesClusterParams) SetExternalloadbalanceripaddress(v strin
 	p.p["externalloadbalanceripaddress"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetExternalloadbalanceripaddress() {
+	if p.p != nil && p.p["externalloadbalanceripaddress"] != nil {
+		delete(p.p, "externalloadbalanceripaddress")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetExternalloadbalanceripaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -486,6 +588,12 @@ func (p *CreateKubernetesClusterParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetKeypair() {
+	if p.p != nil && p.p["keypair"] != nil {
+		delete(p.p, "keypair")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetKeypair() (string, bool) {
@@ -503,6 +611,12 @@ func (p *CreateKubernetesClusterParams) SetKubernetesversionid(v string) {
 	p.p["kubernetesversionid"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetKubernetesversionid() {
+	if p.p != nil && p.p["kubernetesversionid"] != nil {
+		delete(p.p, "kubernetesversionid")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetKubernetesversionid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -516,6 +630,12 @@ func (p *CreateKubernetesClusterParams) SetMasternodes(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["masternodes"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetMasternodes() {
+	if p.p != nil && p.p["masternodes"] != nil {
+		delete(p.p, "masternodes")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetMasternodes() (int64, bool) {
@@ -533,6 +653,12 @@ func (p *CreateKubernetesClusterParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -546,6 +672,12 @@ func (p *CreateKubernetesClusterParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetNetworkid() (string, bool) {
@@ -563,6 +695,12 @@ func (p *CreateKubernetesClusterParams) SetNoderootdisksize(v int64) {
 	p.p["noderootdisksize"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetNoderootdisksize() {
+	if p.p != nil && p.p["noderootdisksize"] != nil {
+		delete(p.p, "noderootdisksize")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetNoderootdisksize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -576,6 +714,12 @@ func (p *CreateKubernetesClusterParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetProjectid() (string, bool) {
@@ -593,6 +737,12 @@ func (p *CreateKubernetesClusterParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -608,6 +758,12 @@ func (p *CreateKubernetesClusterParams) SetSize(v int64) {
 	p.p["size"] = v
 }
 
+func (p *CreateKubernetesClusterParams) ResetSize() {
+	if p.p != nil && p.p["size"] != nil {
+		delete(p.p, "size")
+	}
+}
+
 func (p *CreateKubernetesClusterParams) GetSize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -621,6 +777,12 @@ func (p *CreateKubernetesClusterParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateKubernetesClusterParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateKubernetesClusterParams) GetZoneid() (string, bool) {
@@ -750,6 +912,12 @@ func (p *DeleteKubernetesClusterParams) SetCleanup(v bool) {
 	p.p["cleanup"] = v
 }
 
+func (p *DeleteKubernetesClusterParams) ResetCleanup() {
+	if p.p != nil && p.p["cleanup"] != nil {
+		delete(p.p, "cleanup")
+	}
+}
+
 func (p *DeleteKubernetesClusterParams) GetCleanup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -765,6 +933,12 @@ func (p *DeleteKubernetesClusterParams) SetExpunge(v bool) {
 	p.p["expunge"] = v
 }
 
+func (p *DeleteKubernetesClusterParams) ResetExpunge() {
+	if p.p != nil && p.p["expunge"] != nil {
+		delete(p.p, "expunge")
+	}
+}
+
 func (p *DeleteKubernetesClusterParams) GetExpunge() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -778,6 +952,12 @@ func (p *DeleteKubernetesClusterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteKubernetesClusterParams) GetId() (string, bool) {
@@ -856,6 +1036,12 @@ func (p *DeleteKubernetesSupportedVersionParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteKubernetesSupportedVersionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteKubernetesSupportedVersionParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -930,6 +1116,12 @@ func (p *GetKubernetesClusterConfigParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *GetKubernetesClusterConfigParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *GetKubernetesClusterConfigParams) GetId() (string, bool) {
@@ -1033,6 +1225,12 @@ func (p *ListKubernetesClustersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListKubernetesClustersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListKubernetesClustersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1046,6 +1244,12 @@ func (p *ListKubernetesClustersParams) SetClustertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clustertype"] = v
+}
+
+func (p *ListKubernetesClustersParams) ResetClustertype() {
+	if p.p != nil && p.p["clustertype"] != nil {
+		delete(p.p, "clustertype")
+	}
 }
 
 func (p *ListKubernetesClustersParams) GetClustertype() (string, bool) {
@@ -1063,6 +1267,12 @@ func (p *ListKubernetesClustersParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListKubernetesClustersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListKubernetesClustersParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1076,6 +1286,12 @@ func (p *ListKubernetesClustersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListKubernetesClustersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListKubernetesClustersParams) GetId() (string, bool) {
@@ -1093,6 +1309,12 @@ func (p *ListKubernetesClustersParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListKubernetesClustersParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListKubernetesClustersParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1106,6 +1328,12 @@ func (p *ListKubernetesClustersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListKubernetesClustersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListKubernetesClustersParams) GetKeyword() (string, bool) {
@@ -1123,6 +1351,12 @@ func (p *ListKubernetesClustersParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListKubernetesClustersParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListKubernetesClustersParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1136,6 +1370,12 @@ func (p *ListKubernetesClustersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListKubernetesClustersParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListKubernetesClustersParams) GetName() (string, bool) {
@@ -1153,6 +1393,12 @@ func (p *ListKubernetesClustersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListKubernetesClustersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListKubernetesClustersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1166,6 +1412,12 @@ func (p *ListKubernetesClustersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListKubernetesClustersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListKubernetesClustersParams) GetPagesize() (int, bool) {
@@ -1183,6 +1435,12 @@ func (p *ListKubernetesClustersParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListKubernetesClustersParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListKubernetesClustersParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1196,6 +1454,12 @@ func (p *ListKubernetesClustersParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListKubernetesClustersParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListKubernetesClustersParams) GetState() (string, bool) {
@@ -1399,6 +1663,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListKubernetesSupportedVersionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListKubernetesSupportedVersionsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1412,6 +1682,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListKubernetesSupportedVersionsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListKubernetesSupportedVersionsParams) GetKeyword() (string, bool) {
@@ -1429,6 +1705,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetMinimumkubernetesversionid(v 
 	p.p["minimumkubernetesversionid"] = v
 }
 
+func (p *ListKubernetesSupportedVersionsParams) ResetMinimumkubernetesversionid() {
+	if p.p != nil && p.p["minimumkubernetesversionid"] != nil {
+		delete(p.p, "minimumkubernetesversionid")
+	}
+}
+
 func (p *ListKubernetesSupportedVersionsParams) GetMinimumkubernetesversionid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1442,6 +1724,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetMinimumsemanticversion(v stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["minimumsemanticversion"] = v
+}
+
+func (p *ListKubernetesSupportedVersionsParams) ResetMinimumsemanticversion() {
+	if p.p != nil && p.p["minimumsemanticversion"] != nil {
+		delete(p.p, "minimumsemanticversion")
+	}
 }
 
 func (p *ListKubernetesSupportedVersionsParams) GetMinimumsemanticversion() (string, bool) {
@@ -1459,6 +1747,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListKubernetesSupportedVersionsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListKubernetesSupportedVersionsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1474,6 +1768,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListKubernetesSupportedVersionsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListKubernetesSupportedVersionsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1487,6 +1787,12 @@ func (p *ListKubernetesSupportedVersionsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListKubernetesSupportedVersionsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListKubernetesSupportedVersionsParams) GetZoneid() (string, bool) {
@@ -1673,6 +1979,12 @@ func (p *ScaleKubernetesClusterParams) SetAutoscalingenabled(v bool) {
 	p.p["autoscalingenabled"] = v
 }
 
+func (p *ScaleKubernetesClusterParams) ResetAutoscalingenabled() {
+	if p.p != nil && p.p["autoscalingenabled"] != nil {
+		delete(p.p, "autoscalingenabled")
+	}
+}
+
 func (p *ScaleKubernetesClusterParams) GetAutoscalingenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1686,6 +1998,12 @@ func (p *ScaleKubernetesClusterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ScaleKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ScaleKubernetesClusterParams) GetId() (string, bool) {
@@ -1703,6 +2021,12 @@ func (p *ScaleKubernetesClusterParams) SetMaxsize(v int64) {
 	p.p["maxsize"] = v
 }
 
+func (p *ScaleKubernetesClusterParams) ResetMaxsize() {
+	if p.p != nil && p.p["maxsize"] != nil {
+		delete(p.p, "maxsize")
+	}
+}
+
 func (p *ScaleKubernetesClusterParams) GetMaxsize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1716,6 +2040,12 @@ func (p *ScaleKubernetesClusterParams) SetMinsize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["minsize"] = v
+}
+
+func (p *ScaleKubernetesClusterParams) ResetMinsize() {
+	if p.p != nil && p.p["minsize"] != nil {
+		delete(p.p, "minsize")
+	}
 }
 
 func (p *ScaleKubernetesClusterParams) GetMinsize() (int64, bool) {
@@ -1733,6 +2063,12 @@ func (p *ScaleKubernetesClusterParams) SetNodeids(v []string) {
 	p.p["nodeids"] = v
 }
 
+func (p *ScaleKubernetesClusterParams) ResetNodeids() {
+	if p.p != nil && p.p["nodeids"] != nil {
+		delete(p.p, "nodeids")
+	}
+}
+
 func (p *ScaleKubernetesClusterParams) GetNodeids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1748,6 +2084,12 @@ func (p *ScaleKubernetesClusterParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *ScaleKubernetesClusterParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *ScaleKubernetesClusterParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1761,6 +2103,12 @@ func (p *ScaleKubernetesClusterParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
+}
+
+func (p *ScaleKubernetesClusterParams) ResetSize() {
+	if p.p != nil && p.p["size"] != nil {
+		delete(p.p, "size")
+	}
 }
 
 func (p *ScaleKubernetesClusterParams) GetSize() (int64, bool) {
@@ -1877,6 +2225,12 @@ func (p *StartKubernetesClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *StartKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *StartKubernetesClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1991,6 +2345,12 @@ func (p *StopKubernetesClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *StopKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *StopKubernetesClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2070,6 +2430,12 @@ func (p *UpdateKubernetesSupportedVersionParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateKubernetesSupportedVersionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateKubernetesSupportedVersionParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2083,6 +2449,12 @@ func (p *UpdateKubernetesSupportedVersionParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *UpdateKubernetesSupportedVersionParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *UpdateKubernetesSupportedVersionParams) GetState() (string, bool) {
@@ -2163,6 +2535,12 @@ func (p *UpgradeKubernetesClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpgradeKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpgradeKubernetesClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2176,6 +2554,12 @@ func (p *UpgradeKubernetesClusterParams) SetKubernetesversionid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["kubernetesversionid"] = v
+}
+
+func (p *UpgradeKubernetesClusterParams) ResetKubernetesversionid() {
+	if p.p != nil && p.p["kubernetesversionid"] != nil {
+		delete(p.p, "kubernetesversionid")
+	}
 }
 
 func (p *UpgradeKubernetesClusterParams) GetKubernetesversionid() (string, bool) {
@@ -2301,6 +2685,12 @@ func (p *AddVirtualMachinesToKubernetesClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *AddVirtualMachinesToKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *AddVirtualMachinesToKubernetesClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2316,6 +2706,12 @@ func (p *AddVirtualMachinesToKubernetesClusterParams) SetIscontrolnode(v bool) {
 	p.p["iscontrolnode"] = v
 }
 
+func (p *AddVirtualMachinesToKubernetesClusterParams) ResetIscontrolnode() {
+	if p.p != nil && p.p["iscontrolnode"] != nil {
+		delete(p.p, "iscontrolnode")
+	}
+}
+
 func (p *AddVirtualMachinesToKubernetesClusterParams) GetIscontrolnode() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2329,6 +2725,12 @@ func (p *AddVirtualMachinesToKubernetesClusterParams) SetVirtualmachineids(v []s
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineids"] = v
+}
+
+func (p *AddVirtualMachinesToKubernetesClusterParams) ResetVirtualmachineids() {
+	if p.p != nil && p.p["virtualmachineids"] != nil {
+		delete(p.p, "virtualmachineids")
+	}
 }
 
 func (p *AddVirtualMachinesToKubernetesClusterParams) GetVirtualmachineids() ([]string, bool) {
@@ -2435,6 +2837,12 @@ func (p *RemoveVirtualMachinesFromKubernetesClusterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RemoveVirtualMachinesFromKubernetesClusterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RemoveVirtualMachinesFromKubernetesClusterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2448,6 +2856,12 @@ func (p *RemoveVirtualMachinesFromKubernetesClusterParams) SetKeyword(v string) 
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *RemoveVirtualMachinesFromKubernetesClusterParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *RemoveVirtualMachinesFromKubernetesClusterParams) GetKeyword() (string, bool) {
@@ -2465,6 +2879,12 @@ func (p *RemoveVirtualMachinesFromKubernetesClusterParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *RemoveVirtualMachinesFromKubernetesClusterParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *RemoveVirtualMachinesFromKubernetesClusterParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2480,6 +2900,12 @@ func (p *RemoveVirtualMachinesFromKubernetesClusterParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *RemoveVirtualMachinesFromKubernetesClusterParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *RemoveVirtualMachinesFromKubernetesClusterParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2493,6 +2919,12 @@ func (p *RemoveVirtualMachinesFromKubernetesClusterParams) SetVirtualmachineids(
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineids"] = v
+}
+
+func (p *RemoveVirtualMachinesFromKubernetesClusterParams) ResetVirtualmachineids() {
+	if p.p != nil && p.p["virtualmachineids"] != nil {
+		delete(p.p, "virtualmachineids")
+	}
 }
 
 func (p *RemoveVirtualMachinesFromKubernetesClusterParams) GetVirtualmachineids() ([]string, bool) {

--- a/cloudstack/LDAPService.go
+++ b/cloudstack/LDAPService.go
@@ -78,6 +78,12 @@ func (p *AddLdapConfigurationParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *AddLdapConfigurationParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *AddLdapConfigurationParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -93,6 +99,12 @@ func (p *AddLdapConfigurationParams) SetHostname(v string) {
 	p.p["hostname"] = v
 }
 
+func (p *AddLdapConfigurationParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
+}
+
 func (p *AddLdapConfigurationParams) GetHostname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -106,6 +118,12 @@ func (p *AddLdapConfigurationParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
+}
+
+func (p *AddLdapConfigurationParams) ResetPort() {
+	if p.p != nil && p.p["port"] != nil {
+		delete(p.p, "port")
+	}
 }
 
 func (p *AddLdapConfigurationParams) GetPort() (int, bool) {
@@ -178,6 +196,12 @@ func (p *DeleteLdapConfigurationParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *DeleteLdapConfigurationParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *DeleteLdapConfigurationParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -193,6 +217,12 @@ func (p *DeleteLdapConfigurationParams) SetHostname(v string) {
 	p.p["hostname"] = v
 }
 
+func (p *DeleteLdapConfigurationParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
+}
+
 func (p *DeleteLdapConfigurationParams) GetHostname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -206,6 +236,12 @@ func (p *DeleteLdapConfigurationParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
+}
+
+func (p *DeleteLdapConfigurationParams) ResetPort() {
+	if p.p != nil && p.p["port"] != nil {
+		delete(p.p, "port")
+	}
 }
 
 func (p *DeleteLdapConfigurationParams) GetPort() (int, bool) {
@@ -304,6 +340,12 @@ func (p *ImportLdapUsersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ImportLdapUsersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ImportLdapUsersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -317,6 +359,12 @@ func (p *ImportLdapUsersParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
+}
+
+func (p *ImportLdapUsersParams) ResetAccountdetails() {
+	if p.p != nil && p.p["accountdetails"] != nil {
+		delete(p.p, "accountdetails")
+	}
 }
 
 func (p *ImportLdapUsersParams) GetAccountdetails() (map[string]string, bool) {
@@ -334,6 +382,12 @@ func (p *ImportLdapUsersParams) SetAccounttype(v int) {
 	p.p["accounttype"] = v
 }
 
+func (p *ImportLdapUsersParams) ResetAccounttype() {
+	if p.p != nil && p.p["accounttype"] != nil {
+		delete(p.p, "accounttype")
+	}
+}
+
 func (p *ImportLdapUsersParams) GetAccounttype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -347,6 +401,12 @@ func (p *ImportLdapUsersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ImportLdapUsersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ImportLdapUsersParams) GetDomainid() (string, bool) {
@@ -364,6 +424,12 @@ func (p *ImportLdapUsersParams) SetGroup(v string) {
 	p.p["group"] = v
 }
 
+func (p *ImportLdapUsersParams) ResetGroup() {
+	if p.p != nil && p.p["group"] != nil {
+		delete(p.p, "group")
+	}
+}
+
 func (p *ImportLdapUsersParams) GetGroup() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -377,6 +443,12 @@ func (p *ImportLdapUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ImportLdapUsersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ImportLdapUsersParams) GetKeyword() (string, bool) {
@@ -394,6 +466,12 @@ func (p *ImportLdapUsersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ImportLdapUsersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ImportLdapUsersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -407,6 +485,12 @@ func (p *ImportLdapUsersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ImportLdapUsersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ImportLdapUsersParams) GetPagesize() (int, bool) {
@@ -424,6 +508,12 @@ func (p *ImportLdapUsersParams) SetRoleid(v string) {
 	p.p["roleid"] = v
 }
 
+func (p *ImportLdapUsersParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
+}
+
 func (p *ImportLdapUsersParams) GetRoleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -437,6 +527,12 @@ func (p *ImportLdapUsersParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
+}
+
+func (p *ImportLdapUsersParams) ResetTimezone() {
+	if p.p != nil && p.p["timezone"] != nil {
+		delete(p.p, "timezone")
+	}
 }
 
 func (p *ImportLdapUsersParams) GetTimezone() (string, bool) {
@@ -534,6 +630,12 @@ func (p *LdapConfigParams) SetBinddn(v string) {
 	p.p["binddn"] = v
 }
 
+func (p *LdapConfigParams) ResetBinddn() {
+	if p.p != nil && p.p["binddn"] != nil {
+		delete(p.p, "binddn")
+	}
+}
+
 func (p *LdapConfigParams) GetBinddn() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -547,6 +649,12 @@ func (p *LdapConfigParams) SetBindpass(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bindpass"] = v
+}
+
+func (p *LdapConfigParams) ResetBindpass() {
+	if p.p != nil && p.p["bindpass"] != nil {
+		delete(p.p, "bindpass")
+	}
 }
 
 func (p *LdapConfigParams) GetBindpass() (string, bool) {
@@ -564,6 +672,12 @@ func (p *LdapConfigParams) SetHostname(v string) {
 	p.p["hostname"] = v
 }
 
+func (p *LdapConfigParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
+}
+
 func (p *LdapConfigParams) GetHostname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -577,6 +691,12 @@ func (p *LdapConfigParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *LdapConfigParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *LdapConfigParams) GetListall() (bool, bool) {
@@ -594,6 +714,12 @@ func (p *LdapConfigParams) SetPort(v int) {
 	p.p["port"] = v
 }
 
+func (p *LdapConfigParams) ResetPort() {
+	if p.p != nil && p.p["port"] != nil {
+		delete(p.p, "port")
+	}
+}
+
 func (p *LdapConfigParams) GetPort() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -607,6 +733,12 @@ func (p *LdapConfigParams) SetQueryfilter(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["queryfilter"] = v
+}
+
+func (p *LdapConfigParams) ResetQueryfilter() {
+	if p.p != nil && p.p["queryfilter"] != nil {
+		delete(p.p, "queryfilter")
+	}
 }
 
 func (p *LdapConfigParams) GetQueryfilter() (string, bool) {
@@ -624,6 +756,12 @@ func (p *LdapConfigParams) SetSearchbase(v string) {
 	p.p["searchbase"] = v
 }
 
+func (p *LdapConfigParams) ResetSearchbase() {
+	if p.p != nil && p.p["searchbase"] != nil {
+		delete(p.p, "searchbase")
+	}
+}
+
 func (p *LdapConfigParams) GetSearchbase() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -637,6 +775,12 @@ func (p *LdapConfigParams) SetSsl(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ssl"] = v
+}
+
+func (p *LdapConfigParams) ResetSsl() {
+	if p.p != nil && p.p["ssl"] != nil {
+		delete(p.p, "ssl")
+	}
 }
 
 func (p *LdapConfigParams) GetSsl() (bool, bool) {
@@ -654,6 +798,12 @@ func (p *LdapConfigParams) SetTruststore(v string) {
 	p.p["truststore"] = v
 }
 
+func (p *LdapConfigParams) ResetTruststore() {
+	if p.p != nil && p.p["truststore"] != nil {
+		delete(p.p, "truststore")
+	}
+}
+
 func (p *LdapConfigParams) GetTruststore() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -667,6 +817,12 @@ func (p *LdapConfigParams) SetTruststorepass(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["truststorepass"] = v
+}
+
+func (p *LdapConfigParams) ResetTruststorepass() {
+	if p.p != nil && p.p["truststorepass"] != nil {
+		delete(p.p, "truststorepass")
+	}
 }
 
 func (p *LdapConfigParams) GetTruststorepass() (string, bool) {
@@ -766,6 +922,12 @@ func (p *LdapCreateAccountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *LdapCreateAccountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *LdapCreateAccountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -779,6 +941,12 @@ func (p *LdapCreateAccountParams) SetAccountdetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountdetails"] = v
+}
+
+func (p *LdapCreateAccountParams) ResetAccountdetails() {
+	if p.p != nil && p.p["accountdetails"] != nil {
+		delete(p.p, "accountdetails")
+	}
 }
 
 func (p *LdapCreateAccountParams) GetAccountdetails() (map[string]string, bool) {
@@ -796,6 +964,12 @@ func (p *LdapCreateAccountParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *LdapCreateAccountParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *LdapCreateAccountParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -809,6 +983,12 @@ func (p *LdapCreateAccountParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
+}
+
+func (p *LdapCreateAccountParams) ResetAccounttype() {
+	if p.p != nil && p.p["accounttype"] != nil {
+		delete(p.p, "accounttype")
+	}
 }
 
 func (p *LdapCreateAccountParams) GetAccounttype() (int, bool) {
@@ -826,6 +1006,12 @@ func (p *LdapCreateAccountParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *LdapCreateAccountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *LdapCreateAccountParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -839,6 +1025,12 @@ func (p *LdapCreateAccountParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
+}
+
+func (p *LdapCreateAccountParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
 }
 
 func (p *LdapCreateAccountParams) GetNetworkdomain() (string, bool) {
@@ -856,6 +1048,12 @@ func (p *LdapCreateAccountParams) SetRoleid(v string) {
 	p.p["roleid"] = v
 }
 
+func (p *LdapCreateAccountParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
+}
+
 func (p *LdapCreateAccountParams) GetRoleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -869,6 +1067,12 @@ func (p *LdapCreateAccountParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
+}
+
+func (p *LdapCreateAccountParams) ResetTimezone() {
+	if p.p != nil && p.p["timezone"] != nil {
+		delete(p.p, "timezone")
+	}
 }
 
 func (p *LdapCreateAccountParams) GetTimezone() (string, bool) {
@@ -886,6 +1090,12 @@ func (p *LdapCreateAccountParams) SetUserid(v string) {
 	p.p["userid"] = v
 }
 
+func (p *LdapCreateAccountParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
+}
+
 func (p *LdapCreateAccountParams) GetUserid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -899,6 +1109,12 @@ func (p *LdapCreateAccountParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *LdapCreateAccountParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *LdapCreateAccountParams) GetUsername() (string, bool) {
@@ -1109,6 +1325,12 @@ func (p *LinkDomainToLdapParams) SetAccounttype(v int) {
 	p.p["accounttype"] = v
 }
 
+func (p *LinkDomainToLdapParams) ResetAccounttype() {
+	if p.p != nil && p.p["accounttype"] != nil {
+		delete(p.p, "accounttype")
+	}
+}
+
 func (p *LinkDomainToLdapParams) GetAccounttype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1122,6 +1344,12 @@ func (p *LinkDomainToLdapParams) SetAdmin(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["admin"] = v
+}
+
+func (p *LinkDomainToLdapParams) ResetAdmin() {
+	if p.p != nil && p.p["admin"] != nil {
+		delete(p.p, "admin")
+	}
 }
 
 func (p *LinkDomainToLdapParams) GetAdmin() (string, bool) {
@@ -1139,6 +1367,12 @@ func (p *LinkDomainToLdapParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *LinkDomainToLdapParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *LinkDomainToLdapParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1152,6 +1386,12 @@ func (p *LinkDomainToLdapParams) SetLdapdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ldapdomain"] = v
+}
+
+func (p *LinkDomainToLdapParams) ResetLdapdomain() {
+	if p.p != nil && p.p["ldapdomain"] != nil {
+		delete(p.p, "ldapdomain")
+	}
 }
 
 func (p *LinkDomainToLdapParams) GetLdapdomain() (string, bool) {
@@ -1169,6 +1409,12 @@ func (p *LinkDomainToLdapParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *LinkDomainToLdapParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *LinkDomainToLdapParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1182,6 +1428,12 @@ func (p *LinkDomainToLdapParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *LinkDomainToLdapParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *LinkDomainToLdapParams) GetType() (string, bool) {
@@ -1273,6 +1525,12 @@ func (p *ListLdapConfigurationsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListLdapConfigurationsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListLdapConfigurationsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1286,6 +1544,12 @@ func (p *ListLdapConfigurationsParams) SetHostname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostname"] = v
+}
+
+func (p *ListLdapConfigurationsParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
 }
 
 func (p *ListLdapConfigurationsParams) GetHostname() (string, bool) {
@@ -1303,6 +1567,12 @@ func (p *ListLdapConfigurationsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListLdapConfigurationsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListLdapConfigurationsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1316,6 +1586,12 @@ func (p *ListLdapConfigurationsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListLdapConfigurationsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListLdapConfigurationsParams) GetListall() (bool, bool) {
@@ -1333,6 +1609,12 @@ func (p *ListLdapConfigurationsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListLdapConfigurationsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListLdapConfigurationsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1348,6 +1630,12 @@ func (p *ListLdapConfigurationsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListLdapConfigurationsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListLdapConfigurationsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1361,6 +1649,12 @@ func (p *ListLdapConfigurationsParams) SetPort(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["port"] = v
+}
+
+func (p *ListLdapConfigurationsParams) ResetPort() {
+	if p.p != nil && p.p["port"] != nil {
+		delete(p.p, "port")
+	}
 }
 
 func (p *ListLdapConfigurationsParams) GetPort() (int, bool) {
@@ -1446,6 +1740,12 @@ func (p *ListLdapUsersParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListLdapUsersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListLdapUsersParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1459,6 +1759,12 @@ func (p *ListLdapUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListLdapUsersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListLdapUsersParams) GetKeyword() (string, bool) {
@@ -1476,6 +1782,12 @@ func (p *ListLdapUsersParams) SetListtype(v string) {
 	p.p["listtype"] = v
 }
 
+func (p *ListLdapUsersParams) ResetListtype() {
+	if p.p != nil && p.p["listtype"] != nil {
+		delete(p.p, "listtype")
+	}
+}
+
 func (p *ListLdapUsersParams) GetListtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1489,6 +1801,12 @@ func (p *ListLdapUsersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListLdapUsersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListLdapUsersParams) GetPage() (int, bool) {
@@ -1506,6 +1824,12 @@ func (p *ListLdapUsersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListLdapUsersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListLdapUsersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1519,6 +1843,12 @@ func (p *ListLdapUsersParams) SetUserfilter(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userfilter"] = v
+}
+
+func (p *ListLdapUsersParams) ResetUserfilter() {
+	if p.p != nil && p.p["userfilter"] != nil {
+		delete(p.p, "userfilter")
+	}
 }
 
 func (p *ListLdapUsersParams) GetUserfilter() (string, bool) {
@@ -1602,6 +1932,12 @@ func (p *SearchLdapParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *SearchLdapParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *SearchLdapParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1615,6 +1951,12 @@ func (p *SearchLdapParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *SearchLdapParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *SearchLdapParams) GetPage() (int, bool) {
@@ -1632,6 +1974,12 @@ func (p *SearchLdapParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *SearchLdapParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *SearchLdapParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1645,6 +1993,12 @@ func (p *SearchLdapParams) SetQuery(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["query"] = v
+}
+
+func (p *SearchLdapParams) ResetQuery() {
+	if p.p != nil && p.p["query"] != nil {
+		delete(p.p, "query")
+	}
 }
 
 func (p *SearchLdapParams) GetQuery() (string, bool) {

--- a/cloudstack/LimitService.go
+++ b/cloudstack/LimitService.go
@@ -141,6 +141,12 @@ func (p *ListResourceLimitsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListResourceLimitsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListResourceLimitsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -154,6 +160,12 @@ func (p *ListResourceLimitsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListResourceLimitsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListResourceLimitsParams) GetDomainid() (string, bool) {
@@ -171,6 +183,12 @@ func (p *ListResourceLimitsParams) SetId(v int64) {
 	p.p["id"] = v
 }
 
+func (p *ListResourceLimitsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListResourceLimitsParams) GetId() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -184,6 +202,12 @@ func (p *ListResourceLimitsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListResourceLimitsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListResourceLimitsParams) GetIsrecursive() (bool, bool) {
@@ -201,6 +225,12 @@ func (p *ListResourceLimitsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListResourceLimitsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListResourceLimitsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -214,6 +244,12 @@ func (p *ListResourceLimitsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListResourceLimitsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListResourceLimitsParams) GetListall() (bool, bool) {
@@ -231,6 +267,12 @@ func (p *ListResourceLimitsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListResourceLimitsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListResourceLimitsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -244,6 +286,12 @@ func (p *ListResourceLimitsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListResourceLimitsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListResourceLimitsParams) GetPagesize() (int, bool) {
@@ -261,6 +309,12 @@ func (p *ListResourceLimitsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListResourceLimitsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListResourceLimitsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -276,6 +330,12 @@ func (p *ListResourceLimitsParams) SetResourcetype(v int) {
 	p.p["resourcetype"] = v
 }
 
+func (p *ListResourceLimitsParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
+}
+
 func (p *ListResourceLimitsParams) GetResourcetype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -289,6 +349,12 @@ func (p *ListResourceLimitsParams) SetResourcetypename(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetypename"] = v
+}
+
+func (p *ListResourceLimitsParams) ResetResourcetypename() {
+	if p.p != nil && p.p["resourcetypename"] != nil {
+		delete(p.p, "resourcetypename")
+	}
 }
 
 func (p *ListResourceLimitsParams) GetResourcetypename() (string, bool) {
@@ -360,6 +426,12 @@ func (p *ResetApiLimitParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
+}
+
+func (p *ResetApiLimitParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
 }
 
 func (p *ResetApiLimitParams) GetAccount() (string, bool) {
@@ -459,6 +531,12 @@ func (p *UpdateResourceCountParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UpdateResourceCountParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UpdateResourceCountParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -472,6 +550,12 @@ func (p *UpdateResourceCountParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UpdateResourceCountParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UpdateResourceCountParams) GetDomainid() (string, bool) {
@@ -489,6 +573,12 @@ func (p *UpdateResourceCountParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *UpdateResourceCountParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *UpdateResourceCountParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -502,6 +592,12 @@ func (p *UpdateResourceCountParams) SetResourcetype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
+}
+
+func (p *UpdateResourceCountParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
 }
 
 func (p *UpdateResourceCountParams) GetResourcetype() (int, bool) {
@@ -585,6 +681,12 @@ func (p *UpdateResourceLimitParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UpdateResourceLimitParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UpdateResourceLimitParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -598,6 +700,12 @@ func (p *UpdateResourceLimitParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UpdateResourceLimitParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UpdateResourceLimitParams) GetDomainid() (string, bool) {
@@ -615,6 +723,12 @@ func (p *UpdateResourceLimitParams) SetMax(v int64) {
 	p.p["max"] = v
 }
 
+func (p *UpdateResourceLimitParams) ResetMax() {
+	if p.p != nil && p.p["max"] != nil {
+		delete(p.p, "max")
+	}
+}
+
 func (p *UpdateResourceLimitParams) GetMax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -630,6 +744,12 @@ func (p *UpdateResourceLimitParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *UpdateResourceLimitParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *UpdateResourceLimitParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -643,6 +763,12 @@ func (p *UpdateResourceLimitParams) SetResourcetype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
+}
+
+func (p *UpdateResourceLimitParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
 }
 
 func (p *UpdateResourceLimitParams) GetResourcetype() (int, bool) {

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -158,6 +158,12 @@ func (p *AddNetscalerLoadBalancerParams) SetGslbprovider(v bool) {
 	p.p["gslbprovider"] = v
 }
 
+func (p *AddNetscalerLoadBalancerParams) ResetGslbprovider() {
+	if p.p != nil && p.p["gslbprovider"] != nil {
+		delete(p.p, "gslbprovider")
+	}
+}
+
 func (p *AddNetscalerLoadBalancerParams) GetGslbprovider() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -171,6 +177,12 @@ func (p *AddNetscalerLoadBalancerParams) SetGslbproviderprivateip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbproviderprivateip"] = v
+}
+
+func (p *AddNetscalerLoadBalancerParams) ResetGslbproviderprivateip() {
+	if p.p != nil && p.p["gslbproviderprivateip"] != nil {
+		delete(p.p, "gslbproviderprivateip")
+	}
 }
 
 func (p *AddNetscalerLoadBalancerParams) GetGslbproviderprivateip() (string, bool) {
@@ -188,6 +200,12 @@ func (p *AddNetscalerLoadBalancerParams) SetGslbproviderpublicip(v string) {
 	p.p["gslbproviderpublicip"] = v
 }
 
+func (p *AddNetscalerLoadBalancerParams) ResetGslbproviderpublicip() {
+	if p.p != nil && p.p["gslbproviderpublicip"] != nil {
+		delete(p.p, "gslbproviderpublicip")
+	}
+}
+
 func (p *AddNetscalerLoadBalancerParams) GetGslbproviderpublicip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -201,6 +219,12 @@ func (p *AddNetscalerLoadBalancerParams) SetIsexclusivegslbprovider(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isexclusivegslbprovider"] = v
+}
+
+func (p *AddNetscalerLoadBalancerParams) ResetIsexclusivegslbprovider() {
+	if p.p != nil && p.p["isexclusivegslbprovider"] != nil {
+		delete(p.p, "isexclusivegslbprovider")
+	}
 }
 
 func (p *AddNetscalerLoadBalancerParams) GetIsexclusivegslbprovider() (bool, bool) {
@@ -218,6 +242,12 @@ func (p *AddNetscalerLoadBalancerParams) SetNetworkdevicetype(v string) {
 	p.p["networkdevicetype"] = v
 }
 
+func (p *AddNetscalerLoadBalancerParams) ResetNetworkdevicetype() {
+	if p.p != nil && p.p["networkdevicetype"] != nil {
+		delete(p.p, "networkdevicetype")
+	}
+}
+
 func (p *AddNetscalerLoadBalancerParams) GetNetworkdevicetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -231,6 +261,12 @@ func (p *AddNetscalerLoadBalancerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddNetscalerLoadBalancerParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddNetscalerLoadBalancerParams) GetPassword() (string, bool) {
@@ -248,6 +284,12 @@ func (p *AddNetscalerLoadBalancerParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddNetscalerLoadBalancerParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddNetscalerLoadBalancerParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -263,6 +305,12 @@ func (p *AddNetscalerLoadBalancerParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddNetscalerLoadBalancerParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddNetscalerLoadBalancerParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -276,6 +324,12 @@ func (p *AddNetscalerLoadBalancerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddNetscalerLoadBalancerParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddNetscalerLoadBalancerParams) GetUsername() (string, bool) {
@@ -379,6 +433,12 @@ func (p *AssignCertToLoadBalancerParams) SetCertid(v string) {
 	p.p["certid"] = v
 }
 
+func (p *AssignCertToLoadBalancerParams) ResetCertid() {
+	if p.p != nil && p.p["certid"] != nil {
+		delete(p.p, "certid")
+	}
+}
+
 func (p *AssignCertToLoadBalancerParams) GetCertid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -392,6 +452,12 @@ func (p *AssignCertToLoadBalancerParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
+}
+
+func (p *AssignCertToLoadBalancerParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
 }
 
 func (p *AssignCertToLoadBalancerParams) GetLbruleid() (string, bool) {
@@ -482,6 +548,12 @@ func (p *AssignToGlobalLoadBalancerRuleParams) SetGslblbruleweightsmap(v map[str
 	p.p["gslblbruleweightsmap"] = v
 }
 
+func (p *AssignToGlobalLoadBalancerRuleParams) ResetGslblbruleweightsmap() {
+	if p.p != nil && p.p["gslblbruleweightsmap"] != nil {
+		delete(p.p, "gslblbruleweightsmap")
+	}
+}
+
 func (p *AssignToGlobalLoadBalancerRuleParams) GetGslblbruleweightsmap() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -497,6 +569,12 @@ func (p *AssignToGlobalLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *AssignToGlobalLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *AssignToGlobalLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -510,6 +588,12 @@ func (p *AssignToGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []strin
 		p.p = make(map[string]interface{})
 	}
 	p.p["loadbalancerrulelist"] = v
+}
+
+func (p *AssignToGlobalLoadBalancerRuleParams) ResetLoadbalancerrulelist() {
+	if p.p != nil && p.p["loadbalancerrulelist"] != nil {
+		delete(p.p, "loadbalancerrulelist")
+	}
 }
 
 func (p *AssignToGlobalLoadBalancerRuleParams) GetLoadbalancerrulelist() ([]string, bool) {
@@ -600,6 +684,12 @@ func (p *AssignToLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *AssignToLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *AssignToLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -615,6 +705,12 @@ func (p *AssignToLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
 	p.p["virtualmachineids"] = v
 }
 
+func (p *AssignToLoadBalancerRuleParams) ResetVirtualmachineids() {
+	if p.p != nil && p.p["virtualmachineids"] != nil {
+		delete(p.p, "virtualmachineids")
+	}
+}
+
 func (p *AssignToLoadBalancerRuleParams) GetVirtualmachineids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -628,6 +724,12 @@ func (p *AssignToLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmidipmap"] = v
+}
+
+func (p *AssignToLoadBalancerRuleParams) ResetVmidipmap() {
+	if p.p != nil && p.p["vmidipmap"] != nil {
+		delete(p.p, "vmidipmap")
+	}
 }
 
 func (p *AssignToLoadBalancerRuleParams) GetVmidipmap() (map[string]string, bool) {
@@ -722,6 +824,12 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetInline(v bool) {
 	p.p["inline"] = v
 }
 
+func (p *ConfigureNetscalerLoadBalancerParams) ResetInline() {
+	if p.p != nil && p.p["inline"] != nil {
+		delete(p.p, "inline")
+	}
+}
+
 func (p *ConfigureNetscalerLoadBalancerParams) GetInline() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -735,6 +843,12 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicecapacity(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdevicecapacity"] = v
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) ResetLbdevicecapacity() {
+	if p.p != nil && p.p["lbdevicecapacity"] != nil {
+		delete(p.p, "lbdevicecapacity")
+	}
 }
 
 func (p *ConfigureNetscalerLoadBalancerParams) GetLbdevicecapacity() (int64, bool) {
@@ -752,6 +866,12 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetLbdevicededicated(v bool) {
 	p.p["lbdevicededicated"] = v
 }
 
+func (p *ConfigureNetscalerLoadBalancerParams) ResetLbdevicededicated() {
+	if p.p != nil && p.p["lbdevicededicated"] != nil {
+		delete(p.p, "lbdevicededicated")
+	}
+}
+
 func (p *ConfigureNetscalerLoadBalancerParams) GetLbdevicededicated() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -767,6 +887,12 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
 	p.p["lbdeviceid"] = v
 }
 
+func (p *ConfigureNetscalerLoadBalancerParams) ResetLbdeviceid() {
+	if p.p != nil && p.p["lbdeviceid"] != nil {
+		delete(p.p, "lbdeviceid")
+	}
+}
+
 func (p *ConfigureNetscalerLoadBalancerParams) GetLbdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -780,6 +906,12 @@ func (p *ConfigureNetscalerLoadBalancerParams) SetPodids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podids"] = v
+}
+
+func (p *ConfigureNetscalerLoadBalancerParams) ResetPodids() {
+	if p.p != nil && p.p["podids"] != nil {
+		delete(p.p, "podids")
+	}
 }
 
 func (p *ConfigureNetscalerLoadBalancerParams) GetPodids() ([]string, bool) {
@@ -901,6 +1033,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateGlobalLoadBalancerRuleParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateGlobalLoadBalancerRuleParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -914,6 +1052,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) GetDescription() (string, bool) {
@@ -931,6 +1075,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateGlobalLoadBalancerRuleParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateGlobalLoadBalancerRuleParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -944,6 +1094,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslbdomainname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbdomainname"] = v
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) ResetGslbdomainname() {
+	if p.p != nil && p.p["gslbdomainname"] != nil {
+		delete(p.p, "gslbdomainname")
+	}
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) GetGslbdomainname() (string, bool) {
@@ -961,6 +1117,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
 	p.p["gslblbmethod"] = v
 }
 
+func (p *CreateGlobalLoadBalancerRuleParams) ResetGslblbmethod() {
+	if p.p != nil && p.p["gslblbmethod"] != nil {
+		delete(p.p, "gslblbmethod")
+	}
+}
+
 func (p *CreateGlobalLoadBalancerRuleParams) GetGslblbmethod() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -974,6 +1136,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslbservicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslbservicetype"] = v
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) ResetGslbservicetype() {
+	if p.p != nil && p.p["gslbservicetype"] != nil {
+		delete(p.p, "gslbservicetype")
+	}
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) GetGslbservicetype() (string, bool) {
@@ -991,6 +1159,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v st
 	p.p["gslbstickysessionmethodname"] = v
 }
 
+func (p *CreateGlobalLoadBalancerRuleParams) ResetGslbstickysessionmethodname() {
+	if p.p != nil && p.p["gslbstickysessionmethodname"] != nil {
+		delete(p.p, "gslbstickysessionmethodname")
+	}
+}
+
 func (p *CreateGlobalLoadBalancerRuleParams) GetGslbstickysessionmethodname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1006,6 +1180,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateGlobalLoadBalancerRuleParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateGlobalLoadBalancerRuleParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1019,6 +1199,12 @@ func (p *CreateGlobalLoadBalancerRuleParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
+}
+
+func (p *CreateGlobalLoadBalancerRuleParams) ResetRegionid() {
+	if p.p != nil && p.p["regionid"] != nil {
+		delete(p.p, "regionid")
+	}
 }
 
 func (p *CreateGlobalLoadBalancerRuleParams) GetRegionid() (int, bool) {
@@ -1167,6 +1353,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateLBHealthCheckPolicyParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateLBHealthCheckPolicyParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1180,6 +1372,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateLBHealthCheckPolicyParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateLBHealthCheckPolicyParams) GetFordisplay() (bool, bool) {
@@ -1197,6 +1395,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetHealthythreshold(v int) {
 	p.p["healthythreshold"] = v
 }
 
+func (p *CreateLBHealthCheckPolicyParams) ResetHealthythreshold() {
+	if p.p != nil && p.p["healthythreshold"] != nil {
+		delete(p.p, "healthythreshold")
+	}
+}
+
 func (p *CreateLBHealthCheckPolicyParams) GetHealthythreshold() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1210,6 +1414,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetIntervaltime(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["intervaltime"] = v
+}
+
+func (p *CreateLBHealthCheckPolicyParams) ResetIntervaltime() {
+	if p.p != nil && p.p["intervaltime"] != nil {
+		delete(p.p, "intervaltime")
+	}
 }
 
 func (p *CreateLBHealthCheckPolicyParams) GetIntervaltime() (int, bool) {
@@ -1227,6 +1437,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetLbruleid(v string) {
 	p.p["lbruleid"] = v
 }
 
+func (p *CreateLBHealthCheckPolicyParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
+}
+
 func (p *CreateLBHealthCheckPolicyParams) GetLbruleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1240,6 +1456,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetPingpath(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pingpath"] = v
+}
+
+func (p *CreateLBHealthCheckPolicyParams) ResetPingpath() {
+	if p.p != nil && p.p["pingpath"] != nil {
+		delete(p.p, "pingpath")
+	}
 }
 
 func (p *CreateLBHealthCheckPolicyParams) GetPingpath() (string, bool) {
@@ -1257,6 +1479,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetResponsetimeout(v int) {
 	p.p["responsetimeout"] = v
 }
 
+func (p *CreateLBHealthCheckPolicyParams) ResetResponsetimeout() {
+	if p.p != nil && p.p["responsetimeout"] != nil {
+		delete(p.p, "responsetimeout")
+	}
+}
+
 func (p *CreateLBHealthCheckPolicyParams) GetResponsetimeout() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1270,6 +1498,12 @@ func (p *CreateLBHealthCheckPolicyParams) SetUnhealthythreshold(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["unhealthythreshold"] = v
+}
+
+func (p *CreateLBHealthCheckPolicyParams) ResetUnhealthythreshold() {
+	if p.p != nil && p.p["unhealthythreshold"] != nil {
+		delete(p.p, "unhealthythreshold")
+	}
 }
 
 func (p *CreateLBHealthCheckPolicyParams) GetUnhealthythreshold() (int, bool) {
@@ -1389,6 +1623,12 @@ func (p *CreateLBStickinessPolicyParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateLBStickinessPolicyParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateLBStickinessPolicyParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1402,6 +1642,12 @@ func (p *CreateLBStickinessPolicyParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateLBStickinessPolicyParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateLBStickinessPolicyParams) GetFordisplay() (bool, bool) {
@@ -1419,6 +1665,12 @@ func (p *CreateLBStickinessPolicyParams) SetLbruleid(v string) {
 	p.p["lbruleid"] = v
 }
 
+func (p *CreateLBStickinessPolicyParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
+}
+
 func (p *CreateLBStickinessPolicyParams) GetLbruleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1432,6 +1684,12 @@ func (p *CreateLBStickinessPolicyParams) SetMethodname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["methodname"] = v
+}
+
+func (p *CreateLBStickinessPolicyParams) ResetMethodname() {
+	if p.p != nil && p.p["methodname"] != nil {
+		delete(p.p, "methodname")
+	}
 }
 
 func (p *CreateLBStickinessPolicyParams) GetMethodname() (string, bool) {
@@ -1449,6 +1707,12 @@ func (p *CreateLBStickinessPolicyParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateLBStickinessPolicyParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateLBStickinessPolicyParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1462,6 +1726,12 @@ func (p *CreateLBStickinessPolicyParams) SetParam(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["param"] = v
+}
+
+func (p *CreateLBStickinessPolicyParams) ResetParam() {
+	if p.p != nil && p.p["param"] != nil {
+		delete(p.p, "param")
+	}
 }
 
 func (p *CreateLBStickinessPolicyParams) GetParam() (map[string]string, bool) {
@@ -1594,6 +1864,12 @@ func (p *CreateLoadBalancerParams) SetAlgorithm(v string) {
 	p.p["algorithm"] = v
 }
 
+func (p *CreateLoadBalancerParams) ResetAlgorithm() {
+	if p.p != nil && p.p["algorithm"] != nil {
+		delete(p.p, "algorithm")
+	}
+}
+
 func (p *CreateLoadBalancerParams) GetAlgorithm() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1607,6 +1883,12 @@ func (p *CreateLoadBalancerParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *CreateLoadBalancerParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *CreateLoadBalancerParams) GetDescription() (string, bool) {
@@ -1624,6 +1906,12 @@ func (p *CreateLoadBalancerParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateLoadBalancerParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateLoadBalancerParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1637,6 +1925,12 @@ func (p *CreateLoadBalancerParams) SetInstanceport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["instanceport"] = v
+}
+
+func (p *CreateLoadBalancerParams) ResetInstanceport() {
+	if p.p != nil && p.p["instanceport"] != nil {
+		delete(p.p, "instanceport")
+	}
 }
 
 func (p *CreateLoadBalancerParams) GetInstanceport() (int, bool) {
@@ -1654,6 +1948,12 @@ func (p *CreateLoadBalancerParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateLoadBalancerParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateLoadBalancerParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1667,6 +1967,12 @@ func (p *CreateLoadBalancerParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *CreateLoadBalancerParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *CreateLoadBalancerParams) GetNetworkid() (string, bool) {
@@ -1684,6 +1990,12 @@ func (p *CreateLoadBalancerParams) SetScheme(v string) {
 	p.p["scheme"] = v
 }
 
+func (p *CreateLoadBalancerParams) ResetScheme() {
+	if p.p != nil && p.p["scheme"] != nil {
+		delete(p.p, "scheme")
+	}
+}
+
 func (p *CreateLoadBalancerParams) GetScheme() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1697,6 +2009,12 @@ func (p *CreateLoadBalancerParams) SetSourceipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceipaddress"] = v
+}
+
+func (p *CreateLoadBalancerParams) ResetSourceipaddress() {
+	if p.p != nil && p.p["sourceipaddress"] != nil {
+		delete(p.p, "sourceipaddress")
+	}
 }
 
 func (p *CreateLoadBalancerParams) GetSourceipaddress() (string, bool) {
@@ -1714,6 +2032,12 @@ func (p *CreateLoadBalancerParams) SetSourceipaddressnetworkid(v string) {
 	p.p["sourceipaddressnetworkid"] = v
 }
 
+func (p *CreateLoadBalancerParams) ResetSourceipaddressnetworkid() {
+	if p.p != nil && p.p["sourceipaddressnetworkid"] != nil {
+		delete(p.p, "sourceipaddressnetworkid")
+	}
+}
+
 func (p *CreateLoadBalancerParams) GetSourceipaddressnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1727,6 +2051,12 @@ func (p *CreateLoadBalancerParams) SetSourceport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceport"] = v
+}
+
+func (p *CreateLoadBalancerParams) ResetSourceport() {
+	if p.p != nil && p.p["sourceport"] != nil {
+		delete(p.p, "sourceport")
+	}
 }
 
 func (p *CreateLoadBalancerParams) GetSourceport() (int, bool) {
@@ -1887,6 +2217,12 @@ func (p *CreateLoadBalancerRuleParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1900,6 +2236,12 @@ func (p *CreateLoadBalancerRuleParams) SetAlgorithm(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["algorithm"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetAlgorithm() {
+	if p.p != nil && p.p["algorithm"] != nil {
+		delete(p.p, "algorithm")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetAlgorithm() (string, bool) {
@@ -1917,6 +2259,12 @@ func (p *CreateLoadBalancerRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1930,6 +2278,12 @@ func (p *CreateLoadBalancerRuleParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetDescription() (string, bool) {
@@ -1947,6 +2301,12 @@ func (p *CreateLoadBalancerRuleParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1960,6 +2320,12 @@ func (p *CreateLoadBalancerRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetFordisplay() (bool, bool) {
@@ -1977,6 +2343,12 @@ func (p *CreateLoadBalancerRuleParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1990,6 +2362,12 @@ func (p *CreateLoadBalancerRuleParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetNetworkid() (string, bool) {
@@ -2007,6 +2385,12 @@ func (p *CreateLoadBalancerRuleParams) SetOpenfirewall(v bool) {
 	p.p["openfirewall"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetOpenfirewall() {
+	if p.p != nil && p.p["openfirewall"] != nil {
+		delete(p.p, "openfirewall")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetOpenfirewall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2020,6 +2404,12 @@ func (p *CreateLoadBalancerRuleParams) SetPrivateport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privateport"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetPrivateport() {
+	if p.p != nil && p.p["privateport"] != nil {
+		delete(p.p, "privateport")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetPrivateport() (int, bool) {
@@ -2037,6 +2427,12 @@ func (p *CreateLoadBalancerRuleParams) SetProtocol(v string) {
 	p.p["protocol"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetProtocol() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2050,6 +2446,12 @@ func (p *CreateLoadBalancerRuleParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetPublicipid() {
+	if p.p != nil && p.p["publicipid"] != nil {
+		delete(p.p, "publicipid")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetPublicipid() (string, bool) {
@@ -2067,6 +2469,12 @@ func (p *CreateLoadBalancerRuleParams) SetPublicport(v int) {
 	p.p["publicport"] = v
 }
 
+func (p *CreateLoadBalancerRuleParams) ResetPublicport() {
+	if p.p != nil && p.p["publicport"] != nil {
+		delete(p.p, "publicport")
+	}
+}
+
 func (p *CreateLoadBalancerRuleParams) GetPublicport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2080,6 +2488,12 @@ func (p *CreateLoadBalancerRuleParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateLoadBalancerRuleParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateLoadBalancerRuleParams) GetZoneid() (string, bool) {
@@ -2185,6 +2599,12 @@ func (p *DeleteGlobalLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteGlobalLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteGlobalLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2259,6 +2679,12 @@ func (p *DeleteLBHealthCheckPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteLBHealthCheckPolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteLBHealthCheckPolicyParams) GetId() (string, bool) {
@@ -2337,6 +2763,12 @@ func (p *DeleteLBStickinessPolicyParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteLBStickinessPolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteLBStickinessPolicyParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2411,6 +2843,12 @@ func (p *DeleteLoadBalancerParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteLoadBalancerParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteLoadBalancerParams) GetId() (string, bool) {
@@ -2489,6 +2927,12 @@ func (p *DeleteLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2565,6 +3009,12 @@ func (p *DeleteNetscalerLoadBalancerParams) SetLbdeviceid(v string) {
 	p.p["lbdeviceid"] = v
 }
 
+func (p *DeleteNetscalerLoadBalancerParams) ResetLbdeviceid() {
+	if p.p != nil && p.p["lbdeviceid"] != nil {
+		delete(p.p, "lbdeviceid")
+	}
+}
+
 func (p *DeleteNetscalerLoadBalancerParams) GetLbdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2639,6 +3089,12 @@ func (p *DeleteSslCertParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteSslCertParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteSslCertParams) GetId() (string, bool) {
@@ -2768,6 +3224,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListGlobalLoadBalancerRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListGlobalLoadBalancerRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2781,6 +3243,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) GetDomainid() (string, bool) {
@@ -2798,6 +3266,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListGlobalLoadBalancerRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListGlobalLoadBalancerRulesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2811,6 +3285,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) GetIsrecursive() (bool, bool) {
@@ -2828,6 +3308,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListGlobalLoadBalancerRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListGlobalLoadBalancerRulesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2841,6 +3327,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) GetListall() (bool, bool) {
@@ -2858,6 +3350,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListGlobalLoadBalancerRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListGlobalLoadBalancerRulesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2871,6 +3369,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) GetPagesize() (int, bool) {
@@ -2888,6 +3392,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListGlobalLoadBalancerRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListGlobalLoadBalancerRulesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2903,6 +3413,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetRegionid(v int) {
 	p.p["regionid"] = v
 }
 
+func (p *ListGlobalLoadBalancerRulesParams) ResetRegionid() {
+	if p.p != nil && p.p["regionid"] != nil {
+		delete(p.p, "regionid")
+	}
+}
+
 func (p *ListGlobalLoadBalancerRulesParams) GetRegionid() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2916,6 +3432,12 @@ func (p *ListGlobalLoadBalancerRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListGlobalLoadBalancerRulesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListGlobalLoadBalancerRulesParams) GetTags() (map[string]string, bool) {
@@ -3120,6 +3642,12 @@ func (p *ListLBHealthCheckPoliciesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListLBHealthCheckPoliciesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListLBHealthCheckPoliciesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3133,6 +3661,12 @@ func (p *ListLBHealthCheckPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListLBHealthCheckPoliciesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListLBHealthCheckPoliciesParams) GetId() (string, bool) {
@@ -3150,6 +3684,12 @@ func (p *ListLBHealthCheckPoliciesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListLBHealthCheckPoliciesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListLBHealthCheckPoliciesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3163,6 +3703,12 @@ func (p *ListLBHealthCheckPoliciesParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
+}
+
+func (p *ListLBHealthCheckPoliciesParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
 }
 
 func (p *ListLBHealthCheckPoliciesParams) GetLbruleid() (string, bool) {
@@ -3180,6 +3726,12 @@ func (p *ListLBHealthCheckPoliciesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListLBHealthCheckPoliciesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListLBHealthCheckPoliciesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3193,6 +3745,12 @@ func (p *ListLBHealthCheckPoliciesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListLBHealthCheckPoliciesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListLBHealthCheckPoliciesParams) GetPagesize() (int, bool) {
@@ -3327,6 +3885,12 @@ func (p *ListLBStickinessPoliciesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListLBStickinessPoliciesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListLBStickinessPoliciesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3340,6 +3904,12 @@ func (p *ListLBStickinessPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListLBStickinessPoliciesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListLBStickinessPoliciesParams) GetId() (string, bool) {
@@ -3357,6 +3927,12 @@ func (p *ListLBStickinessPoliciesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListLBStickinessPoliciesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListLBStickinessPoliciesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3370,6 +3946,12 @@ func (p *ListLBStickinessPoliciesParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
+}
+
+func (p *ListLBStickinessPoliciesParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
 }
 
 func (p *ListLBStickinessPoliciesParams) GetLbruleid() (string, bool) {
@@ -3387,6 +3969,12 @@ func (p *ListLBStickinessPoliciesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListLBStickinessPoliciesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListLBStickinessPoliciesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3400,6 +3988,12 @@ func (p *ListLBStickinessPoliciesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListLBStickinessPoliciesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListLBStickinessPoliciesParams) GetPagesize() (int, bool) {
@@ -3536,6 +4130,12 @@ func (p *ListLoadBalancerRuleInstancesParams) SetApplied(v bool) {
 	p.p["applied"] = v
 }
 
+func (p *ListLoadBalancerRuleInstancesParams) ResetApplied() {
+	if p.p != nil && p.p["applied"] != nil {
+		delete(p.p, "applied")
+	}
+}
+
 func (p *ListLoadBalancerRuleInstancesParams) GetApplied() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3549,6 +4149,12 @@ func (p *ListLoadBalancerRuleInstancesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) GetId() (string, bool) {
@@ -3566,6 +4172,12 @@ func (p *ListLoadBalancerRuleInstancesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListLoadBalancerRuleInstancesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListLoadBalancerRuleInstancesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3579,6 +4191,12 @@ func (p *ListLoadBalancerRuleInstancesParams) SetLbvmips(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbvmips"] = v
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) ResetLbvmips() {
+	if p.p != nil && p.p["lbvmips"] != nil {
+		delete(p.p, "lbvmips")
+	}
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) GetLbvmips() (bool, bool) {
@@ -3596,6 +4214,12 @@ func (p *ListLoadBalancerRuleInstancesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListLoadBalancerRuleInstancesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListLoadBalancerRuleInstancesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3609,6 +4233,12 @@ func (p *ListLoadBalancerRuleInstancesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListLoadBalancerRuleInstancesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListLoadBalancerRuleInstancesParams) GetPagesize() (int, bool) {
@@ -3765,6 +4395,12 @@ func (p *ListLoadBalancerRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3778,6 +4414,12 @@ func (p *ListLoadBalancerRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetDomainid() (string, bool) {
@@ -3795,6 +4437,12 @@ func (p *ListLoadBalancerRulesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3808,6 +4456,12 @@ func (p *ListLoadBalancerRulesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetId() (string, bool) {
@@ -3825,6 +4479,12 @@ func (p *ListLoadBalancerRulesParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3838,6 +4498,12 @@ func (p *ListLoadBalancerRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetKeyword() (string, bool) {
@@ -3855,6 +4521,12 @@ func (p *ListLoadBalancerRulesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3868,6 +4540,12 @@ func (p *ListLoadBalancerRulesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetName() (string, bool) {
@@ -3885,6 +4563,12 @@ func (p *ListLoadBalancerRulesParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3898,6 +4582,12 @@ func (p *ListLoadBalancerRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetPage() (int, bool) {
@@ -3915,6 +4605,12 @@ func (p *ListLoadBalancerRulesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3928,6 +4624,12 @@ func (p *ListLoadBalancerRulesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetProjectid() (string, bool) {
@@ -3945,6 +4647,12 @@ func (p *ListLoadBalancerRulesParams) SetPublicipid(v string) {
 	p.p["publicipid"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetPublicipid() {
+	if p.p != nil && p.p["publicipid"] != nil {
+		delete(p.p, "publicipid")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetPublicipid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3958,6 +4666,12 @@ func (p *ListLoadBalancerRulesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetTags() (map[string]string, bool) {
@@ -3975,6 +4689,12 @@ func (p *ListLoadBalancerRulesParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *ListLoadBalancerRulesParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *ListLoadBalancerRulesParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3988,6 +4708,12 @@ func (p *ListLoadBalancerRulesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListLoadBalancerRulesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListLoadBalancerRulesParams) GetZoneid() (string, bool) {
@@ -4211,6 +4937,12 @@ func (p *ListLoadBalancersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4224,6 +4956,12 @@ func (p *ListLoadBalancersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetDomainid() (string, bool) {
@@ -4241,6 +4979,12 @@ func (p *ListLoadBalancersParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4254,6 +4998,12 @@ func (p *ListLoadBalancersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetId() (string, bool) {
@@ -4271,6 +5021,12 @@ func (p *ListLoadBalancersParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4284,6 +5040,12 @@ func (p *ListLoadBalancersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetKeyword() (string, bool) {
@@ -4301,6 +5063,12 @@ func (p *ListLoadBalancersParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4314,6 +5082,12 @@ func (p *ListLoadBalancersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetName() (string, bool) {
@@ -4331,6 +5105,12 @@ func (p *ListLoadBalancersParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4344,6 +5124,12 @@ func (p *ListLoadBalancersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetPage() (int, bool) {
@@ -4361,6 +5147,12 @@ func (p *ListLoadBalancersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4374,6 +5166,12 @@ func (p *ListLoadBalancersParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetProjectid() (string, bool) {
@@ -4391,6 +5189,12 @@ func (p *ListLoadBalancersParams) SetScheme(v string) {
 	p.p["scheme"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetScheme() {
+	if p.p != nil && p.p["scheme"] != nil {
+		delete(p.p, "scheme")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetScheme() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4404,6 +5208,12 @@ func (p *ListLoadBalancersParams) SetSourceipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourceipaddress"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetSourceipaddress() {
+	if p.p != nil && p.p["sourceipaddress"] != nil {
+		delete(p.p, "sourceipaddress")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetSourceipaddress() (string, bool) {
@@ -4421,6 +5231,12 @@ func (p *ListLoadBalancersParams) SetSourceipaddressnetworkid(v string) {
 	p.p["sourceipaddressnetworkid"] = v
 }
 
+func (p *ListLoadBalancersParams) ResetSourceipaddressnetworkid() {
+	if p.p != nil && p.p["sourceipaddressnetworkid"] != nil {
+		delete(p.p, "sourceipaddressnetworkid")
+	}
+}
+
 func (p *ListLoadBalancersParams) GetSourceipaddressnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4434,6 +5250,12 @@ func (p *ListLoadBalancersParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListLoadBalancersParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListLoadBalancersParams) GetTags() (map[string]string, bool) {
@@ -4625,6 +5447,12 @@ func (p *ListNetscalerLoadBalancersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetscalerLoadBalancersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetscalerLoadBalancersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4638,6 +5466,12 @@ func (p *ListNetscalerLoadBalancersParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
+}
+
+func (p *ListNetscalerLoadBalancersParams) ResetLbdeviceid() {
+	if p.p != nil && p.p["lbdeviceid"] != nil {
+		delete(p.p, "lbdeviceid")
+	}
 }
 
 func (p *ListNetscalerLoadBalancersParams) GetLbdeviceid() (string, bool) {
@@ -4655,6 +5489,12 @@ func (p *ListNetscalerLoadBalancersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetscalerLoadBalancersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetscalerLoadBalancersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4670,6 +5510,12 @@ func (p *ListNetscalerLoadBalancersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListNetscalerLoadBalancersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListNetscalerLoadBalancersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4683,6 +5529,12 @@ func (p *ListNetscalerLoadBalancersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListNetscalerLoadBalancersParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListNetscalerLoadBalancersParams) GetPhysicalnetworkid() (string, bool) {
@@ -4772,6 +5624,12 @@ func (p *ListSslCertsParams) SetAccountid(v string) {
 	p.p["accountid"] = v
 }
 
+func (p *ListSslCertsParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
+}
+
 func (p *ListSslCertsParams) GetAccountid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4785,6 +5643,12 @@ func (p *ListSslCertsParams) SetCertid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certid"] = v
+}
+
+func (p *ListSslCertsParams) ResetCertid() {
+	if p.p != nil && p.p["certid"] != nil {
+		delete(p.p, "certid")
+	}
 }
 
 func (p *ListSslCertsParams) GetCertid() (string, bool) {
@@ -4802,6 +5666,12 @@ func (p *ListSslCertsParams) SetLbruleid(v string) {
 	p.p["lbruleid"] = v
 }
 
+func (p *ListSslCertsParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
+}
+
 func (p *ListSslCertsParams) GetLbruleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4815,6 +5685,12 @@ func (p *ListSslCertsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListSslCertsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListSslCertsParams) GetProjectid() (string, bool) {
@@ -4889,6 +5765,12 @@ func (p *RemoveCertFromLoadBalancerParams) SetLbruleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbruleid"] = v
+}
+
+func (p *RemoveCertFromLoadBalancerParams) ResetLbruleid() {
+	if p.p != nil && p.p["lbruleid"] != nil {
+		delete(p.p, "lbruleid")
+	}
 }
 
 func (p *RemoveCertFromLoadBalancerParams) GetLbruleid() (string, bool) {
@@ -4971,6 +5853,12 @@ func (p *RemoveFromGlobalLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RemoveFromGlobalLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RemoveFromGlobalLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4984,6 +5872,12 @@ func (p *RemoveFromGlobalLoadBalancerRuleParams) SetLoadbalancerrulelist(v []str
 		p.p = make(map[string]interface{})
 	}
 	p.p["loadbalancerrulelist"] = v
+}
+
+func (p *RemoveFromGlobalLoadBalancerRuleParams) ResetLoadbalancerrulelist() {
+	if p.p != nil && p.p["loadbalancerrulelist"] != nil {
+		delete(p.p, "loadbalancerrulelist")
+	}
 }
 
 func (p *RemoveFromGlobalLoadBalancerRuleParams) GetLoadbalancerrulelist() ([]string, bool) {
@@ -5074,6 +5968,12 @@ func (p *RemoveFromLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RemoveFromLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RemoveFromLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5089,6 +5989,12 @@ func (p *RemoveFromLoadBalancerRuleParams) SetVirtualmachineids(v []string) {
 	p.p["virtualmachineids"] = v
 }
 
+func (p *RemoveFromLoadBalancerRuleParams) ResetVirtualmachineids() {
+	if p.p != nil && p.p["virtualmachineids"] != nil {
+		delete(p.p, "virtualmachineids")
+	}
+}
+
 func (p *RemoveFromLoadBalancerRuleParams) GetVirtualmachineids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5102,6 +6008,12 @@ func (p *RemoveFromLoadBalancerRuleParams) SetVmidipmap(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmidipmap"] = v
+}
+
+func (p *RemoveFromLoadBalancerRuleParams) ResetVmidipmap() {
+	if p.p != nil && p.p["vmidipmap"] != nil {
+		delete(p.p, "vmidipmap")
+	}
 }
 
 func (p *RemoveFromLoadBalancerRuleParams) GetVmidipmap() (map[string]string, bool) {
@@ -5189,6 +6101,12 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *UpdateGlobalLoadBalancerRuleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *UpdateGlobalLoadBalancerRuleParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5202,6 +6120,12 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetGslblbmethod(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gslblbmethod"] = v
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) ResetGslblbmethod() {
+	if p.p != nil && p.p["gslblbmethod"] != nil {
+		delete(p.p, "gslblbmethod")
+	}
 }
 
 func (p *UpdateGlobalLoadBalancerRuleParams) GetGslblbmethod() (string, bool) {
@@ -5219,6 +6143,12 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetGslbstickysessionmethodname(v st
 	p.p["gslbstickysessionmethodname"] = v
 }
 
+func (p *UpdateGlobalLoadBalancerRuleParams) ResetGslbstickysessionmethodname() {
+	if p.p != nil && p.p["gslbstickysessionmethodname"] != nil {
+		delete(p.p, "gslbstickysessionmethodname")
+	}
+}
+
 func (p *UpdateGlobalLoadBalancerRuleParams) GetGslbstickysessionmethodname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5232,6 +6162,12 @@ func (p *UpdateGlobalLoadBalancerRuleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateGlobalLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateGlobalLoadBalancerRuleParams) GetId() (string, bool) {
@@ -5358,6 +6294,12 @@ func (p *UpdateLBHealthCheckPolicyParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateLBHealthCheckPolicyParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateLBHealthCheckPolicyParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5373,6 +6315,12 @@ func (p *UpdateLBHealthCheckPolicyParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateLBHealthCheckPolicyParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateLBHealthCheckPolicyParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5386,6 +6334,12 @@ func (p *UpdateLBHealthCheckPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateLBHealthCheckPolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateLBHealthCheckPolicyParams) GetId() (string, bool) {
@@ -5492,6 +6446,12 @@ func (p *UpdateLBStickinessPolicyParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateLBStickinessPolicyParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateLBStickinessPolicyParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5507,6 +6467,12 @@ func (p *UpdateLBStickinessPolicyParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateLBStickinessPolicyParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateLBStickinessPolicyParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5520,6 +6486,12 @@ func (p *UpdateLBStickinessPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateLBStickinessPolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateLBStickinessPolicyParams) GetId() (string, bool) {
@@ -5627,6 +6599,12 @@ func (p *UpdateLoadBalancerParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateLoadBalancerParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateLoadBalancerParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5642,6 +6620,12 @@ func (p *UpdateLoadBalancerParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateLoadBalancerParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateLoadBalancerParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5655,6 +6639,12 @@ func (p *UpdateLoadBalancerParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateLoadBalancerParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateLoadBalancerParams) GetId() (string, bool) {
@@ -5784,6 +6774,12 @@ func (p *UpdateLoadBalancerRuleParams) SetAlgorithm(v string) {
 	p.p["algorithm"] = v
 }
 
+func (p *UpdateLoadBalancerRuleParams) ResetAlgorithm() {
+	if p.p != nil && p.p["algorithm"] != nil {
+		delete(p.p, "algorithm")
+	}
+}
+
 func (p *UpdateLoadBalancerRuleParams) GetAlgorithm() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5797,6 +6793,12 @@ func (p *UpdateLoadBalancerRuleParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
+}
+
+func (p *UpdateLoadBalancerRuleParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
 }
 
 func (p *UpdateLoadBalancerRuleParams) GetCustomid() (string, bool) {
@@ -5814,6 +6816,12 @@ func (p *UpdateLoadBalancerRuleParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *UpdateLoadBalancerRuleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *UpdateLoadBalancerRuleParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5827,6 +6835,12 @@ func (p *UpdateLoadBalancerRuleParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *UpdateLoadBalancerRuleParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *UpdateLoadBalancerRuleParams) GetFordisplay() (bool, bool) {
@@ -5844,6 +6858,12 @@ func (p *UpdateLoadBalancerRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateLoadBalancerRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateLoadBalancerRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5859,6 +6879,12 @@ func (p *UpdateLoadBalancerRuleParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateLoadBalancerRuleParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateLoadBalancerRuleParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5872,6 +6898,12 @@ func (p *UpdateLoadBalancerRuleParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *UpdateLoadBalancerRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *UpdateLoadBalancerRuleParams) GetProtocol() (string, bool) {
@@ -5999,6 +7031,12 @@ func (p *UploadSslCertParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UploadSslCertParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UploadSslCertParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6012,6 +7050,12 @@ func (p *UploadSslCertParams) SetCertchain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["certchain"] = v
+}
+
+func (p *UploadSslCertParams) ResetCertchain() {
+	if p.p != nil && p.p["certchain"] != nil {
+		delete(p.p, "certchain")
+	}
 }
 
 func (p *UploadSslCertParams) GetCertchain() (string, bool) {
@@ -6029,6 +7073,12 @@ func (p *UploadSslCertParams) SetCertificate(v string) {
 	p.p["certificate"] = v
 }
 
+func (p *UploadSslCertParams) ResetCertificate() {
+	if p.p != nil && p.p["certificate"] != nil {
+		delete(p.p, "certificate")
+	}
+}
+
 func (p *UploadSslCertParams) GetCertificate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6042,6 +7092,12 @@ func (p *UploadSslCertParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UploadSslCertParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UploadSslCertParams) GetDomainid() (string, bool) {
@@ -6059,6 +7115,12 @@ func (p *UploadSslCertParams) SetEnabledrevocationcheck(v bool) {
 	p.p["enabledrevocationcheck"] = v
 }
 
+func (p *UploadSslCertParams) ResetEnabledrevocationcheck() {
+	if p.p != nil && p.p["enabledrevocationcheck"] != nil {
+		delete(p.p, "enabledrevocationcheck")
+	}
+}
+
 func (p *UploadSslCertParams) GetEnabledrevocationcheck() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6072,6 +7134,12 @@ func (p *UploadSslCertParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UploadSslCertParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UploadSslCertParams) GetName() (string, bool) {
@@ -6089,6 +7157,12 @@ func (p *UploadSslCertParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *UploadSslCertParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *UploadSslCertParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6104,6 +7178,12 @@ func (p *UploadSslCertParams) SetPrivatekey(v string) {
 	p.p["privatekey"] = v
 }
 
+func (p *UploadSslCertParams) ResetPrivatekey() {
+	if p.p != nil && p.p["privatekey"] != nil {
+		delete(p.p, "privatekey")
+	}
+}
+
 func (p *UploadSslCertParams) GetPrivatekey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6117,6 +7197,12 @@ func (p *UploadSslCertParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *UploadSslCertParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *UploadSslCertParams) GetProjectid() (string, bool) {

--- a/cloudstack/NATService.go
+++ b/cloudstack/NATService.go
@@ -82,6 +82,12 @@ func (p *CreateIpForwardingRuleParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreateIpForwardingRuleParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreateIpForwardingRuleParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -95,6 +101,12 @@ func (p *CreateIpForwardingRuleParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
+}
+
+func (p *CreateIpForwardingRuleParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
 }
 
 func (p *CreateIpForwardingRuleParams) GetEndport() (int, bool) {
@@ -112,6 +124,12 @@ func (p *CreateIpForwardingRuleParams) SetIpaddressid(v string) {
 	p.p["ipaddressid"] = v
 }
 
+func (p *CreateIpForwardingRuleParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
+}
+
 func (p *CreateIpForwardingRuleParams) GetIpaddressid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -125,6 +143,12 @@ func (p *CreateIpForwardingRuleParams) SetOpenfirewall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["openfirewall"] = v
+}
+
+func (p *CreateIpForwardingRuleParams) ResetOpenfirewall() {
+	if p.p != nil && p.p["openfirewall"] != nil {
+		delete(p.p, "openfirewall")
+	}
 }
 
 func (p *CreateIpForwardingRuleParams) GetOpenfirewall() (bool, bool) {
@@ -142,6 +166,12 @@ func (p *CreateIpForwardingRuleParams) SetProtocol(v string) {
 	p.p["protocol"] = v
 }
 
+func (p *CreateIpForwardingRuleParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
+}
+
 func (p *CreateIpForwardingRuleParams) GetProtocol() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -155,6 +185,12 @@ func (p *CreateIpForwardingRuleParams) SetStartport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startport"] = v
+}
+
+func (p *CreateIpForwardingRuleParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
 }
 
 func (p *CreateIpForwardingRuleParams) GetStartport() (int, bool) {
@@ -255,6 +291,12 @@ func (p *DeleteIpForwardingRuleParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteIpForwardingRuleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteIpForwardingRuleParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -329,6 +371,12 @@ func (p *DisableStaticNatParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
+}
+
+func (p *DisableStaticNatParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
 }
 
 func (p *DisableStaticNatParams) GetIpaddressid() (string, bool) {
@@ -416,6 +464,12 @@ func (p *EnableStaticNatParams) SetIpaddressid(v string) {
 	p.p["ipaddressid"] = v
 }
 
+func (p *EnableStaticNatParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
+}
+
 func (p *EnableStaticNatParams) GetIpaddressid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -429,6 +483,12 @@ func (p *EnableStaticNatParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *EnableStaticNatParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *EnableStaticNatParams) GetNetworkid() (string, bool) {
@@ -446,6 +506,12 @@ func (p *EnableStaticNatParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *EnableStaticNatParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *EnableStaticNatParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -459,6 +525,12 @@ func (p *EnableStaticNatParams) SetVmguestip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmguestip"] = v
+}
+
+func (p *EnableStaticNatParams) ResetVmguestip() {
+	if p.p != nil && p.p["vmguestip"] != nil {
+		delete(p.p, "vmguestip")
+	}
 }
 
 func (p *EnableStaticNatParams) GetVmguestip() (string, bool) {
@@ -584,6 +656,12 @@ func (p *ListIpForwardingRulesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListIpForwardingRulesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListIpForwardingRulesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -597,6 +675,12 @@ func (p *ListIpForwardingRulesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListIpForwardingRulesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListIpForwardingRulesParams) GetDomainid() (string, bool) {
@@ -614,6 +698,12 @@ func (p *ListIpForwardingRulesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListIpForwardingRulesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListIpForwardingRulesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -627,6 +717,12 @@ func (p *ListIpForwardingRulesParams) SetIpaddressid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddressid"] = v
+}
+
+func (p *ListIpForwardingRulesParams) ResetIpaddressid() {
+	if p.p != nil && p.p["ipaddressid"] != nil {
+		delete(p.p, "ipaddressid")
+	}
 }
 
 func (p *ListIpForwardingRulesParams) GetIpaddressid() (string, bool) {
@@ -644,6 +740,12 @@ func (p *ListIpForwardingRulesParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListIpForwardingRulesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListIpForwardingRulesParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -657,6 +759,12 @@ func (p *ListIpForwardingRulesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListIpForwardingRulesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListIpForwardingRulesParams) GetKeyword() (string, bool) {
@@ -674,6 +782,12 @@ func (p *ListIpForwardingRulesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListIpForwardingRulesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListIpForwardingRulesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -687,6 +801,12 @@ func (p *ListIpForwardingRulesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListIpForwardingRulesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListIpForwardingRulesParams) GetPage() (int, bool) {
@@ -704,6 +824,12 @@ func (p *ListIpForwardingRulesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListIpForwardingRulesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListIpForwardingRulesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -719,6 +845,12 @@ func (p *ListIpForwardingRulesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListIpForwardingRulesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListIpForwardingRulesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -732,6 +864,12 @@ func (p *ListIpForwardingRulesParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *ListIpForwardingRulesParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *ListIpForwardingRulesParams) GetVirtualmachineid() (string, bool) {

--- a/cloudstack/NetworkACLService.go
+++ b/cloudstack/NetworkACLService.go
@@ -117,6 +117,12 @@ func (p *CreateNetworkACLParams) SetAclid(v string) {
 	p.p["aclid"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetAclid() {
+	if p.p != nil && p.p["aclid"] != nil {
+		delete(p.p, "aclid")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetAclid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -130,6 +136,12 @@ func (p *CreateNetworkACLParams) SetAction(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["action"] = v
+}
+
+func (p *CreateNetworkACLParams) ResetAction() {
+	if p.p != nil && p.p["action"] != nil {
+		delete(p.p, "action")
+	}
 }
 
 func (p *CreateNetworkACLParams) GetAction() (string, bool) {
@@ -147,6 +159,12 @@ func (p *CreateNetworkACLParams) SetCidrlist(v []string) {
 	p.p["cidrlist"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetCidrlist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -160,6 +178,12 @@ func (p *CreateNetworkACLParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
+}
+
+func (p *CreateNetworkACLParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
 }
 
 func (p *CreateNetworkACLParams) GetEndport() (int, bool) {
@@ -177,6 +201,12 @@ func (p *CreateNetworkACLParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -190,6 +220,12 @@ func (p *CreateNetworkACLParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
+}
+
+func (p *CreateNetworkACLParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
 }
 
 func (p *CreateNetworkACLParams) GetIcmpcode() (int, bool) {
@@ -207,6 +243,12 @@ func (p *CreateNetworkACLParams) SetIcmptype(v int) {
 	p.p["icmptype"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetIcmptype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -220,6 +262,12 @@ func (p *CreateNetworkACLParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *CreateNetworkACLParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *CreateNetworkACLParams) GetNetworkid() (string, bool) {
@@ -237,6 +285,12 @@ func (p *CreateNetworkACLParams) SetNumber(v int) {
 	p.p["number"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetNumber() {
+	if p.p != nil && p.p["number"] != nil {
+		delete(p.p, "number")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetNumber() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -250,6 +304,12 @@ func (p *CreateNetworkACLParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *CreateNetworkACLParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *CreateNetworkACLParams) GetProtocol() (string, bool) {
@@ -267,6 +327,12 @@ func (p *CreateNetworkACLParams) SetReason(v string) {
 	p.p["reason"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetReason() {
+	if p.p != nil && p.p["reason"] != nil {
+		delete(p.p, "reason")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetReason() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -282,6 +348,12 @@ func (p *CreateNetworkACLParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *CreateNetworkACLParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *CreateNetworkACLParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -295,6 +367,12 @@ func (p *CreateNetworkACLParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *CreateNetworkACLParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *CreateNetworkACLParams) GetTraffictype() (string, bool) {
@@ -402,6 +480,12 @@ func (p *CreateNetworkACLListParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateNetworkACLListParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateNetworkACLListParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -415,6 +499,12 @@ func (p *CreateNetworkACLListParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *CreateNetworkACLListParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *CreateNetworkACLListParams) GetFordisplay() (bool, bool) {
@@ -432,6 +522,12 @@ func (p *CreateNetworkACLListParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateNetworkACLListParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateNetworkACLListParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -445,6 +541,12 @@ func (p *CreateNetworkACLListParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *CreateNetworkACLListParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *CreateNetworkACLListParams) GetVpcid() (string, bool) {
@@ -533,6 +635,12 @@ func (p *DeleteNetworkACLParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteNetworkACLParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteNetworkACLParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -607,6 +715,12 @@ func (p *DeleteNetworkACLListParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteNetworkACLListParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteNetworkACLListParams) GetId() (string, bool) {
@@ -726,6 +840,12 @@ func (p *ListNetworkACLListsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -739,6 +859,12 @@ func (p *ListNetworkACLListsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListNetworkACLListsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListNetworkACLListsParams) GetDomainid() (string, bool) {
@@ -756,6 +882,12 @@ func (p *ListNetworkACLListsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -769,6 +901,12 @@ func (p *ListNetworkACLListsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListNetworkACLListsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListNetworkACLListsParams) GetId() (string, bool) {
@@ -786,6 +924,12 @@ func (p *ListNetworkACLListsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -799,6 +943,12 @@ func (p *ListNetworkACLListsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListNetworkACLListsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListNetworkACLListsParams) GetKeyword() (string, bool) {
@@ -816,6 +966,12 @@ func (p *ListNetworkACLListsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -829,6 +985,12 @@ func (p *ListNetworkACLListsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListNetworkACLListsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListNetworkACLListsParams) GetName() (string, bool) {
@@ -846,6 +1008,12 @@ func (p *ListNetworkACLListsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -859,6 +1027,12 @@ func (p *ListNetworkACLListsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListNetworkACLListsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListNetworkACLListsParams) GetPage() (int, bool) {
@@ -876,6 +1050,12 @@ func (p *ListNetworkACLListsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -891,6 +1071,12 @@ func (p *ListNetworkACLListsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListNetworkACLListsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListNetworkACLListsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -904,6 +1090,12 @@ func (p *ListNetworkACLListsParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *ListNetworkACLListsParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *ListNetworkACLListsParams) GetVpcid() (string, bool) {
@@ -1112,6 +1304,12 @@ func (p *ListNetworkACLsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1125,6 +1323,12 @@ func (p *ListNetworkACLsParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetAclid() {
+	if p.p != nil && p.p["aclid"] != nil {
+		delete(p.p, "aclid")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetAclid() (string, bool) {
@@ -1142,6 +1346,12 @@ func (p *ListNetworkACLsParams) SetAction(v string) {
 	p.p["action"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetAction() {
+	if p.p != nil && p.p["action"] != nil {
+		delete(p.p, "action")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetAction() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1155,6 +1365,12 @@ func (p *ListNetworkACLsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetDomainid() (string, bool) {
@@ -1172,6 +1388,12 @@ func (p *ListNetworkACLsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1185,6 +1407,12 @@ func (p *ListNetworkACLsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetId() (string, bool) {
@@ -1202,6 +1430,12 @@ func (p *ListNetworkACLsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1215,6 +1449,12 @@ func (p *ListNetworkACLsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetKeyword() (string, bool) {
@@ -1232,6 +1472,12 @@ func (p *ListNetworkACLsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1245,6 +1491,12 @@ func (p *ListNetworkACLsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetNetworkid() (string, bool) {
@@ -1262,6 +1514,12 @@ func (p *ListNetworkACLsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1275,6 +1533,12 @@ func (p *ListNetworkACLsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetPagesize() (int, bool) {
@@ -1292,6 +1556,12 @@ func (p *ListNetworkACLsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1305,6 +1575,12 @@ func (p *ListNetworkACLsParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetProtocol() (string, bool) {
@@ -1322,6 +1598,12 @@ func (p *ListNetworkACLsParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListNetworkACLsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListNetworkACLsParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1335,6 +1617,12 @@ func (p *ListNetworkACLsParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *ListNetworkACLsParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *ListNetworkACLsParams) GetTraffictype() (string, bool) {
@@ -1455,6 +1743,12 @@ func (p *ReplaceNetworkACLListParams) SetAclid(v string) {
 	p.p["aclid"] = v
 }
 
+func (p *ReplaceNetworkACLListParams) ResetAclid() {
+	if p.p != nil && p.p["aclid"] != nil {
+		delete(p.p, "aclid")
+	}
+}
+
 func (p *ReplaceNetworkACLListParams) GetAclid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1470,6 +1764,12 @@ func (p *ReplaceNetworkACLListParams) SetGatewayid(v string) {
 	p.p["gatewayid"] = v
 }
 
+func (p *ReplaceNetworkACLListParams) ResetGatewayid() {
+	if p.p != nil && p.p["gatewayid"] != nil {
+		delete(p.p, "gatewayid")
+	}
+}
+
 func (p *ReplaceNetworkACLListParams) GetGatewayid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1483,6 +1783,12 @@ func (p *ReplaceNetworkACLListParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ReplaceNetworkACLListParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ReplaceNetworkACLListParams) GetNetworkid() (string, bool) {
@@ -1608,6 +1914,12 @@ func (p *UpdateNetworkACLItemParams) SetAction(v string) {
 	p.p["action"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetAction() {
+	if p.p != nil && p.p["action"] != nil {
+		delete(p.p, "action")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetAction() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1621,6 +1933,12 @@ func (p *UpdateNetworkACLItemParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetCidrlist() ([]string, bool) {
@@ -1638,6 +1956,12 @@ func (p *UpdateNetworkACLItemParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1651,6 +1975,12 @@ func (p *UpdateNetworkACLItemParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetEndport() (int, bool) {
@@ -1668,6 +1998,12 @@ func (p *UpdateNetworkACLItemParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1681,6 +2017,12 @@ func (p *UpdateNetworkACLItemParams) SetIcmpcode(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmpcode"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetIcmpcode() (int, bool) {
@@ -1698,6 +2040,12 @@ func (p *UpdateNetworkACLItemParams) SetIcmptype(v int) {
 	p.p["icmptype"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetIcmptype() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1711,6 +2059,12 @@ func (p *UpdateNetworkACLItemParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetId() (string, bool) {
@@ -1728,6 +2082,12 @@ func (p *UpdateNetworkACLItemParams) SetNumber(v int) {
 	p.p["number"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetNumber() {
+	if p.p != nil && p.p["number"] != nil {
+		delete(p.p, "number")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetNumber() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1741,6 +2101,12 @@ func (p *UpdateNetworkACLItemParams) SetPartialupgrade(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["partialupgrade"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetPartialupgrade() {
+	if p.p != nil && p.p["partialupgrade"] != nil {
+		delete(p.p, "partialupgrade")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetPartialupgrade() (bool, bool) {
@@ -1758,6 +2124,12 @@ func (p *UpdateNetworkACLItemParams) SetProtocol(v string) {
 	p.p["protocol"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetProtocol() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1771,6 +2143,12 @@ func (p *UpdateNetworkACLItemParams) SetReason(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["reason"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetReason() {
+	if p.p != nil && p.p["reason"] != nil {
+		delete(p.p, "reason")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetReason() (string, bool) {
@@ -1788,6 +2166,12 @@ func (p *UpdateNetworkACLItemParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *UpdateNetworkACLItemParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *UpdateNetworkACLItemParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1801,6 +2185,12 @@ func (p *UpdateNetworkACLItemParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *UpdateNetworkACLItemParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *UpdateNetworkACLItemParams) GetTraffictype() (string, bool) {
@@ -1911,6 +2301,12 @@ func (p *UpdateNetworkACLListParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateNetworkACLListParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateNetworkACLListParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1924,6 +2320,12 @@ func (p *UpdateNetworkACLListParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *UpdateNetworkACLListParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *UpdateNetworkACLListParams) GetDescription() (string, bool) {
@@ -1941,6 +2343,12 @@ func (p *UpdateNetworkACLListParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateNetworkACLListParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateNetworkACLListParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1956,6 +2364,12 @@ func (p *UpdateNetworkACLListParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateNetworkACLListParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateNetworkACLListParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1969,6 +2383,12 @@ func (p *UpdateNetworkACLListParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateNetworkACLListParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateNetworkACLListParams) GetName() (string, bool) {

--- a/cloudstack/NetworkDeviceService.go
+++ b/cloudstack/NetworkDeviceService.go
@@ -64,6 +64,12 @@ func (p *AddNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]stri
 	p.p["networkdeviceparameterlist"] = v
 }
 
+func (p *AddNetworkDeviceParams) ResetNetworkdeviceparameterlist() {
+	if p.p != nil && p.p["networkdeviceparameterlist"] != nil {
+		delete(p.p, "networkdeviceparameterlist")
+	}
+}
+
 func (p *AddNetworkDeviceParams) GetNetworkdeviceparameterlist() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -77,6 +83,12 @@ func (p *AddNetworkDeviceParams) SetNetworkdevicetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdevicetype"] = v
+}
+
+func (p *AddNetworkDeviceParams) ResetNetworkdevicetype() {
+	if p.p != nil && p.p["networkdevicetype"] != nil {
+		delete(p.p, "networkdevicetype")
+	}
 }
 
 func (p *AddNetworkDeviceParams) GetNetworkdevicetype() (string, bool) {
@@ -136,6 +148,12 @@ func (p *DeleteNetworkDeviceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteNetworkDeviceParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteNetworkDeviceParams) GetId() (string, bool) {
@@ -244,6 +262,12 @@ func (p *ListNetworkDeviceParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetworkDeviceParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetworkDeviceParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -257,6 +281,12 @@ func (p *ListNetworkDeviceParams) SetNetworkdeviceparameterlist(v map[string]str
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdeviceparameterlist"] = v
+}
+
+func (p *ListNetworkDeviceParams) ResetNetworkdeviceparameterlist() {
+	if p.p != nil && p.p["networkdeviceparameterlist"] != nil {
+		delete(p.p, "networkdeviceparameterlist")
+	}
 }
 
 func (p *ListNetworkDeviceParams) GetNetworkdeviceparameterlist() (map[string]string, bool) {
@@ -274,6 +304,12 @@ func (p *ListNetworkDeviceParams) SetNetworkdevicetype(v string) {
 	p.p["networkdevicetype"] = v
 }
 
+func (p *ListNetworkDeviceParams) ResetNetworkdevicetype() {
+	if p.p != nil && p.p["networkdevicetype"] != nil {
+		delete(p.p, "networkdevicetype")
+	}
+}
+
 func (p *ListNetworkDeviceParams) GetNetworkdevicetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -289,6 +325,12 @@ func (p *ListNetworkDeviceParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetworkDeviceParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetworkDeviceParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -302,6 +344,12 @@ func (p *ListNetworkDeviceParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNetworkDeviceParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNetworkDeviceParams) GetPagesize() (int, bool) {

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -160,6 +160,12 @@ func (p *CreateNetworkOfferingParams) SetAvailability(v string) {
 	p.p["availability"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetAvailability() {
+	if p.p != nil && p.p["availability"] != nil {
+		delete(p.p, "availability")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetAvailability() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -173,6 +179,12 @@ func (p *CreateNetworkOfferingParams) SetConservemode(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["conservemode"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetConservemode() {
+	if p.p != nil && p.p["conservemode"] != nil {
+		delete(p.p, "conservemode")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetConservemode() (bool, bool) {
@@ -190,6 +202,12 @@ func (p *CreateNetworkOfferingParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -203,6 +221,12 @@ func (p *CreateNetworkOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetDisplaytext() (string, bool) {
@@ -220,6 +244,12 @@ func (p *CreateNetworkOfferingParams) SetDomainid(v []string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetDomainid() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -233,6 +263,12 @@ func (p *CreateNetworkOfferingParams) SetEgressdefaultpolicy(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["egressdefaultpolicy"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetEgressdefaultpolicy() {
+	if p.p != nil && p.p["egressdefaultpolicy"] != nil {
+		delete(p.p, "egressdefaultpolicy")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetEgressdefaultpolicy() (bool, bool) {
@@ -250,6 +286,12 @@ func (p *CreateNetworkOfferingParams) SetEnable(v bool) {
 	p.p["enable"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetEnable() {
+	if p.p != nil && p.p["enable"] != nil {
+		delete(p.p, "enable")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetEnable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -263,6 +305,12 @@ func (p *CreateNetworkOfferingParams) SetFortungsten(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fortungsten"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetFortungsten() {
+	if p.p != nil && p.p["fortungsten"] != nil {
+		delete(p.p, "fortungsten")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetFortungsten() (bool, bool) {
@@ -280,6 +328,12 @@ func (p *CreateNetworkOfferingParams) SetForvpc(v bool) {
 	p.p["forvpc"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetForvpc() {
+	if p.p != nil && p.p["forvpc"] != nil {
+		delete(p.p, "forvpc")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetForvpc() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -293,6 +347,12 @@ func (p *CreateNetworkOfferingParams) SetGuestiptype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestiptype"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetGuestiptype() {
+	if p.p != nil && p.p["guestiptype"] != nil {
+		delete(p.p, "guestiptype")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetGuestiptype() (string, bool) {
@@ -310,6 +370,12 @@ func (p *CreateNetworkOfferingParams) SetInternetprotocol(v string) {
 	p.p["internetprotocol"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetInternetprotocol() {
+	if p.p != nil && p.p["internetprotocol"] != nil {
+		delete(p.p, "internetprotocol")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetInternetprotocol() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -323,6 +389,12 @@ func (p *CreateNetworkOfferingParams) SetIspersistent(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispersistent"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetIspersistent() {
+	if p.p != nil && p.p["ispersistent"] != nil {
+		delete(p.p, "ispersistent")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetIspersistent() (bool, bool) {
@@ -340,6 +412,12 @@ func (p *CreateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
 	p.p["keepaliveenabled"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetKeepaliveenabled() {
+	if p.p != nil && p.p["keepaliveenabled"] != nil {
+		delete(p.p, "keepaliveenabled")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetKeepaliveenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -353,6 +431,12 @@ func (p *CreateNetworkOfferingParams) SetMaxconnections(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxconnections"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetMaxconnections() {
+	if p.p != nil && p.p["maxconnections"] != nil {
+		delete(p.p, "maxconnections")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetMaxconnections() (int, bool) {
@@ -370,6 +454,12 @@ func (p *CreateNetworkOfferingParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -383,6 +473,12 @@ func (p *CreateNetworkOfferingParams) SetNetworkrate(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkrate"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetNetworkrate() {
+	if p.p != nil && p.p["networkrate"] != nil {
+		delete(p.p, "networkrate")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetNetworkrate() (int, bool) {
@@ -400,6 +496,12 @@ func (p *CreateNetworkOfferingParams) SetServicecapabilitylist(v map[string]stri
 	p.p["servicecapabilitylist"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetServicecapabilitylist() {
+	if p.p != nil && p.p["servicecapabilitylist"] != nil {
+		delete(p.p, "servicecapabilitylist")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetServicecapabilitylist() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -413,6 +515,12 @@ func (p *CreateNetworkOfferingParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetServiceofferingid() (string, bool) {
@@ -430,6 +538,12 @@ func (p *CreateNetworkOfferingParams) SetServiceproviderlist(v map[string]string
 	p.p["serviceproviderlist"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetServiceproviderlist() {
+	if p.p != nil && p.p["serviceproviderlist"] != nil {
+		delete(p.p, "serviceproviderlist")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetServiceproviderlist() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -443,6 +557,12 @@ func (p *CreateNetworkOfferingParams) SetSpecifyipranges(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyipranges"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetSpecifyipranges() {
+	if p.p != nil && p.p["specifyipranges"] != nil {
+		delete(p.p, "specifyipranges")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetSpecifyipranges() (bool, bool) {
@@ -460,6 +580,12 @@ func (p *CreateNetworkOfferingParams) SetSpecifyvlan(v bool) {
 	p.p["specifyvlan"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetSpecifyvlan() {
+	if p.p != nil && p.p["specifyvlan"] != nil {
+		delete(p.p, "specifyvlan")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetSpecifyvlan() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -473,6 +599,12 @@ func (p *CreateNetworkOfferingParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetSupportedservices() {
+	if p.p != nil && p.p["supportedservices"] != nil {
+		delete(p.p, "supportedservices")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetSupportedservices() ([]string, bool) {
@@ -490,6 +622,12 @@ func (p *CreateNetworkOfferingParams) SetTags(v string) {
 	p.p["tags"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetTags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -505,6 +643,12 @@ func (p *CreateNetworkOfferingParams) SetTraffictype(v string) {
 	p.p["traffictype"] = v
 }
 
+func (p *CreateNetworkOfferingParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
+}
+
 func (p *CreateNetworkOfferingParams) GetTraffictype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -518,6 +662,12 @@ func (p *CreateNetworkOfferingParams) SetZoneid(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateNetworkOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateNetworkOfferingParams) GetZoneid() ([]string, bool) {
@@ -636,6 +786,12 @@ func (p *DeleteNetworkOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteNetworkOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteNetworkOfferingParams) GetId() (string, bool) {
@@ -795,6 +951,12 @@ func (p *ListNetworkOfferingsParams) SetAvailability(v string) {
 	p.p["availability"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetAvailability() {
+	if p.p != nil && p.p["availability"] != nil {
+		delete(p.p, "availability")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetAvailability() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -808,6 +970,12 @@ func (p *ListNetworkOfferingsParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetDisplaytext() (string, bool) {
@@ -825,6 +993,12 @@ func (p *ListNetworkOfferingsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -838,6 +1012,12 @@ func (p *ListNetworkOfferingsParams) SetForvpc(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvpc"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetForvpc() {
+	if p.p != nil && p.p["forvpc"] != nil {
+		delete(p.p, "forvpc")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetForvpc() (bool, bool) {
@@ -855,6 +1035,12 @@ func (p *ListNetworkOfferingsParams) SetGuestiptype(v string) {
 	p.p["guestiptype"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetGuestiptype() {
+	if p.p != nil && p.p["guestiptype"] != nil {
+		delete(p.p, "guestiptype")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetGuestiptype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -868,6 +1054,12 @@ func (p *ListNetworkOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetId() (string, bool) {
@@ -885,6 +1077,12 @@ func (p *ListNetworkOfferingsParams) SetIsdefault(v bool) {
 	p.p["isdefault"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetIsdefault() {
+	if p.p != nil && p.p["isdefault"] != nil {
+		delete(p.p, "isdefault")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetIsdefault() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -898,6 +1096,12 @@ func (p *ListNetworkOfferingsParams) SetIstagged(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["istagged"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetIstagged() {
+	if p.p != nil && p.p["istagged"] != nil {
+		delete(p.p, "istagged")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetIstagged() (bool, bool) {
@@ -915,6 +1119,12 @@ func (p *ListNetworkOfferingsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -928,6 +1138,12 @@ func (p *ListNetworkOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetName() (string, bool) {
@@ -945,6 +1161,12 @@ func (p *ListNetworkOfferingsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -958,6 +1180,12 @@ func (p *ListNetworkOfferingsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetPage() (int, bool) {
@@ -975,6 +1203,12 @@ func (p *ListNetworkOfferingsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -988,6 +1222,12 @@ func (p *ListNetworkOfferingsParams) SetSourcenatsupported(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcenatsupported"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetSourcenatsupported() {
+	if p.p != nil && p.p["sourcenatsupported"] != nil {
+		delete(p.p, "sourcenatsupported")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetSourcenatsupported() (bool, bool) {
@@ -1005,6 +1245,12 @@ func (p *ListNetworkOfferingsParams) SetSpecifyipranges(v bool) {
 	p.p["specifyipranges"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetSpecifyipranges() {
+	if p.p != nil && p.p["specifyipranges"] != nil {
+		delete(p.p, "specifyipranges")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetSpecifyipranges() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1018,6 +1264,12 @@ func (p *ListNetworkOfferingsParams) SetSpecifyvlan(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyvlan"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetSpecifyvlan() {
+	if p.p != nil && p.p["specifyvlan"] != nil {
+		delete(p.p, "specifyvlan")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetSpecifyvlan() (bool, bool) {
@@ -1035,6 +1287,12 @@ func (p *ListNetworkOfferingsParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1048,6 +1306,12 @@ func (p *ListNetworkOfferingsParams) SetSupportedservices(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["supportedservices"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetSupportedservices() {
+	if p.p != nil && p.p["supportedservices"] != nil {
+		delete(p.p, "supportedservices")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetSupportedservices() ([]string, bool) {
@@ -1065,6 +1329,12 @@ func (p *ListNetworkOfferingsParams) SetTags(v string) {
 	p.p["tags"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetTags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1080,6 +1350,12 @@ func (p *ListNetworkOfferingsParams) SetTraffictype(v string) {
 	p.p["traffictype"] = v
 }
 
+func (p *ListNetworkOfferingsParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
+}
+
 func (p *ListNetworkOfferingsParams) GetTraffictype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1093,6 +1369,12 @@ func (p *ListNetworkOfferingsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListNetworkOfferingsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListNetworkOfferingsParams) GetZoneid() (string, bool) {
@@ -1326,6 +1608,12 @@ func (p *UpdateNetworkOfferingParams) SetAvailability(v string) {
 	p.p["availability"] = v
 }
 
+func (p *UpdateNetworkOfferingParams) ResetAvailability() {
+	if p.p != nil && p.p["availability"] != nil {
+		delete(p.p, "availability")
+	}
+}
+
 func (p *UpdateNetworkOfferingParams) GetAvailability() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1339,6 +1627,12 @@ func (p *UpdateNetworkOfferingParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *UpdateNetworkOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *UpdateNetworkOfferingParams) GetDisplaytext() (string, bool) {
@@ -1356,6 +1650,12 @@ func (p *UpdateNetworkOfferingParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *UpdateNetworkOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *UpdateNetworkOfferingParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1369,6 +1669,12 @@ func (p *UpdateNetworkOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateNetworkOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateNetworkOfferingParams) GetId() (string, bool) {
@@ -1386,6 +1692,12 @@ func (p *UpdateNetworkOfferingParams) SetKeepaliveenabled(v bool) {
 	p.p["keepaliveenabled"] = v
 }
 
+func (p *UpdateNetworkOfferingParams) ResetKeepaliveenabled() {
+	if p.p != nil && p.p["keepaliveenabled"] != nil {
+		delete(p.p, "keepaliveenabled")
+	}
+}
+
 func (p *UpdateNetworkOfferingParams) GetKeepaliveenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1399,6 +1711,12 @@ func (p *UpdateNetworkOfferingParams) SetMaxconnections(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxconnections"] = v
+}
+
+func (p *UpdateNetworkOfferingParams) ResetMaxconnections() {
+	if p.p != nil && p.p["maxconnections"] != nil {
+		delete(p.p, "maxconnections")
+	}
 }
 
 func (p *UpdateNetworkOfferingParams) GetMaxconnections() (int, bool) {
@@ -1416,6 +1734,12 @@ func (p *UpdateNetworkOfferingParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateNetworkOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateNetworkOfferingParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1429,6 +1753,12 @@ func (p *UpdateNetworkOfferingParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
+}
+
+func (p *UpdateNetworkOfferingParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
 }
 
 func (p *UpdateNetworkOfferingParams) GetSortkey() (int, bool) {
@@ -1446,6 +1776,12 @@ func (p *UpdateNetworkOfferingParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *UpdateNetworkOfferingParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *UpdateNetworkOfferingParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1461,6 +1797,12 @@ func (p *UpdateNetworkOfferingParams) SetTags(v string) {
 	p.p["tags"] = v
 }
 
+func (p *UpdateNetworkOfferingParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *UpdateNetworkOfferingParams) GetTags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1474,6 +1816,12 @@ func (p *UpdateNetworkOfferingParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UpdateNetworkOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UpdateNetworkOfferingParams) GetZoneid() (string, bool) {

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -145,6 +145,12 @@ func (p *AddNetworkServiceProviderParams) SetDestinationphysicalnetworkid(v stri
 	p.p["destinationphysicalnetworkid"] = v
 }
 
+func (p *AddNetworkServiceProviderParams) ResetDestinationphysicalnetworkid() {
+	if p.p != nil && p.p["destinationphysicalnetworkid"] != nil {
+		delete(p.p, "destinationphysicalnetworkid")
+	}
+}
+
 func (p *AddNetworkServiceProviderParams) GetDestinationphysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -158,6 +164,12 @@ func (p *AddNetworkServiceProviderParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *AddNetworkServiceProviderParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *AddNetworkServiceProviderParams) GetName() (string, bool) {
@@ -175,6 +187,12 @@ func (p *AddNetworkServiceProviderParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddNetworkServiceProviderParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddNetworkServiceProviderParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -188,6 +206,12 @@ func (p *AddNetworkServiceProviderParams) SetServicelist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["servicelist"] = v
+}
+
+func (p *AddNetworkServiceProviderParams) ResetServicelist() {
+	if p.p != nil && p.p["servicelist"] != nil {
+		delete(p.p, "servicelist")
+	}
 }
 
 func (p *AddNetworkServiceProviderParams) GetServicelist() ([]string, bool) {
@@ -286,6 +310,12 @@ func (p *AddOpenDaylightControllerParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddOpenDaylightControllerParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddOpenDaylightControllerParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -299,6 +329,12 @@ func (p *AddOpenDaylightControllerParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *AddOpenDaylightControllerParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *AddOpenDaylightControllerParams) GetPhysicalnetworkid() (string, bool) {
@@ -316,6 +352,12 @@ func (p *AddOpenDaylightControllerParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddOpenDaylightControllerParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddOpenDaylightControllerParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -329,6 +371,12 @@ func (p *AddOpenDaylightControllerParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddOpenDaylightControllerParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddOpenDaylightControllerParams) GetUsername() (string, bool) {
@@ -351,7 +399,7 @@ func (s *NetworkService) NewAddOpenDaylightControllerParams(password string, phy
 	return p
 }
 
-// Adds an OpenDaylight controller
+// Adds an OpenDyalight controler
 func (s *NetworkService) AddOpenDaylightController(p *AddOpenDaylightControllerParams) (*AddOpenDaylightControllerResponse, error) {
 	resp, err := s.cs.newRequest("addOpenDaylightController", p.toURLValues())
 	if err != nil {
@@ -538,6 +586,12 @@ func (p *CreateNetworkParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateNetworkParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateNetworkParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -551,6 +605,12 @@ func (p *CreateNetworkParams) SetAclid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["aclid"] = v
+}
+
+func (p *CreateNetworkParams) ResetAclid() {
+	if p.p != nil && p.p["aclid"] != nil {
+		delete(p.p, "aclid")
+	}
 }
 
 func (p *CreateNetworkParams) GetAclid() (string, bool) {
@@ -568,6 +628,12 @@ func (p *CreateNetworkParams) SetAcltype(v string) {
 	p.p["acltype"] = v
 }
 
+func (p *CreateNetworkParams) ResetAcltype() {
+	if p.p != nil && p.p["acltype"] != nil {
+		delete(p.p, "acltype")
+	}
+}
+
 func (p *CreateNetworkParams) GetAcltype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -581,6 +647,12 @@ func (p *CreateNetworkParams) SetAssociatednetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["associatednetworkid"] = v
+}
+
+func (p *CreateNetworkParams) ResetAssociatednetworkid() {
+	if p.p != nil && p.p["associatednetworkid"] != nil {
+		delete(p.p, "associatednetworkid")
+	}
 }
 
 func (p *CreateNetworkParams) GetAssociatednetworkid() (string, bool) {
@@ -598,6 +670,12 @@ func (p *CreateNetworkParams) SetBypassvlanoverlapcheck(v bool) {
 	p.p["bypassvlanoverlapcheck"] = v
 }
 
+func (p *CreateNetworkParams) ResetBypassvlanoverlapcheck() {
+	if p.p != nil && p.p["bypassvlanoverlapcheck"] != nil {
+		delete(p.p, "bypassvlanoverlapcheck")
+	}
+}
+
 func (p *CreateNetworkParams) GetBypassvlanoverlapcheck() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -611,6 +689,12 @@ func (p *CreateNetworkParams) SetDisplaynetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaynetwork"] = v
+}
+
+func (p *CreateNetworkParams) ResetDisplaynetwork() {
+	if p.p != nil && p.p["displaynetwork"] != nil {
+		delete(p.p, "displaynetwork")
+	}
 }
 
 func (p *CreateNetworkParams) GetDisplaynetwork() (bool, bool) {
@@ -628,6 +712,12 @@ func (p *CreateNetworkParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *CreateNetworkParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *CreateNetworkParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -641,6 +731,12 @@ func (p *CreateNetworkParams) SetDns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns1"] = v
+}
+
+func (p *CreateNetworkParams) ResetDns1() {
+	if p.p != nil && p.p["dns1"] != nil {
+		delete(p.p, "dns1")
+	}
 }
 
 func (p *CreateNetworkParams) GetDns1() (string, bool) {
@@ -658,6 +754,12 @@ func (p *CreateNetworkParams) SetDns2(v string) {
 	p.p["dns2"] = v
 }
 
+func (p *CreateNetworkParams) ResetDns2() {
+	if p.p != nil && p.p["dns2"] != nil {
+		delete(p.p, "dns2")
+	}
+}
+
 func (p *CreateNetworkParams) GetDns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -671,6 +773,12 @@ func (p *CreateNetworkParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateNetworkParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateNetworkParams) GetDomainid() (string, bool) {
@@ -688,6 +796,12 @@ func (p *CreateNetworkParams) SetEndip(v string) {
 	p.p["endip"] = v
 }
 
+func (p *CreateNetworkParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
+}
+
 func (p *CreateNetworkParams) GetEndip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -701,6 +815,12 @@ func (p *CreateNetworkParams) SetEndipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endipv6"] = v
+}
+
+func (p *CreateNetworkParams) ResetEndipv6() {
+	if p.p != nil && p.p["endipv6"] != nil {
+		delete(p.p, "endipv6")
+	}
 }
 
 func (p *CreateNetworkParams) GetEndipv6() (string, bool) {
@@ -718,6 +838,12 @@ func (p *CreateNetworkParams) SetExternalid(v string) {
 	p.p["externalid"] = v
 }
 
+func (p *CreateNetworkParams) ResetExternalid() {
+	if p.p != nil && p.p["externalid"] != nil {
+		delete(p.p, "externalid")
+	}
+}
+
 func (p *CreateNetworkParams) GetExternalid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -731,6 +857,12 @@ func (p *CreateNetworkParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *CreateNetworkParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *CreateNetworkParams) GetGateway() (string, bool) {
@@ -748,6 +880,12 @@ func (p *CreateNetworkParams) SetHideipaddressusage(v bool) {
 	p.p["hideipaddressusage"] = v
 }
 
+func (p *CreateNetworkParams) ResetHideipaddressusage() {
+	if p.p != nil && p.p["hideipaddressusage"] != nil {
+		delete(p.p, "hideipaddressusage")
+	}
+}
+
 func (p *CreateNetworkParams) GetHideipaddressusage() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -761,6 +899,12 @@ func (p *CreateNetworkParams) SetIp6cidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6cidr"] = v
+}
+
+func (p *CreateNetworkParams) ResetIp6cidr() {
+	if p.p != nil && p.p["ip6cidr"] != nil {
+		delete(p.p, "ip6cidr")
+	}
 }
 
 func (p *CreateNetworkParams) GetIp6cidr() (string, bool) {
@@ -778,6 +922,12 @@ func (p *CreateNetworkParams) SetIp6dns1(v string) {
 	p.p["ip6dns1"] = v
 }
 
+func (p *CreateNetworkParams) ResetIp6dns1() {
+	if p.p != nil && p.p["ip6dns1"] != nil {
+		delete(p.p, "ip6dns1")
+	}
+}
+
 func (p *CreateNetworkParams) GetIp6dns1() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -791,6 +941,12 @@ func (p *CreateNetworkParams) SetIp6dns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns2"] = v
+}
+
+func (p *CreateNetworkParams) ResetIp6dns2() {
+	if p.p != nil && p.p["ip6dns2"] != nil {
+		delete(p.p, "ip6dns2")
+	}
 }
 
 func (p *CreateNetworkParams) GetIp6dns2() (string, bool) {
@@ -808,6 +964,12 @@ func (p *CreateNetworkParams) SetIp6gateway(v string) {
 	p.p["ip6gateway"] = v
 }
 
+func (p *CreateNetworkParams) ResetIp6gateway() {
+	if p.p != nil && p.p["ip6gateway"] != nil {
+		delete(p.p, "ip6gateway")
+	}
+}
+
 func (p *CreateNetworkParams) GetIp6gateway() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -821,6 +983,12 @@ func (p *CreateNetworkParams) SetIsolatedpvlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isolatedpvlan"] = v
+}
+
+func (p *CreateNetworkParams) ResetIsolatedpvlan() {
+	if p.p != nil && p.p["isolatedpvlan"] != nil {
+		delete(p.p, "isolatedpvlan")
+	}
 }
 
 func (p *CreateNetworkParams) GetIsolatedpvlan() (string, bool) {
@@ -838,6 +1006,12 @@ func (p *CreateNetworkParams) SetIsolatedpvlantype(v string) {
 	p.p["isolatedpvlantype"] = v
 }
 
+func (p *CreateNetworkParams) ResetIsolatedpvlantype() {
+	if p.p != nil && p.p["isolatedpvlantype"] != nil {
+		delete(p.p, "isolatedpvlantype")
+	}
+}
+
 func (p *CreateNetworkParams) GetIsolatedpvlantype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -851,6 +1025,12 @@ func (p *CreateNetworkParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateNetworkParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateNetworkParams) GetName() (string, bool) {
@@ -868,6 +1048,12 @@ func (p *CreateNetworkParams) SetNetmask(v string) {
 	p.p["netmask"] = v
 }
 
+func (p *CreateNetworkParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
+}
+
 func (p *CreateNetworkParams) GetNetmask() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -881,6 +1067,12 @@ func (p *CreateNetworkParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
+}
+
+func (p *CreateNetworkParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
 }
 
 func (p *CreateNetworkParams) GetNetworkdomain() (string, bool) {
@@ -898,6 +1090,12 @@ func (p *CreateNetworkParams) SetNetworkofferingid(v string) {
 	p.p["networkofferingid"] = v
 }
 
+func (p *CreateNetworkParams) ResetNetworkofferingid() {
+	if p.p != nil && p.p["networkofferingid"] != nil {
+		delete(p.p, "networkofferingid")
+	}
+}
+
 func (p *CreateNetworkParams) GetNetworkofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -911,6 +1109,12 @@ func (p *CreateNetworkParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *CreateNetworkParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *CreateNetworkParams) GetPhysicalnetworkid() (string, bool) {
@@ -928,6 +1132,12 @@ func (p *CreateNetworkParams) SetPrivatemtu(v int) {
 	p.p["privatemtu"] = v
 }
 
+func (p *CreateNetworkParams) ResetPrivatemtu() {
+	if p.p != nil && p.p["privatemtu"] != nil {
+		delete(p.p, "privatemtu")
+	}
+}
+
 func (p *CreateNetworkParams) GetPrivatemtu() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -941,6 +1151,12 @@ func (p *CreateNetworkParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateNetworkParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateNetworkParams) GetProjectid() (string, bool) {
@@ -958,6 +1174,12 @@ func (p *CreateNetworkParams) SetPublicmtu(v int) {
 	p.p["publicmtu"] = v
 }
 
+func (p *CreateNetworkParams) ResetPublicmtu() {
+	if p.p != nil && p.p["publicmtu"] != nil {
+		delete(p.p, "publicmtu")
+	}
+}
+
 func (p *CreateNetworkParams) GetPublicmtu() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -971,6 +1193,12 @@ func (p *CreateNetworkParams) SetRouterip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["routerip"] = v
+}
+
+func (p *CreateNetworkParams) ResetRouterip() {
+	if p.p != nil && p.p["routerip"] != nil {
+		delete(p.p, "routerip")
+	}
 }
 
 func (p *CreateNetworkParams) GetRouterip() (string, bool) {
@@ -988,6 +1216,12 @@ func (p *CreateNetworkParams) SetRouteripv6(v string) {
 	p.p["routeripv6"] = v
 }
 
+func (p *CreateNetworkParams) ResetRouteripv6() {
+	if p.p != nil && p.p["routeripv6"] != nil {
+		delete(p.p, "routeripv6")
+	}
+}
+
 func (p *CreateNetworkParams) GetRouteripv6() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1001,6 +1235,12 @@ func (p *CreateNetworkParams) SetSourcenatipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcenatipaddress"] = v
+}
+
+func (p *CreateNetworkParams) ResetSourcenatipaddress() {
+	if p.p != nil && p.p["sourcenatipaddress"] != nil {
+		delete(p.p, "sourcenatipaddress")
+	}
 }
 
 func (p *CreateNetworkParams) GetSourcenatipaddress() (string, bool) {
@@ -1018,6 +1258,12 @@ func (p *CreateNetworkParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *CreateNetworkParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *CreateNetworkParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1031,6 +1277,12 @@ func (p *CreateNetworkParams) SetStartipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startipv6"] = v
+}
+
+func (p *CreateNetworkParams) ResetStartipv6() {
+	if p.p != nil && p.p["startipv6"] != nil {
+		delete(p.p, "startipv6")
+	}
 }
 
 func (p *CreateNetworkParams) GetStartipv6() (string, bool) {
@@ -1048,6 +1300,12 @@ func (p *CreateNetworkParams) SetSubdomainaccess(v bool) {
 	p.p["subdomainaccess"] = v
 }
 
+func (p *CreateNetworkParams) ResetSubdomainaccess() {
+	if p.p != nil && p.p["subdomainaccess"] != nil {
+		delete(p.p, "subdomainaccess")
+	}
+}
+
 func (p *CreateNetworkParams) GetSubdomainaccess() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1061,6 +1319,12 @@ func (p *CreateNetworkParams) SetTungstenvirtualrouteruuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tungstenvirtualrouteruuid"] = v
+}
+
+func (p *CreateNetworkParams) ResetTungstenvirtualrouteruuid() {
+	if p.p != nil && p.p["tungstenvirtualrouteruuid"] != nil {
+		delete(p.p, "tungstenvirtualrouteruuid")
+	}
 }
 
 func (p *CreateNetworkParams) GetTungstenvirtualrouteruuid() (string, bool) {
@@ -1078,6 +1342,12 @@ func (p *CreateNetworkParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *CreateNetworkParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *CreateNetworkParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1093,6 +1363,12 @@ func (p *CreateNetworkParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *CreateNetworkParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *CreateNetworkParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1106,6 +1382,12 @@ func (p *CreateNetworkParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateNetworkParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateNetworkParams) GetZoneid() (string, bool) {
@@ -1289,6 +1571,12 @@ func (p *CreatePhysicalNetworkParams) SetBroadcastdomainrange(v string) {
 	p.p["broadcastdomainrange"] = v
 }
 
+func (p *CreatePhysicalNetworkParams) ResetBroadcastdomainrange() {
+	if p.p != nil && p.p["broadcastdomainrange"] != nil {
+		delete(p.p, "broadcastdomainrange")
+	}
+}
+
 func (p *CreatePhysicalNetworkParams) GetBroadcastdomainrange() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1302,6 +1590,12 @@ func (p *CreatePhysicalNetworkParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreatePhysicalNetworkParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreatePhysicalNetworkParams) GetDomainid() (string, bool) {
@@ -1319,6 +1613,12 @@ func (p *CreatePhysicalNetworkParams) SetIsolationmethods(v []string) {
 	p.p["isolationmethods"] = v
 }
 
+func (p *CreatePhysicalNetworkParams) ResetIsolationmethods() {
+	if p.p != nil && p.p["isolationmethods"] != nil {
+		delete(p.p, "isolationmethods")
+	}
+}
+
 func (p *CreatePhysicalNetworkParams) GetIsolationmethods() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1332,6 +1632,12 @@ func (p *CreatePhysicalNetworkParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreatePhysicalNetworkParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreatePhysicalNetworkParams) GetName() (string, bool) {
@@ -1349,6 +1655,12 @@ func (p *CreatePhysicalNetworkParams) SetNetworkspeed(v string) {
 	p.p["networkspeed"] = v
 }
 
+func (p *CreatePhysicalNetworkParams) ResetNetworkspeed() {
+	if p.p != nil && p.p["networkspeed"] != nil {
+		delete(p.p, "networkspeed")
+	}
+}
+
 func (p *CreatePhysicalNetworkParams) GetNetworkspeed() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1362,6 +1674,12 @@ func (p *CreatePhysicalNetworkParams) SetTags(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *CreatePhysicalNetworkParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *CreatePhysicalNetworkParams) GetTags() ([]string, bool) {
@@ -1379,6 +1697,12 @@ func (p *CreatePhysicalNetworkParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *CreatePhysicalNetworkParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *CreatePhysicalNetworkParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1392,6 +1716,12 @@ func (p *CreatePhysicalNetworkParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreatePhysicalNetworkParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreatePhysicalNetworkParams) GetZoneid() (string, bool) {
@@ -1509,6 +1839,12 @@ func (p *CreateServiceInstanceParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateServiceInstanceParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateServiceInstanceParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1522,6 +1858,12 @@ func (p *CreateServiceInstanceParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateServiceInstanceParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateServiceInstanceParams) GetDomainid() (string, bool) {
@@ -1539,6 +1881,12 @@ func (p *CreateServiceInstanceParams) SetLeftnetworkid(v string) {
 	p.p["leftnetworkid"] = v
 }
 
+func (p *CreateServiceInstanceParams) ResetLeftnetworkid() {
+	if p.p != nil && p.p["leftnetworkid"] != nil {
+		delete(p.p, "leftnetworkid")
+	}
+}
+
 func (p *CreateServiceInstanceParams) GetLeftnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1552,6 +1900,12 @@ func (p *CreateServiceInstanceParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateServiceInstanceParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateServiceInstanceParams) GetName() (string, bool) {
@@ -1569,6 +1923,12 @@ func (p *CreateServiceInstanceParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *CreateServiceInstanceParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *CreateServiceInstanceParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1582,6 +1942,12 @@ func (p *CreateServiceInstanceParams) SetRightnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["rightnetworkid"] = v
+}
+
+func (p *CreateServiceInstanceParams) ResetRightnetworkid() {
+	if p.p != nil && p.p["rightnetworkid"] != nil {
+		delete(p.p, "rightnetworkid")
+	}
 }
 
 func (p *CreateServiceInstanceParams) GetRightnetworkid() (string, bool) {
@@ -1599,6 +1965,12 @@ func (p *CreateServiceInstanceParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *CreateServiceInstanceParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *CreateServiceInstanceParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1614,6 +1986,12 @@ func (p *CreateServiceInstanceParams) SetTemplateid(v string) {
 	p.p["templateid"] = v
 }
 
+func (p *CreateServiceInstanceParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
+}
+
 func (p *CreateServiceInstanceParams) GetTemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1627,6 +2005,12 @@ func (p *CreateServiceInstanceParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateServiceInstanceParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateServiceInstanceParams) GetZoneid() (string, bool) {
@@ -1737,6 +2121,12 @@ func (p *CreateStorageNetworkIpRangeParams) SetEndip(v string) {
 	p.p["endip"] = v
 }
 
+func (p *CreateStorageNetworkIpRangeParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
+}
+
 func (p *CreateStorageNetworkIpRangeParams) GetEndip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1750,6 +2140,12 @@ func (p *CreateStorageNetworkIpRangeParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *CreateStorageNetworkIpRangeParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *CreateStorageNetworkIpRangeParams) GetGateway() (string, bool) {
@@ -1767,6 +2163,12 @@ func (p *CreateStorageNetworkIpRangeParams) SetNetmask(v string) {
 	p.p["netmask"] = v
 }
 
+func (p *CreateStorageNetworkIpRangeParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
+}
+
 func (p *CreateStorageNetworkIpRangeParams) GetNetmask() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1780,6 +2182,12 @@ func (p *CreateStorageNetworkIpRangeParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *CreateStorageNetworkIpRangeParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *CreateStorageNetworkIpRangeParams) GetPodid() (string, bool) {
@@ -1797,6 +2205,12 @@ func (p *CreateStorageNetworkIpRangeParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *CreateStorageNetworkIpRangeParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *CreateStorageNetworkIpRangeParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1810,6 +2224,12 @@ func (p *CreateStorageNetworkIpRangeParams) SetVlan(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
+}
+
+func (p *CreateStorageNetworkIpRangeParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
 }
 
 func (p *CreateStorageNetworkIpRangeParams) GetVlan() (int, bool) {
@@ -1912,6 +2332,12 @@ func (p *DedicatePublicIpRangeParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DedicatePublicIpRangeParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DedicatePublicIpRangeParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1925,6 +2351,12 @@ func (p *DedicatePublicIpRangeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DedicatePublicIpRangeParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DedicatePublicIpRangeParams) GetDomainid() (string, bool) {
@@ -1942,6 +2374,12 @@ func (p *DedicatePublicIpRangeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DedicatePublicIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DedicatePublicIpRangeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1955,6 +2393,12 @@ func (p *DedicatePublicIpRangeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *DedicatePublicIpRangeParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *DedicatePublicIpRangeParams) GetProjectid() (string, bool) {
@@ -2045,6 +2489,12 @@ func (p *DeleteNetworkParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *DeleteNetworkParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *DeleteNetworkParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2058,6 +2508,12 @@ func (p *DeleteNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteNetworkParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteNetworkParams) GetId() (string, bool) {
@@ -2136,6 +2592,12 @@ func (p *DeleteNetworkServiceProviderParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteNetworkServiceProviderParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteNetworkServiceProviderParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2212,6 +2674,12 @@ func (p *DeleteOpenDaylightControllerParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteOpenDaylightControllerParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteOpenDaylightControllerParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2229,7 +2697,7 @@ func (s *NetworkService) NewDeleteOpenDaylightControllerParams(id string) *Delet
 	return p
 }
 
-// Removes an OpenDaylight controller
+// Removes an OpenDyalight controler
 func (s *NetworkService) DeleteOpenDaylightController(p *DeleteOpenDaylightControllerParams) (*DeleteOpenDaylightControllerResponse, error) {
 	resp, err := s.cs.newRequest("deleteOpenDaylightController", p.toURLValues())
 	if err != nil {
@@ -2294,6 +2762,12 @@ func (p *DeletePhysicalNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeletePhysicalNetworkParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeletePhysicalNetworkParams) GetId() (string, bool) {
@@ -2370,6 +2844,12 @@ func (p *DeleteStorageNetworkIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteStorageNetworkIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteStorageNetworkIpRangeParams) GetId() (string, bool) {
@@ -2459,6 +2939,12 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetscalerLoadBalancerNetworksParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetscalerLoadBalancerNetworksParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2472,6 +2958,12 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) ResetLbdeviceid() {
+	if p.p != nil && p.p["lbdeviceid"] != nil {
+		delete(p.p, "lbdeviceid")
+	}
 }
 
 func (p *ListNetscalerLoadBalancerNetworksParams) GetLbdeviceid() (string, bool) {
@@ -2489,6 +2981,12 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetscalerLoadBalancerNetworksParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetscalerLoadBalancerNetworksParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2502,6 +3000,12 @@ func (p *ListNetscalerLoadBalancerNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNetscalerLoadBalancerNetworksParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNetscalerLoadBalancerNetworksParams) GetPagesize() (int, bool) {
@@ -2706,6 +3210,12 @@ func (p *ListNetworkIsolationMethodsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetworkIsolationMethodsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetworkIsolationMethodsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2721,6 +3231,12 @@ func (p *ListNetworkIsolationMethodsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetworkIsolationMethodsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetworkIsolationMethodsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2734,6 +3250,12 @@ func (p *ListNetworkIsolationMethodsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNetworkIsolationMethodsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNetworkIsolationMethodsParams) GetPagesize() (int, bool) {
@@ -2817,6 +3339,12 @@ func (p *ListNetworkServiceProvidersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetworkServiceProvidersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetworkServiceProvidersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2830,6 +3358,12 @@ func (p *ListNetworkServiceProvidersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListNetworkServiceProvidersParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListNetworkServiceProvidersParams) GetName() (string, bool) {
@@ -2847,6 +3381,12 @@ func (p *ListNetworkServiceProvidersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetworkServiceProvidersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetworkServiceProvidersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2860,6 +3400,12 @@ func (p *ListNetworkServiceProvidersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNetworkServiceProvidersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNetworkServiceProvidersParams) GetPagesize() (int, bool) {
@@ -2877,6 +3423,12 @@ func (p *ListNetworkServiceProvidersParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *ListNetworkServiceProvidersParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *ListNetworkServiceProvidersParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2890,6 +3442,12 @@ func (p *ListNetworkServiceProvidersParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListNetworkServiceProvidersParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListNetworkServiceProvidersParams) GetState() (string, bool) {
@@ -3099,6 +3657,12 @@ func (p *ListNetworksParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListNetworksParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListNetworksParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3112,6 +3676,12 @@ func (p *ListNetworksParams) SetAcltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["acltype"] = v
+}
+
+func (p *ListNetworksParams) ResetAcltype() {
+	if p.p != nil && p.p["acltype"] != nil {
+		delete(p.p, "acltype")
+	}
 }
 
 func (p *ListNetworksParams) GetAcltype() (string, bool) {
@@ -3129,6 +3699,12 @@ func (p *ListNetworksParams) SetAssociatednetworkid(v string) {
 	p.p["associatednetworkid"] = v
 }
 
+func (p *ListNetworksParams) ResetAssociatednetworkid() {
+	if p.p != nil && p.p["associatednetworkid"] != nil {
+		delete(p.p, "associatednetworkid")
+	}
+}
+
 func (p *ListNetworksParams) GetAssociatednetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3142,6 +3718,12 @@ func (p *ListNetworksParams) SetCanusefordeploy(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["canusefordeploy"] = v
+}
+
+func (p *ListNetworksParams) ResetCanusefordeploy() {
+	if p.p != nil && p.p["canusefordeploy"] != nil {
+		delete(p.p, "canusefordeploy")
+	}
 }
 
 func (p *ListNetworksParams) GetCanusefordeploy() (bool, bool) {
@@ -3159,6 +3741,12 @@ func (p *ListNetworksParams) SetDisplaynetwork(v bool) {
 	p.p["displaynetwork"] = v
 }
 
+func (p *ListNetworksParams) ResetDisplaynetwork() {
+	if p.p != nil && p.p["displaynetwork"] != nil {
+		delete(p.p, "displaynetwork")
+	}
+}
+
 func (p *ListNetworksParams) GetDisplaynetwork() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3172,6 +3760,12 @@ func (p *ListNetworksParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListNetworksParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListNetworksParams) GetDomainid() (string, bool) {
@@ -3189,6 +3783,12 @@ func (p *ListNetworksParams) SetForvpc(v bool) {
 	p.p["forvpc"] = v
 }
 
+func (p *ListNetworksParams) ResetForvpc() {
+	if p.p != nil && p.p["forvpc"] != nil {
+		delete(p.p, "forvpc")
+	}
+}
+
 func (p *ListNetworksParams) GetForvpc() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3202,6 +3802,12 @@ func (p *ListNetworksParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListNetworksParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListNetworksParams) GetId() (string, bool) {
@@ -3219,6 +3825,12 @@ func (p *ListNetworksParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListNetworksParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListNetworksParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3232,6 +3844,12 @@ func (p *ListNetworksParams) SetIssystem(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["issystem"] = v
+}
+
+func (p *ListNetworksParams) ResetIssystem() {
+	if p.p != nil && p.p["issystem"] != nil {
+		delete(p.p, "issystem")
+	}
 }
 
 func (p *ListNetworksParams) GetIssystem() (bool, bool) {
@@ -3249,6 +3867,12 @@ func (p *ListNetworksParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNetworksParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNetworksParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3262,6 +3886,12 @@ func (p *ListNetworksParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListNetworksParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListNetworksParams) GetListall() (bool, bool) {
@@ -3279,6 +3909,12 @@ func (p *ListNetworksParams) SetNetworkfilter(v string) {
 	p.p["networkfilter"] = v
 }
 
+func (p *ListNetworksParams) ResetNetworkfilter() {
+	if p.p != nil && p.p["networkfilter"] != nil {
+		delete(p.p, "networkfilter")
+	}
+}
+
 func (p *ListNetworksParams) GetNetworkfilter() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3292,6 +3928,12 @@ func (p *ListNetworksParams) SetNetworkofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkofferingid"] = v
+}
+
+func (p *ListNetworksParams) ResetNetworkofferingid() {
+	if p.p != nil && p.p["networkofferingid"] != nil {
+		delete(p.p, "networkofferingid")
+	}
 }
 
 func (p *ListNetworksParams) GetNetworkofferingid() (string, bool) {
@@ -3309,6 +3951,12 @@ func (p *ListNetworksParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNetworksParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNetworksParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3322,6 +3970,12 @@ func (p *ListNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNetworksParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNetworksParams) GetPagesize() (int, bool) {
@@ -3339,6 +3993,12 @@ func (p *ListNetworksParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *ListNetworksParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *ListNetworksParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3352,6 +4012,12 @@ func (p *ListNetworksParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListNetworksParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListNetworksParams) GetProjectid() (string, bool) {
@@ -3369,6 +4035,12 @@ func (p *ListNetworksParams) SetRestartrequired(v bool) {
 	p.p["restartrequired"] = v
 }
 
+func (p *ListNetworksParams) ResetRestartrequired() {
+	if p.p != nil && p.p["restartrequired"] != nil {
+		delete(p.p, "restartrequired")
+	}
+}
+
 func (p *ListNetworksParams) GetRestartrequired() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3382,6 +4054,12 @@ func (p *ListNetworksParams) SetRetrieveonlyresourcecount(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListNetworksParams) ResetRetrieveonlyresourcecount() {
+	if p.p != nil && p.p["retrieveonlyresourcecount"] != nil {
+		delete(p.p, "retrieveonlyresourcecount")
+	}
 }
 
 func (p *ListNetworksParams) GetRetrieveonlyresourcecount() (bool, bool) {
@@ -3399,6 +4077,12 @@ func (p *ListNetworksParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListNetworksParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListNetworksParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3412,6 +4096,12 @@ func (p *ListNetworksParams) SetSpecifyipranges(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["specifyipranges"] = v
+}
+
+func (p *ListNetworksParams) ResetSpecifyipranges() {
+	if p.p != nil && p.p["specifyipranges"] != nil {
+		delete(p.p, "specifyipranges")
+	}
 }
 
 func (p *ListNetworksParams) GetSpecifyipranges() (bool, bool) {
@@ -3429,6 +4119,12 @@ func (p *ListNetworksParams) SetSupportedservices(v []string) {
 	p.p["supportedservices"] = v
 }
 
+func (p *ListNetworksParams) ResetSupportedservices() {
+	if p.p != nil && p.p["supportedservices"] != nil {
+		delete(p.p, "supportedservices")
+	}
+}
+
 func (p *ListNetworksParams) GetSupportedservices() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3442,6 +4138,12 @@ func (p *ListNetworksParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListNetworksParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListNetworksParams) GetTags() (map[string]string, bool) {
@@ -3459,6 +4161,12 @@ func (p *ListNetworksParams) SetTraffictype(v string) {
 	p.p["traffictype"] = v
 }
 
+func (p *ListNetworksParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
+}
+
 func (p *ListNetworksParams) GetTraffictype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3472,6 +4180,12 @@ func (p *ListNetworksParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListNetworksParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListNetworksParams) GetType() (string, bool) {
@@ -3489,6 +4203,12 @@ func (p *ListNetworksParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *ListNetworksParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *ListNetworksParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3504,6 +4224,12 @@ func (p *ListNetworksParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *ListNetworksParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *ListNetworksParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3517,6 +4243,12 @@ func (p *ListNetworksParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListNetworksParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListNetworksParams) GetZoneid() (string, bool) {
@@ -3769,6 +4501,12 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNiciraNvpDeviceNetworksParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNiciraNvpDeviceNetworksParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3782,6 +4520,12 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetNvpdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nvpdeviceid"] = v
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) ResetNvpdeviceid() {
+	if p.p != nil && p.p["nvpdeviceid"] != nil {
+		delete(p.p, "nvpdeviceid")
+	}
 }
 
 func (p *ListNiciraNvpDeviceNetworksParams) GetNvpdeviceid() (string, bool) {
@@ -3799,6 +4543,12 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNiciraNvpDeviceNetworksParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNiciraNvpDeviceNetworksParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3812,6 +4562,12 @@ func (p *ListNiciraNvpDeviceNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListNiciraNvpDeviceNetworksParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListNiciraNvpDeviceNetworksParams) GetPagesize() (int, bool) {
@@ -4011,6 +4767,12 @@ func (p *ListOpenDaylightControllersParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListOpenDaylightControllersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListOpenDaylightControllersParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4024,6 +4786,12 @@ func (p *ListOpenDaylightControllersParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListOpenDaylightControllersParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListOpenDaylightControllersParams) GetPhysicalnetworkid() (string, bool) {
@@ -4075,7 +4843,7 @@ func (s *NetworkService) GetOpenDaylightControllerByID(id string, opts ...Option
 	return nil, l.Count, fmt.Errorf("There is more then one result for OpenDaylightController UUID: %s!", id)
 }
 
-// Lists OpenDaylight controllers
+// Lists OpenDyalight controllers
 func (s *NetworkService) ListOpenDaylightControllers(p *ListOpenDaylightControllersParams) (*ListOpenDaylightControllersResponse, error) {
 	resp, err := s.cs.newRequest("listOpenDaylightControllers", p.toURLValues())
 	if err != nil {
@@ -4138,6 +4906,12 @@ func (p *ListPaloAltoFirewallNetworksParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListPaloAltoFirewallNetworksParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListPaloAltoFirewallNetworksParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4151,6 +4925,12 @@ func (p *ListPaloAltoFirewallNetworksParams) SetLbdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["lbdeviceid"] = v
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) ResetLbdeviceid() {
+	if p.p != nil && p.p["lbdeviceid"] != nil {
+		delete(p.p, "lbdeviceid")
+	}
 }
 
 func (p *ListPaloAltoFirewallNetworksParams) GetLbdeviceid() (string, bool) {
@@ -4168,6 +4948,12 @@ func (p *ListPaloAltoFirewallNetworksParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListPaloAltoFirewallNetworksParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListPaloAltoFirewallNetworksParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4181,6 +4967,12 @@ func (p *ListPaloAltoFirewallNetworksParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListPaloAltoFirewallNetworksParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListPaloAltoFirewallNetworksParams) GetPagesize() (int, bool) {
@@ -4394,6 +5186,12 @@ func (p *ListPhysicalNetworksParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListPhysicalNetworksParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListPhysicalNetworksParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4407,6 +5205,12 @@ func (p *ListPhysicalNetworksParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListPhysicalNetworksParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListPhysicalNetworksParams) GetKeyword() (string, bool) {
@@ -4424,6 +5228,12 @@ func (p *ListPhysicalNetworksParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListPhysicalNetworksParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListPhysicalNetworksParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4437,6 +5247,12 @@ func (p *ListPhysicalNetworksParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListPhysicalNetworksParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListPhysicalNetworksParams) GetPage() (int, bool) {
@@ -4454,6 +5270,12 @@ func (p *ListPhysicalNetworksParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListPhysicalNetworksParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListPhysicalNetworksParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4467,6 +5289,12 @@ func (p *ListPhysicalNetworksParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListPhysicalNetworksParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListPhysicalNetworksParams) GetZoneid() (string, bool) {
@@ -4643,6 +5471,12 @@ func (p *ListStorageNetworkIpRangeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListStorageNetworkIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListStorageNetworkIpRangeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4656,6 +5490,12 @@ func (p *ListStorageNetworkIpRangeParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListStorageNetworkIpRangeParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListStorageNetworkIpRangeParams) GetKeyword() (string, bool) {
@@ -4673,6 +5513,12 @@ func (p *ListStorageNetworkIpRangeParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListStorageNetworkIpRangeParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListStorageNetworkIpRangeParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4686,6 +5532,12 @@ func (p *ListStorageNetworkIpRangeParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListStorageNetworkIpRangeParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListStorageNetworkIpRangeParams) GetPagesize() (int, bool) {
@@ -4703,6 +5555,12 @@ func (p *ListStorageNetworkIpRangeParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *ListStorageNetworkIpRangeParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *ListStorageNetworkIpRangeParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4716,6 +5574,12 @@ func (p *ListStorageNetworkIpRangeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListStorageNetworkIpRangeParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListStorageNetworkIpRangeParams) GetZoneid() (string, bool) {
@@ -4837,6 +5701,12 @@ func (p *ListSupportedNetworkServicesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListSupportedNetworkServicesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListSupportedNetworkServicesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4850,6 +5720,12 @@ func (p *ListSupportedNetworkServicesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListSupportedNetworkServicesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListSupportedNetworkServicesParams) GetPage() (int, bool) {
@@ -4867,6 +5743,12 @@ func (p *ListSupportedNetworkServicesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListSupportedNetworkServicesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListSupportedNetworkServicesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4882,6 +5764,12 @@ func (p *ListSupportedNetworkServicesParams) SetProvider(v string) {
 	p.p["provider"] = v
 }
 
+func (p *ListSupportedNetworkServicesParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
+}
+
 func (p *ListSupportedNetworkServicesParams) GetProvider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4895,6 +5783,12 @@ func (p *ListSupportedNetworkServicesParams) SetService(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["service"] = v
+}
+
+func (p *ListSupportedNetworkServicesParams) ResetService() {
+	if p.p != nil && p.p["service"] != nil {
+		delete(p.p, "service")
+	}
 }
 
 func (p *ListSupportedNetworkServicesParams) GetService() (string, bool) {
@@ -4977,6 +5871,12 @@ func (p *ReleasePublicIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ReleasePublicIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ReleasePublicIpRangeParams) GetId() (string, bool) {
@@ -5079,6 +5979,12 @@ func (p *RestartNetworkParams) SetCleanup(v bool) {
 	p.p["cleanup"] = v
 }
 
+func (p *RestartNetworkParams) ResetCleanup() {
+	if p.p != nil && p.p["cleanup"] != nil {
+		delete(p.p, "cleanup")
+	}
+}
+
 func (p *RestartNetworkParams) GetCleanup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5092,6 +5998,12 @@ func (p *RestartNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RestartNetworkParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RestartNetworkParams) GetId() (string, bool) {
@@ -5109,6 +6021,12 @@ func (p *RestartNetworkParams) SetLivepatch(v bool) {
 	p.p["livepatch"] = v
 }
 
+func (p *RestartNetworkParams) ResetLivepatch() {
+	if p.p != nil && p.p["livepatch"] != nil {
+		delete(p.p, "livepatch")
+	}
+}
+
 func (p *RestartNetworkParams) GetLivepatch() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5122,6 +6040,12 @@ func (p *RestartNetworkParams) SetMakeredundant(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["makeredundant"] = v
+}
+
+func (p *RestartNetworkParams) ResetMakeredundant() {
+	if p.p != nil && p.p["makeredundant"] != nil {
+		delete(p.p, "makeredundant")
+	}
 }
 
 func (p *RestartNetworkParams) GetMakeredundant() (bool, bool) {
@@ -5261,6 +6185,12 @@ func (p *UpdateNetworkParams) SetChangecidr(v bool) {
 	p.p["changecidr"] = v
 }
 
+func (p *UpdateNetworkParams) ResetChangecidr() {
+	if p.p != nil && p.p["changecidr"] != nil {
+		delete(p.p, "changecidr")
+	}
+}
+
 func (p *UpdateNetworkParams) GetChangecidr() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5274,6 +6204,12 @@ func (p *UpdateNetworkParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
+}
+
+func (p *UpdateNetworkParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
 }
 
 func (p *UpdateNetworkParams) GetCustomid() (string, bool) {
@@ -5291,6 +6227,12 @@ func (p *UpdateNetworkParams) SetDisplaynetwork(v bool) {
 	p.p["displaynetwork"] = v
 }
 
+func (p *UpdateNetworkParams) ResetDisplaynetwork() {
+	if p.p != nil && p.p["displaynetwork"] != nil {
+		delete(p.p, "displaynetwork")
+	}
+}
+
 func (p *UpdateNetworkParams) GetDisplaynetwork() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5304,6 +6246,12 @@ func (p *UpdateNetworkParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *UpdateNetworkParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *UpdateNetworkParams) GetDisplaytext() (string, bool) {
@@ -5321,6 +6269,12 @@ func (p *UpdateNetworkParams) SetDns1(v string) {
 	p.p["dns1"] = v
 }
 
+func (p *UpdateNetworkParams) ResetDns1() {
+	if p.p != nil && p.p["dns1"] != nil {
+		delete(p.p, "dns1")
+	}
+}
+
 func (p *UpdateNetworkParams) GetDns1() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5334,6 +6288,12 @@ func (p *UpdateNetworkParams) SetDns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns2"] = v
+}
+
+func (p *UpdateNetworkParams) ResetDns2() {
+	if p.p != nil && p.p["dns2"] != nil {
+		delete(p.p, "dns2")
+	}
 }
 
 func (p *UpdateNetworkParams) GetDns2() (string, bool) {
@@ -5351,6 +6311,12 @@ func (p *UpdateNetworkParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *UpdateNetworkParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *UpdateNetworkParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5364,6 +6330,12 @@ func (p *UpdateNetworkParams) SetGuestvmcidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestvmcidr"] = v
+}
+
+func (p *UpdateNetworkParams) ResetGuestvmcidr() {
+	if p.p != nil && p.p["guestvmcidr"] != nil {
+		delete(p.p, "guestvmcidr")
+	}
 }
 
 func (p *UpdateNetworkParams) GetGuestvmcidr() (string, bool) {
@@ -5381,6 +6353,12 @@ func (p *UpdateNetworkParams) SetHideipaddressusage(v bool) {
 	p.p["hideipaddressusage"] = v
 }
 
+func (p *UpdateNetworkParams) ResetHideipaddressusage() {
+	if p.p != nil && p.p["hideipaddressusage"] != nil {
+		delete(p.p, "hideipaddressusage")
+	}
+}
+
 func (p *UpdateNetworkParams) GetHideipaddressusage() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5394,6 +6372,12 @@ func (p *UpdateNetworkParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateNetworkParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateNetworkParams) GetId() (string, bool) {
@@ -5411,6 +6395,12 @@ func (p *UpdateNetworkParams) SetIp6dns1(v string) {
 	p.p["ip6dns1"] = v
 }
 
+func (p *UpdateNetworkParams) ResetIp6dns1() {
+	if p.p != nil && p.p["ip6dns1"] != nil {
+		delete(p.p, "ip6dns1")
+	}
+}
+
 func (p *UpdateNetworkParams) GetIp6dns1() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5424,6 +6414,12 @@ func (p *UpdateNetworkParams) SetIp6dns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns2"] = v
+}
+
+func (p *UpdateNetworkParams) ResetIp6dns2() {
+	if p.p != nil && p.p["ip6dns2"] != nil {
+		delete(p.p, "ip6dns2")
+	}
 }
 
 func (p *UpdateNetworkParams) GetIp6dns2() (string, bool) {
@@ -5441,6 +6437,12 @@ func (p *UpdateNetworkParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateNetworkParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateNetworkParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5454,6 +6456,12 @@ func (p *UpdateNetworkParams) SetNetworkdomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkdomain"] = v
+}
+
+func (p *UpdateNetworkParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
 }
 
 func (p *UpdateNetworkParams) GetNetworkdomain() (string, bool) {
@@ -5471,6 +6479,12 @@ func (p *UpdateNetworkParams) SetNetworkofferingid(v string) {
 	p.p["networkofferingid"] = v
 }
 
+func (p *UpdateNetworkParams) ResetNetworkofferingid() {
+	if p.p != nil && p.p["networkofferingid"] != nil {
+		delete(p.p, "networkofferingid")
+	}
+}
+
 func (p *UpdateNetworkParams) GetNetworkofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5484,6 +6498,12 @@ func (p *UpdateNetworkParams) SetPrivatemtu(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["privatemtu"] = v
+}
+
+func (p *UpdateNetworkParams) ResetPrivatemtu() {
+	if p.p != nil && p.p["privatemtu"] != nil {
+		delete(p.p, "privatemtu")
+	}
 }
 
 func (p *UpdateNetworkParams) GetPrivatemtu() (int, bool) {
@@ -5501,6 +6521,12 @@ func (p *UpdateNetworkParams) SetPublicmtu(v int) {
 	p.p["publicmtu"] = v
 }
 
+func (p *UpdateNetworkParams) ResetPublicmtu() {
+	if p.p != nil && p.p["publicmtu"] != nil {
+		delete(p.p, "publicmtu")
+	}
+}
+
 func (p *UpdateNetworkParams) GetPublicmtu() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5516,6 +6542,12 @@ func (p *UpdateNetworkParams) SetSourcenatipaddress(v string) {
 	p.p["sourcenatipaddress"] = v
 }
 
+func (p *UpdateNetworkParams) ResetSourcenatipaddress() {
+	if p.p != nil && p.p["sourcenatipaddress"] != nil {
+		delete(p.p, "sourcenatipaddress")
+	}
+}
+
 func (p *UpdateNetworkParams) GetSourcenatipaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5529,6 +6561,12 @@ func (p *UpdateNetworkParams) SetUpdateinsequence(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["updateinsequence"] = v
+}
+
+func (p *UpdateNetworkParams) ResetUpdateinsequence() {
+	if p.p != nil && p.p["updateinsequence"] != nil {
+		delete(p.p, "updateinsequence")
+	}
 }
 
 func (p *UpdateNetworkParams) GetUpdateinsequence() (bool, bool) {
@@ -5710,6 +6748,12 @@ func (p *UpdateNetworkServiceProviderParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateNetworkServiceProviderParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateNetworkServiceProviderParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5725,6 +6769,12 @@ func (p *UpdateNetworkServiceProviderParams) SetServicelist(v []string) {
 	p.p["servicelist"] = v
 }
 
+func (p *UpdateNetworkServiceProviderParams) ResetServicelist() {
+	if p.p != nil && p.p["servicelist"] != nil {
+		delete(p.p, "servicelist")
+	}
+}
+
 func (p *UpdateNetworkServiceProviderParams) GetServicelist() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5738,6 +6788,12 @@ func (p *UpdateNetworkServiceProviderParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *UpdateNetworkServiceProviderParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *UpdateNetworkServiceProviderParams) GetState() (string, bool) {
@@ -5839,6 +6895,12 @@ func (p *UpdatePhysicalNetworkParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdatePhysicalNetworkParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdatePhysicalNetworkParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5852,6 +6914,12 @@ func (p *UpdatePhysicalNetworkParams) SetNetworkspeed(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkspeed"] = v
+}
+
+func (p *UpdatePhysicalNetworkParams) ResetNetworkspeed() {
+	if p.p != nil && p.p["networkspeed"] != nil {
+		delete(p.p, "networkspeed")
+	}
 }
 
 func (p *UpdatePhysicalNetworkParams) GetNetworkspeed() (string, bool) {
@@ -5869,6 +6937,12 @@ func (p *UpdatePhysicalNetworkParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *UpdatePhysicalNetworkParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *UpdatePhysicalNetworkParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5884,6 +6958,12 @@ func (p *UpdatePhysicalNetworkParams) SetTags(v []string) {
 	p.p["tags"] = v
 }
 
+func (p *UpdatePhysicalNetworkParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *UpdatePhysicalNetworkParams) GetTags() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5897,6 +6977,12 @@ func (p *UpdatePhysicalNetworkParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
+}
+
+func (p *UpdatePhysicalNetworkParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
 }
 
 func (p *UpdatePhysicalNetworkParams) GetVlan() (string, bool) {
@@ -6002,6 +7088,12 @@ func (p *UpdateStorageNetworkIpRangeParams) SetEndip(v string) {
 	p.p["endip"] = v
 }
 
+func (p *UpdateStorageNetworkIpRangeParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
+}
+
 func (p *UpdateStorageNetworkIpRangeParams) GetEndip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6015,6 +7107,12 @@ func (p *UpdateStorageNetworkIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateStorageNetworkIpRangeParams) GetId() (string, bool) {
@@ -6032,6 +7130,12 @@ func (p *UpdateStorageNetworkIpRangeParams) SetNetmask(v string) {
 	p.p["netmask"] = v
 }
 
+func (p *UpdateStorageNetworkIpRangeParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
+}
+
 func (p *UpdateStorageNetworkIpRangeParams) GetNetmask() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6047,6 +7151,12 @@ func (p *UpdateStorageNetworkIpRangeParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *UpdateStorageNetworkIpRangeParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *UpdateStorageNetworkIpRangeParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6060,6 +7170,12 @@ func (p *UpdateStorageNetworkIpRangeParams) SetVlan(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
+}
+
+func (p *UpdateStorageNetworkIpRangeParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
 }
 
 func (p *UpdateStorageNetworkIpRangeParams) GetVlan() (int, bool) {
@@ -6150,6 +7266,12 @@ func (p *DeleteGuestNetworkIpv6PrefixParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteGuestNetworkIpv6PrefixParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteGuestNetworkIpv6PrefixParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6229,6 +7351,12 @@ func (p *CreateGuestNetworkIpv6PrefixParams) SetPrefix(v string) {
 	p.p["prefix"] = v
 }
 
+func (p *CreateGuestNetworkIpv6PrefixParams) ResetPrefix() {
+	if p.p != nil && p.p["prefix"] != nil {
+		delete(p.p, "prefix")
+	}
+}
+
 func (p *CreateGuestNetworkIpv6PrefixParams) GetPrefix() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6242,6 +7370,12 @@ func (p *CreateGuestNetworkIpv6PrefixParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateGuestNetworkIpv6PrefixParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateGuestNetworkIpv6PrefixParams) GetZoneid() (string, bool) {
@@ -6345,6 +7479,12 @@ func (p *ListGuestNetworkIpv6PrefixesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListGuestNetworkIpv6PrefixesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListGuestNetworkIpv6PrefixesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6358,6 +7498,12 @@ func (p *ListGuestNetworkIpv6PrefixesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListGuestNetworkIpv6PrefixesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListGuestNetworkIpv6PrefixesParams) GetKeyword() (string, bool) {
@@ -6375,6 +7521,12 @@ func (p *ListGuestNetworkIpv6PrefixesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListGuestNetworkIpv6PrefixesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListGuestNetworkIpv6PrefixesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6390,6 +7542,12 @@ func (p *ListGuestNetworkIpv6PrefixesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListGuestNetworkIpv6PrefixesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListGuestNetworkIpv6PrefixesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6403,6 +7561,12 @@ func (p *ListGuestNetworkIpv6PrefixesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListGuestNetworkIpv6PrefixesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListGuestNetworkIpv6PrefixesParams) GetZoneid() (string, bool) {
@@ -6520,6 +7684,12 @@ func (p *CreateNetworkPermissionsParams) SetAccountids(v []string) {
 	p.p["accountids"] = v
 }
 
+func (p *CreateNetworkPermissionsParams) ResetAccountids() {
+	if p.p != nil && p.p["accountids"] != nil {
+		delete(p.p, "accountids")
+	}
+}
+
 func (p *CreateNetworkPermissionsParams) GetAccountids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6533,6 +7703,12 @@ func (p *CreateNetworkPermissionsParams) SetAccounts(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounts"] = v
+}
+
+func (p *CreateNetworkPermissionsParams) ResetAccounts() {
+	if p.p != nil && p.p["accounts"] != nil {
+		delete(p.p, "accounts")
+	}
 }
 
 func (p *CreateNetworkPermissionsParams) GetAccounts() ([]string, bool) {
@@ -6550,6 +7726,12 @@ func (p *CreateNetworkPermissionsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *CreateNetworkPermissionsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *CreateNetworkPermissionsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6563,6 +7745,12 @@ func (p *CreateNetworkPermissionsParams) SetProjectids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectids"] = v
+}
+
+func (p *CreateNetworkPermissionsParams) ResetProjectids() {
+	if p.p != nil && p.p["projectids"] != nil {
+		delete(p.p, "projectids")
+	}
 }
 
 func (p *CreateNetworkPermissionsParams) GetProjectids() ([]string, bool) {
@@ -6653,6 +7841,12 @@ func (p *ResetNetworkPermissionsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ResetNetworkPermissionsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ResetNetworkPermissionsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6741,6 +7935,12 @@ func (p *ListNetworkPermissionsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListNetworkPermissionsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListNetworkPermissionsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6824,6 +8024,12 @@ func (p *RemoveNetworkPermissionsParams) SetAccountids(v []string) {
 	p.p["accountids"] = v
 }
 
+func (p *RemoveNetworkPermissionsParams) ResetAccountids() {
+	if p.p != nil && p.p["accountids"] != nil {
+		delete(p.p, "accountids")
+	}
+}
+
 func (p *RemoveNetworkPermissionsParams) GetAccountids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6837,6 +8043,12 @@ func (p *RemoveNetworkPermissionsParams) SetAccounts(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounts"] = v
+}
+
+func (p *RemoveNetworkPermissionsParams) ResetAccounts() {
+	if p.p != nil && p.p["accounts"] != nil {
+		delete(p.p, "accounts")
+	}
 }
 
 func (p *RemoveNetworkPermissionsParams) GetAccounts() ([]string, bool) {
@@ -6854,6 +8066,12 @@ func (p *RemoveNetworkPermissionsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *RemoveNetworkPermissionsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *RemoveNetworkPermissionsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6867,6 +8085,12 @@ func (p *RemoveNetworkPermissionsParams) SetProjectids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectids"] = v
+}
+
+func (p *RemoveNetworkPermissionsParams) ResetProjectids() {
+	if p.p != nil && p.p["projectids"] != nil {
+		delete(p.p, "projectids")
+	}
 }
 
 func (p *RemoveNetworkPermissionsParams) GetProjectids() ([]string, bool) {

--- a/cloudstack/NicService.go
+++ b/cloudstack/NicService.go
@@ -61,6 +61,12 @@ func (p *AddIpToNicParams) SetIpaddress(v string) {
 	p.p["ipaddress"] = v
 }
 
+func (p *AddIpToNicParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
+}
+
 func (p *AddIpToNicParams) GetIpaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -74,6 +80,12 @@ func (p *AddIpToNicParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
+}
+
+func (p *AddIpToNicParams) ResetNicid() {
+	if p.p != nil && p.p["nicid"] != nil {
+		delete(p.p, "nicid")
+	}
 }
 
 func (p *AddIpToNicParams) GetNicid() (string, bool) {
@@ -185,6 +197,12 @@ func (p *ListNicsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListNicsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListNicsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -198,6 +216,12 @@ func (p *ListNicsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListNicsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListNicsParams) GetKeyword() (string, bool) {
@@ -215,6 +239,12 @@ func (p *ListNicsParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListNicsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListNicsParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -228,6 +258,12 @@ func (p *ListNicsParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
+}
+
+func (p *ListNicsParams) ResetNicid() {
+	if p.p != nil && p.p["nicid"] != nil {
+		delete(p.p, "nicid")
+	}
 }
 
 func (p *ListNicsParams) GetNicid() (string, bool) {
@@ -245,6 +281,12 @@ func (p *ListNicsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNicsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNicsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -260,6 +302,12 @@ func (p *ListNicsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListNicsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListNicsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -273,6 +321,12 @@ func (p *ListNicsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *ListNicsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *ListNicsParams) GetVirtualmachineid() (string, bool) {
@@ -373,6 +427,12 @@ func (p *RemoveIpFromNicParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RemoveIpFromNicParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RemoveIpFromNicParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -452,6 +512,12 @@ func (p *UpdateVmNicIpParams) SetIpaddress(v string) {
 	p.p["ipaddress"] = v
 }
 
+func (p *UpdateVmNicIpParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
+}
+
 func (p *UpdateVmNicIpParams) GetIpaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -465,6 +531,12 @@ func (p *UpdateVmNicIpParams) SetNicid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicid"] = v
+}
+
+func (p *UpdateVmNicIpParams) ResetNicid() {
+	if p.p != nil && p.p["nicid"] != nil {
+		delete(p.p, "nicid")
+	}
 }
 
 func (p *UpdateVmNicIpParams) GetNicid() (string, bool) {

--- a/cloudstack/NiciraNVPService.go
+++ b/cloudstack/NiciraNVPService.go
@@ -74,6 +74,12 @@ func (p *AddNiciraNvpDeviceParams) SetHostname(v string) {
 	p.p["hostname"] = v
 }
 
+func (p *AddNiciraNvpDeviceParams) ResetHostname() {
+	if p.p != nil && p.p["hostname"] != nil {
+		delete(p.p, "hostname")
+	}
+}
+
 func (p *AddNiciraNvpDeviceParams) GetHostname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -87,6 +93,12 @@ func (p *AddNiciraNvpDeviceParams) SetL2gatewayserviceuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["l2gatewayserviceuuid"] = v
+}
+
+func (p *AddNiciraNvpDeviceParams) ResetL2gatewayserviceuuid() {
+	if p.p != nil && p.p["l2gatewayserviceuuid"] != nil {
+		delete(p.p, "l2gatewayserviceuuid")
+	}
 }
 
 func (p *AddNiciraNvpDeviceParams) GetL2gatewayserviceuuid() (string, bool) {
@@ -104,6 +116,12 @@ func (p *AddNiciraNvpDeviceParams) SetL3gatewayserviceuuid(v string) {
 	p.p["l3gatewayserviceuuid"] = v
 }
 
+func (p *AddNiciraNvpDeviceParams) ResetL3gatewayserviceuuid() {
+	if p.p != nil && p.p["l3gatewayserviceuuid"] != nil {
+		delete(p.p, "l3gatewayserviceuuid")
+	}
+}
+
 func (p *AddNiciraNvpDeviceParams) GetL3gatewayserviceuuid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -117,6 +135,12 @@ func (p *AddNiciraNvpDeviceParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddNiciraNvpDeviceParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddNiciraNvpDeviceParams) GetPassword() (string, bool) {
@@ -134,6 +158,12 @@ func (p *AddNiciraNvpDeviceParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddNiciraNvpDeviceParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddNiciraNvpDeviceParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -149,6 +179,12 @@ func (p *AddNiciraNvpDeviceParams) SetTransportzoneuuid(v string) {
 	p.p["transportzoneuuid"] = v
 }
 
+func (p *AddNiciraNvpDeviceParams) ResetTransportzoneuuid() {
+	if p.p != nil && p.p["transportzoneuuid"] != nil {
+		delete(p.p, "transportzoneuuid")
+	}
+}
+
 func (p *AddNiciraNvpDeviceParams) GetTransportzoneuuid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -162,6 +198,12 @@ func (p *AddNiciraNvpDeviceParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddNiciraNvpDeviceParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddNiciraNvpDeviceParams) GetUsername() (string, bool) {
@@ -255,6 +297,12 @@ func (p *DeleteNiciraNvpDeviceParams) SetNvpdeviceid(v string) {
 	p.p["nvpdeviceid"] = v
 }
 
+func (p *DeleteNiciraNvpDeviceParams) ResetNvpdeviceid() {
+	if p.p != nil && p.p["nvpdeviceid"] != nil {
+		delete(p.p, "nvpdeviceid")
+	}
+}
+
 func (p *DeleteNiciraNvpDeviceParams) GetNvpdeviceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -345,6 +393,12 @@ func (p *ListNiciraNvpDevicesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListNiciraNvpDevicesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListNiciraNvpDevicesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -358,6 +412,12 @@ func (p *ListNiciraNvpDevicesParams) SetNvpdeviceid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nvpdeviceid"] = v
+}
+
+func (p *ListNiciraNvpDevicesParams) ResetNvpdeviceid() {
+	if p.p != nil && p.p["nvpdeviceid"] != nil {
+		delete(p.p, "nvpdeviceid")
+	}
 }
 
 func (p *ListNiciraNvpDevicesParams) GetNvpdeviceid() (string, bool) {
@@ -375,6 +435,12 @@ func (p *ListNiciraNvpDevicesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListNiciraNvpDevicesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListNiciraNvpDevicesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -390,6 +456,12 @@ func (p *ListNiciraNvpDevicesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListNiciraNvpDevicesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListNiciraNvpDevicesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -403,6 +475,12 @@ func (p *ListNiciraNvpDevicesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListNiciraNvpDevicesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListNiciraNvpDevicesParams) GetPhysicalnetworkid() (string, bool) {

--- a/cloudstack/OutofbandManagementService.go
+++ b/cloudstack/OutofbandManagementService.go
@@ -59,6 +59,12 @@ func (p *ChangeOutOfBandManagementPasswordParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ChangeOutOfBandManagementPasswordParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ChangeOutOfBandManagementPasswordParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -72,6 +78,12 @@ func (p *ChangeOutOfBandManagementPasswordParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *ChangeOutOfBandManagementPasswordParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *ChangeOutOfBandManagementPasswordParams) GetPassword() (string, bool) {
@@ -179,6 +191,12 @@ func (p *ConfigureOutOfBandManagementParams) SetAddress(v string) {
 	p.p["address"] = v
 }
 
+func (p *ConfigureOutOfBandManagementParams) ResetAddress() {
+	if p.p != nil && p.p["address"] != nil {
+		delete(p.p, "address")
+	}
+}
+
 func (p *ConfigureOutOfBandManagementParams) GetAddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -192,6 +210,12 @@ func (p *ConfigureOutOfBandManagementParams) SetDriver(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["driver"] = v
+}
+
+func (p *ConfigureOutOfBandManagementParams) ResetDriver() {
+	if p.p != nil && p.p["driver"] != nil {
+		delete(p.p, "driver")
+	}
 }
 
 func (p *ConfigureOutOfBandManagementParams) GetDriver() (string, bool) {
@@ -209,6 +233,12 @@ func (p *ConfigureOutOfBandManagementParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ConfigureOutOfBandManagementParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ConfigureOutOfBandManagementParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -222,6 +252,12 @@ func (p *ConfigureOutOfBandManagementParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *ConfigureOutOfBandManagementParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *ConfigureOutOfBandManagementParams) GetPassword() (string, bool) {
@@ -239,6 +275,12 @@ func (p *ConfigureOutOfBandManagementParams) SetPort(v string) {
 	p.p["port"] = v
 }
 
+func (p *ConfigureOutOfBandManagementParams) ResetPort() {
+	if p.p != nil && p.p["port"] != nil {
+		delete(p.p, "port")
+	}
+}
+
 func (p *ConfigureOutOfBandManagementParams) GetPort() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -252,6 +294,12 @@ func (p *ConfigureOutOfBandManagementParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *ConfigureOutOfBandManagementParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *ConfigureOutOfBandManagementParams) GetUsername() (string, bool) {
@@ -336,6 +384,12 @@ func (p *IssueOutOfBandManagementPowerActionParams) SetAction(v string) {
 	p.p["action"] = v
 }
 
+func (p *IssueOutOfBandManagementPowerActionParams) ResetAction() {
+	if p.p != nil && p.p["action"] != nil {
+		delete(p.p, "action")
+	}
+}
+
 func (p *IssueOutOfBandManagementPowerActionParams) GetAction() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -351,6 +405,12 @@ func (p *IssueOutOfBandManagementPowerActionParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *IssueOutOfBandManagementPowerActionParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *IssueOutOfBandManagementPowerActionParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -364,6 +424,12 @@ func (p *IssueOutOfBandManagementPowerActionParams) SetTimeout(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timeout"] = v
+}
+
+func (p *IssueOutOfBandManagementPowerActionParams) ResetTimeout() {
+	if p.p != nil && p.p["timeout"] != nil {
+		delete(p.p, "timeout")
+	}
 }
 
 func (p *IssueOutOfBandManagementPowerActionParams) GetTimeout() (int64, bool) {

--- a/cloudstack/OvsElementService.go
+++ b/cloudstack/OvsElementService.go
@@ -61,6 +61,12 @@ func (p *ConfigureOvsElementParams) SetEnabled(v bool) {
 	p.p["enabled"] = v
 }
 
+func (p *ConfigureOvsElementParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
+}
+
 func (p *ConfigureOvsElementParams) GetEnabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -74,6 +80,12 @@ func (p *ConfigureOvsElementParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ConfigureOvsElementParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ConfigureOvsElementParams) GetId() (string, bool) {
@@ -182,6 +194,12 @@ func (p *ListOvsElementsParams) SetEnabled(v bool) {
 	p.p["enabled"] = v
 }
 
+func (p *ListOvsElementsParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
+}
+
 func (p *ListOvsElementsParams) GetEnabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -195,6 +213,12 @@ func (p *ListOvsElementsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListOvsElementsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListOvsElementsParams) GetId() (string, bool) {
@@ -212,6 +236,12 @@ func (p *ListOvsElementsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListOvsElementsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListOvsElementsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -225,6 +255,12 @@ func (p *ListOvsElementsParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
+}
+
+func (p *ListOvsElementsParams) ResetNspid() {
+	if p.p != nil && p.p["nspid"] != nil {
+		delete(p.p, "nspid")
+	}
 }
 
 func (p *ListOvsElementsParams) GetNspid() (string, bool) {
@@ -242,6 +278,12 @@ func (p *ListOvsElementsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListOvsElementsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListOvsElementsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -255,6 +297,12 @@ func (p *ListOvsElementsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListOvsElementsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListOvsElementsParams) GetPagesize() (int, bool) {

--- a/cloudstack/PodService.go
+++ b/cloudstack/PodService.go
@@ -87,6 +87,12 @@ func (p *CreatePodParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *CreatePodParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *CreatePodParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -100,6 +106,12 @@ func (p *CreatePodParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
+}
+
+func (p *CreatePodParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
 }
 
 func (p *CreatePodParams) GetEndip() (string, bool) {
@@ -117,6 +129,12 @@ func (p *CreatePodParams) SetGateway(v string) {
 	p.p["gateway"] = v
 }
 
+func (p *CreatePodParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
+}
+
 func (p *CreatePodParams) GetGateway() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -130,6 +148,12 @@ func (p *CreatePodParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreatePodParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreatePodParams) GetName() (string, bool) {
@@ -147,6 +171,12 @@ func (p *CreatePodParams) SetNetmask(v string) {
 	p.p["netmask"] = v
 }
 
+func (p *CreatePodParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
+}
+
 func (p *CreatePodParams) GetNetmask() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -162,6 +192,12 @@ func (p *CreatePodParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *CreatePodParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *CreatePodParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -175,6 +211,12 @@ func (p *CreatePodParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreatePodParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreatePodParams) GetZoneid() (string, bool) {
@@ -285,6 +327,12 @@ func (p *DedicatePodParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DedicatePodParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DedicatePodParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -300,6 +348,12 @@ func (p *DedicatePodParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *DedicatePodParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *DedicatePodParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -313,6 +367,12 @@ func (p *DedicatePodParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *DedicatePodParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *DedicatePodParams) GetPodid() (string, bool) {
@@ -399,6 +459,12 @@ func (p *DeletePodParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeletePodParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeletePodParams) GetId() (string, bool) {
@@ -509,6 +575,12 @@ func (p *ListDedicatedPodsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListDedicatedPodsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListDedicatedPodsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -522,6 +594,12 @@ func (p *ListDedicatedPodsParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
+}
+
+func (p *ListDedicatedPodsParams) ResetAffinitygroupid() {
+	if p.p != nil && p.p["affinitygroupid"] != nil {
+		delete(p.p, "affinitygroupid")
+	}
 }
 
 func (p *ListDedicatedPodsParams) GetAffinitygroupid() (string, bool) {
@@ -539,6 +617,12 @@ func (p *ListDedicatedPodsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListDedicatedPodsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListDedicatedPodsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -552,6 +636,12 @@ func (p *ListDedicatedPodsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListDedicatedPodsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListDedicatedPodsParams) GetKeyword() (string, bool) {
@@ -569,6 +659,12 @@ func (p *ListDedicatedPodsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDedicatedPodsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDedicatedPodsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -584,6 +680,12 @@ func (p *ListDedicatedPodsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListDedicatedPodsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListDedicatedPodsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -597,6 +699,12 @@ func (p *ListDedicatedPodsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListDedicatedPodsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListDedicatedPodsParams) GetPodid() (string, bool) {
@@ -692,6 +800,12 @@ func (p *ListPodsParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *ListPodsParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *ListPodsParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -705,6 +819,12 @@ func (p *ListPodsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListPodsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListPodsParams) GetId() (string, bool) {
@@ -722,6 +842,12 @@ func (p *ListPodsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListPodsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListPodsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -735,6 +861,12 @@ func (p *ListPodsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListPodsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListPodsParams) GetName() (string, bool) {
@@ -752,6 +884,12 @@ func (p *ListPodsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListPodsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListPodsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -765,6 +903,12 @@ func (p *ListPodsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListPodsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListPodsParams) GetPagesize() (int, bool) {
@@ -782,6 +926,12 @@ func (p *ListPodsParams) SetShowcapacities(v bool) {
 	p.p["showcapacities"] = v
 }
 
+func (p *ListPodsParams) ResetShowcapacities() {
+	if p.p != nil && p.p["showcapacities"] != nil {
+		delete(p.p, "showcapacities")
+	}
+}
+
 func (p *ListPodsParams) GetShowcapacities() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -795,6 +945,12 @@ func (p *ListPodsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListPodsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListPodsParams) GetZoneid() (string, bool) {
@@ -981,6 +1137,12 @@ func (p *ReleaseDedicatedPodParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *ReleaseDedicatedPodParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *ReleaseDedicatedPodParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1075,6 +1237,12 @@ func (p *UpdatePodParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *UpdatePodParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *UpdatePodParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1088,6 +1256,12 @@ func (p *UpdatePodParams) SetEndip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endip"] = v
+}
+
+func (p *UpdatePodParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
 }
 
 func (p *UpdatePodParams) GetEndip() (string, bool) {
@@ -1105,6 +1279,12 @@ func (p *UpdatePodParams) SetGateway(v string) {
 	p.p["gateway"] = v
 }
 
+func (p *UpdatePodParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
+}
+
 func (p *UpdatePodParams) GetGateway() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1118,6 +1298,12 @@ func (p *UpdatePodParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdatePodParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdatePodParams) GetId() (string, bool) {
@@ -1135,6 +1321,12 @@ func (p *UpdatePodParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdatePodParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdatePodParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1150,6 +1342,12 @@ func (p *UpdatePodParams) SetNetmask(v string) {
 	p.p["netmask"] = v
 }
 
+func (p *UpdatePodParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
+}
+
 func (p *UpdatePodParams) GetNetmask() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1163,6 +1361,12 @@ func (p *UpdatePodParams) SetStartip(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startip"] = v
+}
+
+func (p *UpdatePodParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
 }
 
 func (p *UpdatePodParams) GetStartip() (string, bool) {

--- a/cloudstack/PoolService.go
+++ b/cloudstack/PoolService.go
@@ -113,6 +113,12 @@ func (p *CreateStoragePoolParams) SetCapacitybytes(v int64) {
 	p.p["capacitybytes"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetCapacitybytes() {
+	if p.p != nil && p.p["capacitybytes"] != nil {
+		delete(p.p, "capacitybytes")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetCapacitybytes() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -126,6 +132,12 @@ func (p *CreateStoragePoolParams) SetCapacityiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["capacityiops"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetCapacityiops() {
+	if p.p != nil && p.p["capacityiops"] != nil {
+		delete(p.p, "capacityiops")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetCapacityiops() (int64, bool) {
@@ -143,6 +155,12 @@ func (p *CreateStoragePoolParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -156,6 +174,12 @@ func (p *CreateStoragePoolParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetDetails() (map[string]string, bool) {
@@ -173,6 +197,12 @@ func (p *CreateStoragePoolParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -186,6 +216,12 @@ func (p *CreateStoragePoolParams) SetIstagarule(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["istagarule"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetIstagarule() {
+	if p.p != nil && p.p["istagarule"] != nil {
+		delete(p.p, "istagarule")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetIstagarule() (bool, bool) {
@@ -203,6 +239,12 @@ func (p *CreateStoragePoolParams) SetManaged(v bool) {
 	p.p["managed"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetManaged() {
+	if p.p != nil && p.p["managed"] != nil {
+		delete(p.p, "managed")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetManaged() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -216,6 +258,12 @@ func (p *CreateStoragePoolParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetName() (string, bool) {
@@ -233,6 +281,12 @@ func (p *CreateStoragePoolParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -246,6 +300,12 @@ func (p *CreateStoragePoolParams) SetProvider(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provider"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetProvider() {
+	if p.p != nil && p.p["provider"] != nil {
+		delete(p.p, "provider")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetProvider() (string, bool) {
@@ -263,6 +323,12 @@ func (p *CreateStoragePoolParams) SetScope(v string) {
 	p.p["scope"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetScope() {
+	if p.p != nil && p.p["scope"] != nil {
+		delete(p.p, "scope")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetScope() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -276,6 +342,12 @@ func (p *CreateStoragePoolParams) SetTags(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetTags() (string, bool) {
@@ -293,6 +365,12 @@ func (p *CreateStoragePoolParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *CreateStoragePoolParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *CreateStoragePoolParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -306,6 +384,12 @@ func (p *CreateStoragePoolParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateStoragePoolParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateStoragePoolParams) GetZoneid() (string, bool) {
@@ -404,6 +488,12 @@ func (p *DeleteStoragePoolParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *DeleteStoragePoolParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *DeleteStoragePoolParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -417,6 +507,12 @@ func (p *DeleteStoragePoolParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteStoragePoolParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteStoragePoolParams) GetId() (string, bool) {
@@ -518,6 +614,12 @@ func (p *FindStoragePoolsForMigrationParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *FindStoragePoolsForMigrationParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *FindStoragePoolsForMigrationParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -531,6 +633,12 @@ func (p *FindStoragePoolsForMigrationParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *FindStoragePoolsForMigrationParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *FindStoragePoolsForMigrationParams) GetKeyword() (string, bool) {
@@ -548,6 +656,12 @@ func (p *FindStoragePoolsForMigrationParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *FindStoragePoolsForMigrationParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *FindStoragePoolsForMigrationParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -561,6 +675,12 @@ func (p *FindStoragePoolsForMigrationParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *FindStoragePoolsForMigrationParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *FindStoragePoolsForMigrationParams) GetPagesize() (int, bool) {
@@ -687,6 +807,12 @@ func (p *ListStoragePoolsParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -700,6 +826,12 @@ func (p *ListStoragePoolsParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *ListStoragePoolsParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *ListStoragePoolsParams) GetHostid() (string, bool) {
@@ -717,6 +849,12 @@ func (p *ListStoragePoolsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -730,6 +868,12 @@ func (p *ListStoragePoolsParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+}
+
+func (p *ListStoragePoolsParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
 }
 
 func (p *ListStoragePoolsParams) GetIpaddress() (string, bool) {
@@ -747,6 +891,12 @@ func (p *ListStoragePoolsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -760,6 +910,12 @@ func (p *ListStoragePoolsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListStoragePoolsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListStoragePoolsParams) GetName() (string, bool) {
@@ -777,6 +933,12 @@ func (p *ListStoragePoolsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -790,6 +952,12 @@ func (p *ListStoragePoolsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListStoragePoolsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListStoragePoolsParams) GetPagesize() (int, bool) {
@@ -807,6 +975,12 @@ func (p *ListStoragePoolsParams) SetPath(v string) {
 	p.p["path"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetPath() {
+	if p.p != nil && p.p["path"] != nil {
+		delete(p.p, "path")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetPath() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -820,6 +994,12 @@ func (p *ListStoragePoolsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListStoragePoolsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListStoragePoolsParams) GetPodid() (string, bool) {
@@ -837,6 +1017,12 @@ func (p *ListStoragePoolsParams) SetScope(v string) {
 	p.p["scope"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetScope() {
+	if p.p != nil && p.p["scope"] != nil {
+		delete(p.p, "scope")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetScope() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -852,6 +1038,12 @@ func (p *ListStoragePoolsParams) SetStatus(v string) {
 	p.p["status"] = v
 }
 
+func (p *ListStoragePoolsParams) ResetStatus() {
+	if p.p != nil && p.p["status"] != nil {
+		delete(p.p, "status")
+	}
+}
+
 func (p *ListStoragePoolsParams) GetStatus() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -865,6 +1057,12 @@ func (p *ListStoragePoolsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListStoragePoolsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListStoragePoolsParams) GetZoneid() (string, bool) {
@@ -1040,6 +1238,12 @@ func (p *SyncStoragePoolParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *SyncStoragePoolParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *SyncStoragePoolParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1178,6 +1382,12 @@ func (p *UpdateStoragePoolParams) SetCapacitybytes(v int64) {
 	p.p["capacitybytes"] = v
 }
 
+func (p *UpdateStoragePoolParams) ResetCapacitybytes() {
+	if p.p != nil && p.p["capacitybytes"] != nil {
+		delete(p.p, "capacitybytes")
+	}
+}
+
 func (p *UpdateStoragePoolParams) GetCapacitybytes() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1191,6 +1401,12 @@ func (p *UpdateStoragePoolParams) SetCapacityiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["capacityiops"] = v
+}
+
+func (p *UpdateStoragePoolParams) ResetCapacityiops() {
+	if p.p != nil && p.p["capacityiops"] != nil {
+		delete(p.p, "capacityiops")
+	}
 }
 
 func (p *UpdateStoragePoolParams) GetCapacityiops() (int64, bool) {
@@ -1208,6 +1424,12 @@ func (p *UpdateStoragePoolParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *UpdateStoragePoolParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *UpdateStoragePoolParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1221,6 +1443,12 @@ func (p *UpdateStoragePoolParams) SetEnabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enabled"] = v
+}
+
+func (p *UpdateStoragePoolParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
 }
 
 func (p *UpdateStoragePoolParams) GetEnabled() (bool, bool) {
@@ -1238,6 +1466,12 @@ func (p *UpdateStoragePoolParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateStoragePoolParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateStoragePoolParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1251,6 +1485,12 @@ func (p *UpdateStoragePoolParams) SetIstagarule(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["istagarule"] = v
+}
+
+func (p *UpdateStoragePoolParams) ResetIstagarule() {
+	if p.p != nil && p.p["istagarule"] != nil {
+		delete(p.p, "istagarule")
+	}
 }
 
 func (p *UpdateStoragePoolParams) GetIstagarule() (bool, bool) {
@@ -1268,6 +1508,12 @@ func (p *UpdateStoragePoolParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateStoragePoolParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateStoragePoolParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1283,6 +1529,12 @@ func (p *UpdateStoragePoolParams) SetTags(v []string) {
 	p.p["tags"] = v
 }
 
+func (p *UpdateStoragePoolParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *UpdateStoragePoolParams) GetTags() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1296,6 +1548,12 @@ func (p *UpdateStoragePoolParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *UpdateStoragePoolParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *UpdateStoragePoolParams) GetUrl() (string, bool) {

--- a/cloudstack/PortableIPService.go
+++ b/cloudstack/PortableIPService.go
@@ -75,6 +75,12 @@ func (p *CreatePortableIpRangeParams) SetEndip(v string) {
 	p.p["endip"] = v
 }
 
+func (p *CreatePortableIpRangeParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
+}
+
 func (p *CreatePortableIpRangeParams) GetEndip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -88,6 +94,12 @@ func (p *CreatePortableIpRangeParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *CreatePortableIpRangeParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *CreatePortableIpRangeParams) GetGateway() (string, bool) {
@@ -105,6 +117,12 @@ func (p *CreatePortableIpRangeParams) SetNetmask(v string) {
 	p.p["netmask"] = v
 }
 
+func (p *CreatePortableIpRangeParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
+}
+
 func (p *CreatePortableIpRangeParams) GetNetmask() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -118,6 +136,12 @@ func (p *CreatePortableIpRangeParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
+}
+
+func (p *CreatePortableIpRangeParams) ResetRegionid() {
+	if p.p != nil && p.p["regionid"] != nil {
+		delete(p.p, "regionid")
+	}
 }
 
 func (p *CreatePortableIpRangeParams) GetRegionid() (int, bool) {
@@ -135,6 +159,12 @@ func (p *CreatePortableIpRangeParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *CreatePortableIpRangeParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *CreatePortableIpRangeParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -148,6 +178,12 @@ func (p *CreatePortableIpRangeParams) SetVlan(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlan"] = v
+}
+
+func (p *CreatePortableIpRangeParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
 }
 
 func (p *CreatePortableIpRangeParams) GetVlan() (string, bool) {
@@ -254,6 +290,12 @@ func (p *DeletePortableIpRangeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeletePortableIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeletePortableIpRangeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -345,6 +387,12 @@ func (p *ListPortableIpRangesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListPortableIpRangesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListPortableIpRangesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -358,6 +406,12 @@ func (p *ListPortableIpRangesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListPortableIpRangesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListPortableIpRangesParams) GetKeyword() (string, bool) {
@@ -375,6 +429,12 @@ func (p *ListPortableIpRangesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListPortableIpRangesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListPortableIpRangesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -390,6 +450,12 @@ func (p *ListPortableIpRangesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListPortableIpRangesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListPortableIpRangesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -403,6 +469,12 @@ func (p *ListPortableIpRangesParams) SetRegionid(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["regionid"] = v
+}
+
+func (p *ListPortableIpRangesParams) ResetRegionid() {
+	if p.p != nil && p.p["regionid"] != nil {
+		delete(p.p, "regionid")
+	}
 }
 
 func (p *ListPortableIpRangesParams) GetRegionid() (int, bool) {

--- a/cloudstack/ProjectService.go
+++ b/cloudstack/ProjectService.go
@@ -90,6 +90,12 @@ func (p *ActivateProjectParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ActivateProjectParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ActivateProjectParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -227,6 +233,12 @@ func (p *AddAccountToProjectParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AddAccountToProjectParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AddAccountToProjectParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -240,6 +252,12 @@ func (p *AddAccountToProjectParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
+}
+
+func (p *AddAccountToProjectParams) ResetEmail() {
+	if p.p != nil && p.p["email"] != nil {
+		delete(p.p, "email")
+	}
 }
 
 func (p *AddAccountToProjectParams) GetEmail() (string, bool) {
@@ -257,6 +275,12 @@ func (p *AddAccountToProjectParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *AddAccountToProjectParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *AddAccountToProjectParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -272,6 +296,12 @@ func (p *AddAccountToProjectParams) SetProjectroleid(v string) {
 	p.p["projectroleid"] = v
 }
 
+func (p *AddAccountToProjectParams) ResetProjectroleid() {
+	if p.p != nil && p.p["projectroleid"] != nil {
+		delete(p.p, "projectroleid")
+	}
+}
+
 func (p *AddAccountToProjectParams) GetProjectroleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -285,6 +315,12 @@ func (p *AddAccountToProjectParams) SetRoletype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roletype"] = v
+}
+
+func (p *AddAccountToProjectParams) ResetRoletype() {
+	if p.p != nil && p.p["roletype"] != nil {
+		delete(p.p, "roletype")
+	}
 }
 
 func (p *AddAccountToProjectParams) GetRoletype() (string, bool) {
@@ -375,6 +411,12 @@ func (p *AddUserToProjectParams) SetEmail(v string) {
 	p.p["email"] = v
 }
 
+func (p *AddUserToProjectParams) ResetEmail() {
+	if p.p != nil && p.p["email"] != nil {
+		delete(p.p, "email")
+	}
+}
+
 func (p *AddUserToProjectParams) GetEmail() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -388,6 +430,12 @@ func (p *AddUserToProjectParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *AddUserToProjectParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *AddUserToProjectParams) GetProjectid() (string, bool) {
@@ -405,6 +453,12 @@ func (p *AddUserToProjectParams) SetProjectroleid(v string) {
 	p.p["projectroleid"] = v
 }
 
+func (p *AddUserToProjectParams) ResetProjectroleid() {
+	if p.p != nil && p.p["projectroleid"] != nil {
+		delete(p.p, "projectroleid")
+	}
+}
+
 func (p *AddUserToProjectParams) GetProjectroleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -420,6 +474,12 @@ func (p *AddUserToProjectParams) SetRoletype(v string) {
 	p.p["roletype"] = v
 }
 
+func (p *AddUserToProjectParams) ResetRoletype() {
+	if p.p != nil && p.p["roletype"] != nil {
+		delete(p.p, "roletype")
+	}
+}
+
 func (p *AddUserToProjectParams) GetRoletype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -433,6 +493,12 @@ func (p *AddUserToProjectParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddUserToProjectParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddUserToProjectParams) GetUsername() (string, bool) {
@@ -527,6 +593,12 @@ func (p *CreateProjectParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateProjectParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateProjectParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -540,6 +612,12 @@ func (p *CreateProjectParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
+}
+
+func (p *CreateProjectParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
 }
 
 func (p *CreateProjectParams) GetAccountid() (string, bool) {
@@ -557,6 +635,12 @@ func (p *CreateProjectParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *CreateProjectParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *CreateProjectParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -570,6 +654,12 @@ func (p *CreateProjectParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateProjectParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateProjectParams) GetDomainid() (string, bool) {
@@ -587,6 +677,12 @@ func (p *CreateProjectParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateProjectParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateProjectParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -600,6 +696,12 @@ func (p *CreateProjectParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *CreateProjectParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *CreateProjectParams) GetUserid() (string, bool) {
@@ -731,6 +833,12 @@ func (p *DeleteAccountFromProjectParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DeleteAccountFromProjectParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DeleteAccountFromProjectParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -744,6 +852,12 @@ func (p *DeleteAccountFromProjectParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *DeleteAccountFromProjectParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *DeleteAccountFromProjectParams) GetProjectid() (string, bool) {
@@ -826,6 +940,12 @@ func (p *DeleteUserFromProjectParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *DeleteUserFromProjectParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *DeleteUserFromProjectParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -839,6 +959,12 @@ func (p *DeleteUserFromProjectParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *DeleteUserFromProjectParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *DeleteUserFromProjectParams) GetUserid() (string, bool) {
@@ -922,6 +1048,12 @@ func (p *DeleteProjectParams) SetCleanup(v bool) {
 	p.p["cleanup"] = v
 }
 
+func (p *DeleteProjectParams) ResetCleanup() {
+	if p.p != nil && p.p["cleanup"] != nil {
+		delete(p.p, "cleanup")
+	}
+}
+
 func (p *DeleteProjectParams) GetCleanup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -935,6 +1067,12 @@ func (p *DeleteProjectParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteProjectParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteProjectParams) GetId() (string, bool) {
@@ -1011,6 +1149,12 @@ func (p *DeleteProjectInvitationParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteProjectInvitationParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteProjectInvitationParams) GetId() (string, bool) {
@@ -1127,6 +1271,12 @@ func (p *ListProjectInvitationsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListProjectInvitationsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListProjectInvitationsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1140,6 +1290,12 @@ func (p *ListProjectInvitationsParams) SetActiveonly(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["activeonly"] = v
+}
+
+func (p *ListProjectInvitationsParams) ResetActiveonly() {
+	if p.p != nil && p.p["activeonly"] != nil {
+		delete(p.p, "activeonly")
+	}
 }
 
 func (p *ListProjectInvitationsParams) GetActiveonly() (bool, bool) {
@@ -1157,6 +1313,12 @@ func (p *ListProjectInvitationsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListProjectInvitationsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListProjectInvitationsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1170,6 +1332,12 @@ func (p *ListProjectInvitationsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListProjectInvitationsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListProjectInvitationsParams) GetId() (string, bool) {
@@ -1187,6 +1355,12 @@ func (p *ListProjectInvitationsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListProjectInvitationsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListProjectInvitationsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1200,6 +1374,12 @@ func (p *ListProjectInvitationsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListProjectInvitationsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListProjectInvitationsParams) GetKeyword() (string, bool) {
@@ -1217,6 +1397,12 @@ func (p *ListProjectInvitationsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListProjectInvitationsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListProjectInvitationsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1230,6 +1416,12 @@ func (p *ListProjectInvitationsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListProjectInvitationsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListProjectInvitationsParams) GetPage() (int, bool) {
@@ -1247,6 +1439,12 @@ func (p *ListProjectInvitationsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListProjectInvitationsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListProjectInvitationsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1260,6 +1458,12 @@ func (p *ListProjectInvitationsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListProjectInvitationsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListProjectInvitationsParams) GetProjectid() (string, bool) {
@@ -1277,6 +1481,12 @@ func (p *ListProjectInvitationsParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListProjectInvitationsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListProjectInvitationsParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1290,6 +1500,12 @@ func (p *ListProjectInvitationsParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *ListProjectInvitationsParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *ListProjectInvitationsParams) GetUserid() (string, bool) {
@@ -1449,6 +1665,12 @@ func (p *ListProjectsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListProjectsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListProjectsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1462,6 +1684,12 @@ func (p *ListProjectsParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ListProjectsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ListProjectsParams) GetDetails() ([]string, bool) {
@@ -1479,6 +1707,12 @@ func (p *ListProjectsParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *ListProjectsParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *ListProjectsParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1492,6 +1726,12 @@ func (p *ListProjectsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListProjectsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListProjectsParams) GetDomainid() (string, bool) {
@@ -1509,6 +1749,12 @@ func (p *ListProjectsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListProjectsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListProjectsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1522,6 +1768,12 @@ func (p *ListProjectsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListProjectsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListProjectsParams) GetIsrecursive() (bool, bool) {
@@ -1539,6 +1791,12 @@ func (p *ListProjectsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListProjectsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListProjectsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1552,6 +1810,12 @@ func (p *ListProjectsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListProjectsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListProjectsParams) GetListall() (bool, bool) {
@@ -1569,6 +1833,12 @@ func (p *ListProjectsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListProjectsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListProjectsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1582,6 +1852,12 @@ func (p *ListProjectsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListProjectsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListProjectsParams) GetPage() (int, bool) {
@@ -1599,6 +1875,12 @@ func (p *ListProjectsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListProjectsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListProjectsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1612,6 +1894,12 @@ func (p *ListProjectsParams) SetShowicon(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showicon"] = v
+}
+
+func (p *ListProjectsParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
 }
 
 func (p *ListProjectsParams) GetShowicon() (bool, bool) {
@@ -1629,6 +1917,12 @@ func (p *ListProjectsParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListProjectsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListProjectsParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1644,6 +1938,12 @@ func (p *ListProjectsParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListProjectsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListProjectsParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1657,6 +1957,12 @@ func (p *ListProjectsParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *ListProjectsParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *ListProjectsParams) GetUsername() (string, bool) {
@@ -1851,6 +2157,12 @@ func (p *SuspendProjectParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *SuspendProjectParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *SuspendProjectParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1995,6 +2307,12 @@ func (p *UpdateProjectParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UpdateProjectParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UpdateProjectParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2008,6 +2326,12 @@ func (p *UpdateProjectParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *UpdateProjectParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *UpdateProjectParams) GetDisplaytext() (string, bool) {
@@ -2025,6 +2349,12 @@ func (p *UpdateProjectParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateProjectParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateProjectParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2038,6 +2368,12 @@ func (p *UpdateProjectParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateProjectParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateProjectParams) GetName() (string, bool) {
@@ -2055,6 +2391,12 @@ func (p *UpdateProjectParams) SetRoletype(v string) {
 	p.p["roletype"] = v
 }
 
+func (p *UpdateProjectParams) ResetRoletype() {
+	if p.p != nil && p.p["roletype"] != nil {
+		delete(p.p, "roletype")
+	}
+}
+
 func (p *UpdateProjectParams) GetRoletype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2070,6 +2412,12 @@ func (p *UpdateProjectParams) SetSwapowner(v bool) {
 	p.p["swapowner"] = v
 }
 
+func (p *UpdateProjectParams) ResetSwapowner() {
+	if p.p != nil && p.p["swapowner"] != nil {
+		delete(p.p, "swapowner")
+	}
+}
+
 func (p *UpdateProjectParams) GetSwapowner() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2083,6 +2431,12 @@ func (p *UpdateProjectParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *UpdateProjectParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *UpdateProjectParams) GetUserid() (string, bool) {
@@ -2223,6 +2577,12 @@ func (p *UpdateProjectInvitationParams) SetAccept(v bool) {
 	p.p["accept"] = v
 }
 
+func (p *UpdateProjectInvitationParams) ResetAccept() {
+	if p.p != nil && p.p["accept"] != nil {
+		delete(p.p, "accept")
+	}
+}
+
 func (p *UpdateProjectInvitationParams) GetAccept() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2236,6 +2596,12 @@ func (p *UpdateProjectInvitationParams) SetAccount(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["account"] = v
+}
+
+func (p *UpdateProjectInvitationParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
 }
 
 func (p *UpdateProjectInvitationParams) GetAccount() (string, bool) {
@@ -2253,6 +2619,12 @@ func (p *UpdateProjectInvitationParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *UpdateProjectInvitationParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *UpdateProjectInvitationParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2268,6 +2640,12 @@ func (p *UpdateProjectInvitationParams) SetToken(v string) {
 	p.p["token"] = v
 }
 
+func (p *UpdateProjectInvitationParams) ResetToken() {
+	if p.p != nil && p.p["token"] != nil {
+		delete(p.p, "token")
+	}
+}
+
 func (p *UpdateProjectInvitationParams) GetToken() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2281,6 +2659,12 @@ func (p *UpdateProjectInvitationParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *UpdateProjectInvitationParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *UpdateProjectInvitationParams) GetUserid() (string, bool) {
@@ -2362,6 +2746,12 @@ func (p *ListProjectRolePermissionsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListProjectRolePermissionsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListProjectRolePermissionsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2375,6 +2765,12 @@ func (p *ListProjectRolePermissionsParams) SetProjectroleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectroleid"] = v
+}
+
+func (p *ListProjectRolePermissionsParams) ResetProjectroleid() {
+	if p.p != nil && p.p["projectroleid"] != nil {
+		delete(p.p, "projectroleid")
+	}
 }
 
 func (p *ListProjectRolePermissionsParams) GetProjectroleid() (string, bool) {
@@ -2460,6 +2856,12 @@ func (p *CreateProjectRolePermissionParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateProjectRolePermissionParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateProjectRolePermissionParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2473,6 +2875,12 @@ func (p *CreateProjectRolePermissionParams) SetPermission(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["permission"] = v
+}
+
+func (p *CreateProjectRolePermissionParams) ResetPermission() {
+	if p.p != nil && p.p["permission"] != nil {
+		delete(p.p, "permission")
+	}
 }
 
 func (p *CreateProjectRolePermissionParams) GetPermission() (string, bool) {
@@ -2490,6 +2898,12 @@ func (p *CreateProjectRolePermissionParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *CreateProjectRolePermissionParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *CreateProjectRolePermissionParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2505,6 +2919,12 @@ func (p *CreateProjectRolePermissionParams) SetProjectroleid(v string) {
 	p.p["projectroleid"] = v
 }
 
+func (p *CreateProjectRolePermissionParams) ResetProjectroleid() {
+	if p.p != nil && p.p["projectroleid"] != nil {
+		delete(p.p, "projectroleid")
+	}
+}
+
 func (p *CreateProjectRolePermissionParams) GetProjectroleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2518,6 +2938,12 @@ func (p *CreateProjectRolePermissionParams) SetRule(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["rule"] = v
+}
+
+func (p *CreateProjectRolePermissionParams) ResetRule() {
+	if p.p != nil && p.p["rule"] != nil {
+		delete(p.p, "rule")
+	}
 }
 
 func (p *CreateProjectRolePermissionParams) GetRule() (string, bool) {
@@ -2602,6 +3028,12 @@ func (p *UpdateProjectRolePermissionParams) SetPermission(v string) {
 	p.p["permission"] = v
 }
 
+func (p *UpdateProjectRolePermissionParams) ResetPermission() {
+	if p.p != nil && p.p["permission"] != nil {
+		delete(p.p, "permission")
+	}
+}
+
 func (p *UpdateProjectRolePermissionParams) GetPermission() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2615,6 +3047,12 @@ func (p *UpdateProjectRolePermissionParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *UpdateProjectRolePermissionParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *UpdateProjectRolePermissionParams) GetProjectid() (string, bool) {
@@ -2632,6 +3070,12 @@ func (p *UpdateProjectRolePermissionParams) SetProjectroleid(v string) {
 	p.p["projectroleid"] = v
 }
 
+func (p *UpdateProjectRolePermissionParams) ResetProjectroleid() {
+	if p.p != nil && p.p["projectroleid"] != nil {
+		delete(p.p, "projectroleid")
+	}
+}
+
 func (p *UpdateProjectRolePermissionParams) GetProjectroleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2647,6 +3091,12 @@ func (p *UpdateProjectRolePermissionParams) SetProjectrolepermissionid(v string)
 	p.p["projectrolepermissionid"] = v
 }
 
+func (p *UpdateProjectRolePermissionParams) ResetProjectrolepermissionid() {
+	if p.p != nil && p.p["projectrolepermissionid"] != nil {
+		delete(p.p, "projectrolepermissionid")
+	}
+}
+
 func (p *UpdateProjectRolePermissionParams) GetProjectrolepermissionid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2660,6 +3110,12 @@ func (p *UpdateProjectRolePermissionParams) SetRuleorder(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ruleorder"] = v
+}
+
+func (p *UpdateProjectRolePermissionParams) ResetRuleorder() {
+	if p.p != nil && p.p["ruleorder"] != nil {
+		delete(p.p, "ruleorder")
+	}
 }
 
 func (p *UpdateProjectRolePermissionParams) GetRuleorder() ([]string, bool) {
@@ -2754,6 +3210,12 @@ func (p *DeleteProjectRolePermissionParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteProjectRolePermissionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteProjectRolePermissionParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2767,6 +3229,12 @@ func (p *DeleteProjectRolePermissionParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *DeleteProjectRolePermissionParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *DeleteProjectRolePermissionParams) GetProjectid() (string, bool) {

--- a/cloudstack/RegionService.go
+++ b/cloudstack/RegionService.go
@@ -65,6 +65,12 @@ func (p *AddRegionParams) SetEndpoint(v string) {
 	p.p["endpoint"] = v
 }
 
+func (p *AddRegionParams) ResetEndpoint() {
+	if p.p != nil && p.p["endpoint"] != nil {
+		delete(p.p, "endpoint")
+	}
+}
+
 func (p *AddRegionParams) GetEndpoint() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -80,6 +86,12 @@ func (p *AddRegionParams) SetId(v int) {
 	p.p["id"] = v
 }
 
+func (p *AddRegionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *AddRegionParams) GetId() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -93,6 +105,12 @@ func (p *AddRegionParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *AddRegionParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *AddRegionParams) GetName() (string, bool) {
@@ -176,6 +194,12 @@ func (p *ListRegionsParams) SetId(v int) {
 	p.p["id"] = v
 }
 
+func (p *ListRegionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListRegionsParams) GetId() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -189,6 +213,12 @@ func (p *ListRegionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListRegionsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListRegionsParams) GetKeyword() (string, bool) {
@@ -206,6 +236,12 @@ func (p *ListRegionsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListRegionsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListRegionsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -221,6 +257,12 @@ func (p *ListRegionsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListRegionsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListRegionsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -234,6 +276,12 @@ func (p *ListRegionsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListRegionsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListRegionsParams) GetPagesize() (int, bool) {
@@ -303,6 +351,12 @@ func (p *RemoveRegionParams) SetId(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RemoveRegionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RemoveRegionParams) GetId() (int, bool) {
@@ -400,6 +454,12 @@ func (p *UpdateRegionParams) SetEndpoint(v string) {
 	p.p["endpoint"] = v
 }
 
+func (p *UpdateRegionParams) ResetEndpoint() {
+	if p.p != nil && p.p["endpoint"] != nil {
+		delete(p.p, "endpoint")
+	}
+}
+
 func (p *UpdateRegionParams) GetEndpoint() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -415,6 +475,12 @@ func (p *UpdateRegionParams) SetId(v int) {
 	p.p["id"] = v
 }
 
+func (p *UpdateRegionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateRegionParams) GetId() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -428,6 +494,12 @@ func (p *UpdateRegionParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateRegionParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateRegionParams) GetName() (string, bool) {

--- a/cloudstack/ResourcemetadataService.go
+++ b/cloudstack/ResourcemetadataService.go
@@ -73,6 +73,12 @@ func (p *AddResourceDetailParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *AddResourceDetailParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *AddResourceDetailParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -86,6 +92,12 @@ func (p *AddResourceDetailParams) SetFordisplay(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fordisplay"] = v
+}
+
+func (p *AddResourceDetailParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
 }
 
 func (p *AddResourceDetailParams) GetFordisplay() (bool, bool) {
@@ -103,6 +115,12 @@ func (p *AddResourceDetailParams) SetResourceid(v string) {
 	p.p["resourceid"] = v
 }
 
+func (p *AddResourceDetailParams) ResetResourceid() {
+	if p.p != nil && p.p["resourceid"] != nil {
+		delete(p.p, "resourceid")
+	}
+}
+
 func (p *AddResourceDetailParams) GetResourceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -116,6 +134,12 @@ func (p *AddResourceDetailParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
+}
+
+func (p *AddResourceDetailParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
 }
 
 func (p *AddResourceDetailParams) GetResourcetype() (string, bool) {
@@ -194,6 +218,12 @@ func (p *GetVolumeSnapshotDetailsParams) SetSnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshotid"] = v
+}
+
+func (p *GetVolumeSnapshotDetailsParams) ResetSnapshotid() {
+	if p.p != nil && p.p["snapshotid"] != nil {
+		delete(p.p, "snapshotid")
+	}
 }
 
 func (p *GetVolumeSnapshotDetailsParams) GetSnapshotid() (string, bool) {
@@ -297,6 +327,12 @@ func (p *ListResourceDetailsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -310,6 +346,12 @@ func (p *ListResourceDetailsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListResourceDetailsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListResourceDetailsParams) GetDomainid() (string, bool) {
@@ -327,6 +369,12 @@ func (p *ListResourceDetailsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -340,6 +388,12 @@ func (p *ListResourceDetailsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListResourceDetailsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListResourceDetailsParams) GetIsrecursive() (bool, bool) {
@@ -357,6 +411,12 @@ func (p *ListResourceDetailsParams) SetKey(v string) {
 	p.p["key"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetKey() {
+	if p.p != nil && p.p["key"] != nil {
+		delete(p.p, "key")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetKey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -370,6 +430,12 @@ func (p *ListResourceDetailsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListResourceDetailsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListResourceDetailsParams) GetKeyword() (string, bool) {
@@ -387,6 +453,12 @@ func (p *ListResourceDetailsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -400,6 +472,12 @@ func (p *ListResourceDetailsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListResourceDetailsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListResourceDetailsParams) GetPage() (int, bool) {
@@ -417,6 +495,12 @@ func (p *ListResourceDetailsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -430,6 +514,12 @@ func (p *ListResourceDetailsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListResourceDetailsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListResourceDetailsParams) GetProjectid() (string, bool) {
@@ -447,6 +537,12 @@ func (p *ListResourceDetailsParams) SetResourceid(v string) {
 	p.p["resourceid"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetResourceid() {
+	if p.p != nil && p.p["resourceid"] != nil {
+		delete(p.p, "resourceid")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetResourceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -462,6 +558,12 @@ func (p *ListResourceDetailsParams) SetResourcetype(v string) {
 	p.p["resourcetype"] = v
 }
 
+func (p *ListResourceDetailsParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
+}
+
 func (p *ListResourceDetailsParams) GetResourcetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -475,6 +577,12 @@ func (p *ListResourceDetailsParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
+}
+
+func (p *ListResourceDetailsParams) ResetValue() {
+	if p.p != nil && p.p["value"] != nil {
+		delete(p.p, "value")
+	}
 }
 
 func (p *ListResourceDetailsParams) GetValue() (string, bool) {
@@ -557,6 +665,12 @@ func (p *RemoveResourceDetailParams) SetKey(v string) {
 	p.p["key"] = v
 }
 
+func (p *RemoveResourceDetailParams) ResetKey() {
+	if p.p != nil && p.p["key"] != nil {
+		delete(p.p, "key")
+	}
+}
+
 func (p *RemoveResourceDetailParams) GetKey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -572,6 +686,12 @@ func (p *RemoveResourceDetailParams) SetResourceid(v string) {
 	p.p["resourceid"] = v
 }
 
+func (p *RemoveResourceDetailParams) ResetResourceid() {
+	if p.p != nil && p.p["resourceid"] != nil {
+		delete(p.p, "resourceid")
+	}
+}
+
 func (p *RemoveResourceDetailParams) GetResourceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -585,6 +705,12 @@ func (p *RemoveResourceDetailParams) SetResourcetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourcetype"] = v
+}
+
+func (p *RemoveResourceDetailParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
 }
 
 func (p *RemoveResourceDetailParams) GetResourcetype() (string, bool) {

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -75,6 +75,12 @@ func (p *CreateTagsParams) SetCustomer(v string) {
 	p.p["customer"] = v
 }
 
+func (p *CreateTagsParams) ResetCustomer() {
+	if p.p != nil && p.p["customer"] != nil {
+		delete(p.p, "customer")
+	}
+}
+
 func (p *CreateTagsParams) GetCustomer() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -88,6 +94,12 @@ func (p *CreateTagsParams) SetResourceids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["resourceids"] = v
+}
+
+func (p *CreateTagsParams) ResetResourceids() {
+	if p.p != nil && p.p["resourceids"] != nil {
+		delete(p.p, "resourceids")
+	}
 }
 
 func (p *CreateTagsParams) GetResourceids() ([]string, bool) {
@@ -105,6 +117,12 @@ func (p *CreateTagsParams) SetResourcetype(v string) {
 	p.p["resourcetype"] = v
 }
 
+func (p *CreateTagsParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
+}
+
 func (p *CreateTagsParams) GetResourcetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -118,6 +136,12 @@ func (p *CreateTagsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *CreateTagsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *CreateTagsParams) GetTags() (map[string]string, bool) {
@@ -211,6 +235,12 @@ func (p *DeleteTagsParams) SetResourceids(v []string) {
 	p.p["resourceids"] = v
 }
 
+func (p *DeleteTagsParams) ResetResourceids() {
+	if p.p != nil && p.p["resourceids"] != nil {
+		delete(p.p, "resourceids")
+	}
+}
+
 func (p *DeleteTagsParams) GetResourceids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -226,6 +256,12 @@ func (p *DeleteTagsParams) SetResourcetype(v string) {
 	p.p["resourcetype"] = v
 }
 
+func (p *DeleteTagsParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
+}
+
 func (p *DeleteTagsParams) GetResourcetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -239,6 +275,12 @@ func (p *DeleteTagsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *DeleteTagsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *DeleteTagsParams) GetTags() (map[string]string, bool) {
@@ -326,6 +368,12 @@ func (p *ListStorageTagsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListStorageTagsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListStorageTagsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -341,6 +389,12 @@ func (p *ListStorageTagsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListStorageTagsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListStorageTagsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -354,6 +408,12 @@ func (p *ListStorageTagsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListStorageTagsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListStorageTagsParams) GetPagesize() (int, bool) {
@@ -498,6 +558,12 @@ func (p *ListTagsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListTagsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListTagsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -511,6 +577,12 @@ func (p *ListTagsParams) SetCustomer(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customer"] = v
+}
+
+func (p *ListTagsParams) ResetCustomer() {
+	if p.p != nil && p.p["customer"] != nil {
+		delete(p.p, "customer")
+	}
 }
 
 func (p *ListTagsParams) GetCustomer() (string, bool) {
@@ -528,6 +600,12 @@ func (p *ListTagsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListTagsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListTagsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -541,6 +619,12 @@ func (p *ListTagsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListTagsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListTagsParams) GetIsrecursive() (bool, bool) {
@@ -558,6 +642,12 @@ func (p *ListTagsParams) SetKey(v string) {
 	p.p["key"] = v
 }
 
+func (p *ListTagsParams) ResetKey() {
+	if p.p != nil && p.p["key"] != nil {
+		delete(p.p, "key")
+	}
+}
+
 func (p *ListTagsParams) GetKey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -571,6 +661,12 @@ func (p *ListTagsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListTagsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListTagsParams) GetKeyword() (string, bool) {
@@ -588,6 +684,12 @@ func (p *ListTagsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListTagsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListTagsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -601,6 +703,12 @@ func (p *ListTagsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListTagsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListTagsParams) GetPage() (int, bool) {
@@ -618,6 +726,12 @@ func (p *ListTagsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListTagsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListTagsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -631,6 +745,12 @@ func (p *ListTagsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListTagsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListTagsParams) GetProjectid() (string, bool) {
@@ -648,6 +768,12 @@ func (p *ListTagsParams) SetResourceid(v string) {
 	p.p["resourceid"] = v
 }
 
+func (p *ListTagsParams) ResetResourceid() {
+	if p.p != nil && p.p["resourceid"] != nil {
+		delete(p.p, "resourceid")
+	}
+}
+
 func (p *ListTagsParams) GetResourceid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -663,6 +789,12 @@ func (p *ListTagsParams) SetResourcetype(v string) {
 	p.p["resourcetype"] = v
 }
 
+func (p *ListTagsParams) ResetResourcetype() {
+	if p.p != nil && p.p["resourcetype"] != nil {
+		delete(p.p, "resourcetype")
+	}
+}
+
 func (p *ListTagsParams) GetResourcetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -676,6 +808,12 @@ func (p *ListTagsParams) SetValue(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["value"] = v
+}
+
+func (p *ListTagsParams) ResetValue() {
+	if p.p != nil && p.p["value"] != nil {
+		delete(p.p, "value")
+	}
 }
 
 func (p *ListTagsParams) GetValue() (string, bool) {

--- a/cloudstack/RoleService.go
+++ b/cloudstack/RoleService.go
@@ -86,6 +86,12 @@ func (p *CreateRoleParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateRoleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateRoleParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -99,6 +105,12 @@ func (p *CreateRoleParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
+}
+
+func (p *CreateRoleParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
 }
 
 func (p *CreateRoleParams) GetIspublic() (bool, bool) {
@@ -116,6 +128,12 @@ func (p *CreateRoleParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateRoleParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateRoleParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -131,6 +149,12 @@ func (p *CreateRoleParams) SetRoleid(v string) {
 	p.p["roleid"] = v
 }
 
+func (p *CreateRoleParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
+}
+
 func (p *CreateRoleParams) GetRoleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -144,6 +168,12 @@ func (p *CreateRoleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *CreateRoleParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *CreateRoleParams) GetType() (string, bool) {
@@ -223,6 +253,12 @@ func (p *CreateRolePermissionParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateRolePermissionParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateRolePermissionParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -236,6 +272,12 @@ func (p *CreateRolePermissionParams) SetPermission(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["permission"] = v
+}
+
+func (p *CreateRolePermissionParams) ResetPermission() {
+	if p.p != nil && p.p["permission"] != nil {
+		delete(p.p, "permission")
+	}
 }
 
 func (p *CreateRolePermissionParams) GetPermission() (string, bool) {
@@ -253,6 +295,12 @@ func (p *CreateRolePermissionParams) SetRoleid(v string) {
 	p.p["roleid"] = v
 }
 
+func (p *CreateRolePermissionParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
+}
+
 func (p *CreateRolePermissionParams) GetRoleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -266,6 +314,12 @@ func (p *CreateRolePermissionParams) SetRule(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["rule"] = v
+}
+
+func (p *CreateRolePermissionParams) ResetRule() {
+	if p.p != nil && p.p["rule"] != nil {
+		delete(p.p, "rule")
+	}
 }
 
 func (p *CreateRolePermissionParams) GetRule() (string, bool) {
@@ -336,6 +390,12 @@ func (p *DeleteRoleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteRoleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteRoleParams) GetId() (string, bool) {
@@ -424,6 +484,12 @@ func (p *DeleteRolePermissionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteRolePermissionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteRolePermissionParams) GetId() (string, bool) {
@@ -535,6 +601,12 @@ func (p *ImportRoleParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *ImportRoleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *ImportRoleParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -548,6 +620,12 @@ func (p *ImportRoleParams) SetForced(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forced"] = v
+}
+
+func (p *ImportRoleParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
 }
 
 func (p *ImportRoleParams) GetForced() (bool, bool) {
@@ -565,6 +643,12 @@ func (p *ImportRoleParams) SetIspublic(v bool) {
 	p.p["ispublic"] = v
 }
 
+func (p *ImportRoleParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
+}
+
 func (p *ImportRoleParams) GetIspublic() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -578,6 +662,12 @@ func (p *ImportRoleParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ImportRoleParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ImportRoleParams) GetName() (string, bool) {
@@ -595,6 +685,12 @@ func (p *ImportRoleParams) SetRules(v map[string]string) {
 	p.p["rules"] = v
 }
 
+func (p *ImportRoleParams) ResetRules() {
+	if p.p != nil && p.p["rules"] != nil {
+		delete(p.p, "rules")
+	}
+}
+
 func (p *ImportRoleParams) GetRules() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -608,6 +704,12 @@ func (p *ImportRoleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ImportRoleParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ImportRoleParams) GetType() (string, bool) {
@@ -674,6 +776,12 @@ func (p *ListRolePermissionsParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
+}
+
+func (p *ListRolePermissionsParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
 }
 
 func (p *ListRolePermissionsParams) GetRoleid() (string, bool) {
@@ -762,6 +870,12 @@ func (p *ListRolesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListRolesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListRolesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -775,6 +889,12 @@ func (p *ListRolesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListRolesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListRolesParams) GetKeyword() (string, bool) {
@@ -792,6 +912,12 @@ func (p *ListRolesParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListRolesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListRolesParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -805,6 +931,12 @@ func (p *ListRolesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListRolesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListRolesParams) GetPage() (int, bool) {
@@ -822,6 +954,12 @@ func (p *ListRolesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListRolesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListRolesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -835,6 +973,12 @@ func (p *ListRolesParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListRolesParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListRolesParams) GetType() (string, bool) {
@@ -1005,6 +1149,12 @@ func (p *UpdateRoleParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *UpdateRoleParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *UpdateRoleParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1018,6 +1168,12 @@ func (p *UpdateRoleParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateRoleParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateRoleParams) GetId() (string, bool) {
@@ -1035,6 +1191,12 @@ func (p *UpdateRoleParams) SetIspublic(v bool) {
 	p.p["ispublic"] = v
 }
 
+func (p *UpdateRoleParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
+}
+
 func (p *UpdateRoleParams) GetIspublic() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1050,6 +1212,12 @@ func (p *UpdateRoleParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateRoleParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateRoleParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1063,6 +1231,12 @@ func (p *UpdateRoleParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *UpdateRoleParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *UpdateRoleParams) GetType() (string, bool) {
@@ -1140,6 +1314,12 @@ func (p *UpdateRolePermissionParams) SetPermission(v string) {
 	p.p["permission"] = v
 }
 
+func (p *UpdateRolePermissionParams) ResetPermission() {
+	if p.p != nil && p.p["permission"] != nil {
+		delete(p.p, "permission")
+	}
+}
+
 func (p *UpdateRolePermissionParams) GetPermission() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1153,6 +1333,12 @@ func (p *UpdateRolePermissionParams) SetRoleid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["roleid"] = v
+}
+
+func (p *UpdateRolePermissionParams) ResetRoleid() {
+	if p.p != nil && p.p["roleid"] != nil {
+		delete(p.p, "roleid")
+	}
 }
 
 func (p *UpdateRolePermissionParams) GetRoleid() (string, bool) {
@@ -1170,6 +1356,12 @@ func (p *UpdateRolePermissionParams) SetRuleid(v string) {
 	p.p["ruleid"] = v
 }
 
+func (p *UpdateRolePermissionParams) ResetRuleid() {
+	if p.p != nil && p.p["ruleid"] != nil {
+		delete(p.p, "ruleid")
+	}
+}
+
 func (p *UpdateRolePermissionParams) GetRuleid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1183,6 +1375,12 @@ func (p *UpdateRolePermissionParams) SetRuleorder(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ruleorder"] = v
+}
+
+func (p *UpdateRolePermissionParams) ResetRuleorder() {
+	if p.p != nil && p.p["ruleorder"] != nil {
+		delete(p.p, "ruleorder")
+	}
 }
 
 func (p *UpdateRolePermissionParams) GetRuleorder() ([]string, bool) {

--- a/cloudstack/RouterService.go
+++ b/cloudstack/RouterService.go
@@ -77,6 +77,12 @@ func (p *ChangeServiceForRouterParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ChangeServiceForRouterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ChangeServiceForRouterParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -90,6 +96,12 @@ func (p *ChangeServiceForRouterParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *ChangeServiceForRouterParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *ChangeServiceForRouterParams) GetServiceofferingid() (string, bool) {
@@ -217,6 +229,12 @@ func (p *ConfigureVirtualRouterElementParams) SetEnabled(v bool) {
 	p.p["enabled"] = v
 }
 
+func (p *ConfigureVirtualRouterElementParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
+}
+
 func (p *ConfigureVirtualRouterElementParams) GetEnabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -230,6 +248,12 @@ func (p *ConfigureVirtualRouterElementParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ConfigureVirtualRouterElementParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ConfigureVirtualRouterElementParams) GetId() (string, bool) {
@@ -323,6 +347,12 @@ func (p *CreateVirtualRouterElementParams) SetNspid(v string) {
 	p.p["nspid"] = v
 }
 
+func (p *CreateVirtualRouterElementParams) ResetNspid() {
+	if p.p != nil && p.p["nspid"] != nil {
+		delete(p.p, "nspid")
+	}
+}
+
 func (p *CreateVirtualRouterElementParams) GetNspid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -336,6 +366,12 @@ func (p *CreateVirtualRouterElementParams) SetProvidertype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["providertype"] = v
+}
+
+func (p *CreateVirtualRouterElementParams) ResetProvidertype() {
+	if p.p != nil && p.p["providertype"] != nil {
+		delete(p.p, "providertype")
+	}
 }
 
 func (p *CreateVirtualRouterElementParams) GetProvidertype() (string, bool) {
@@ -423,6 +459,12 @@ func (p *DestroyRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DestroyRouterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DestroyRouterParams) GetId() (string, bool) {
@@ -632,6 +674,12 @@ func (p *ListRoutersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListRoutersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListRoutersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -645,6 +693,12 @@ func (p *ListRoutersParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ListRoutersParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ListRoutersParams) GetClusterid() (string, bool) {
@@ -662,6 +716,12 @@ func (p *ListRoutersParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListRoutersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListRoutersParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -675,6 +735,12 @@ func (p *ListRoutersParams) SetFetchhealthcheckresults(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fetchhealthcheckresults"] = v
+}
+
+func (p *ListRoutersParams) ResetFetchhealthcheckresults() {
+	if p.p != nil && p.p["fetchhealthcheckresults"] != nil {
+		delete(p.p, "fetchhealthcheckresults")
+	}
 }
 
 func (p *ListRoutersParams) GetFetchhealthcheckresults() (bool, bool) {
@@ -692,6 +758,12 @@ func (p *ListRoutersParams) SetForvpc(v bool) {
 	p.p["forvpc"] = v
 }
 
+func (p *ListRoutersParams) ResetForvpc() {
+	if p.p != nil && p.p["forvpc"] != nil {
+		delete(p.p, "forvpc")
+	}
+}
+
 func (p *ListRoutersParams) GetForvpc() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -705,6 +777,12 @@ func (p *ListRoutersParams) SetHealthchecksfailed(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["healthchecksfailed"] = v
+}
+
+func (p *ListRoutersParams) ResetHealthchecksfailed() {
+	if p.p != nil && p.p["healthchecksfailed"] != nil {
+		delete(p.p, "healthchecksfailed")
+	}
 }
 
 func (p *ListRoutersParams) GetHealthchecksfailed() (bool, bool) {
@@ -722,6 +800,12 @@ func (p *ListRoutersParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ListRoutersParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ListRoutersParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -735,6 +819,12 @@ func (p *ListRoutersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListRoutersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListRoutersParams) GetId() (string, bool) {
@@ -752,6 +842,12 @@ func (p *ListRoutersParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListRoutersParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListRoutersParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -765,6 +861,12 @@ func (p *ListRoutersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListRoutersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListRoutersParams) GetKeyword() (string, bool) {
@@ -782,6 +884,12 @@ func (p *ListRoutersParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListRoutersParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListRoutersParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -795,6 +903,12 @@ func (p *ListRoutersParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListRoutersParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListRoutersParams) GetName() (string, bool) {
@@ -812,6 +926,12 @@ func (p *ListRoutersParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *ListRoutersParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *ListRoutersParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -825,6 +945,12 @@ func (p *ListRoutersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListRoutersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListRoutersParams) GetPage() (int, bool) {
@@ -842,6 +968,12 @@ func (p *ListRoutersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListRoutersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListRoutersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -855,6 +987,12 @@ func (p *ListRoutersParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListRoutersParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListRoutersParams) GetPodid() (string, bool) {
@@ -872,6 +1010,12 @@ func (p *ListRoutersParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListRoutersParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListRoutersParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -885,6 +1029,12 @@ func (p *ListRoutersParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListRoutersParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListRoutersParams) GetState() (string, bool) {
@@ -902,6 +1052,12 @@ func (p *ListRoutersParams) SetVersion(v string) {
 	p.p["version"] = v
 }
 
+func (p *ListRoutersParams) ResetVersion() {
+	if p.p != nil && p.p["version"] != nil {
+		delete(p.p, "version")
+	}
+}
+
 func (p *ListRoutersParams) GetVersion() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -917,6 +1073,12 @@ func (p *ListRoutersParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *ListRoutersParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *ListRoutersParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -930,6 +1092,12 @@ func (p *ListRoutersParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListRoutersParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListRoutersParams) GetZoneid() (string, bool) {
@@ -1157,6 +1325,12 @@ func (p *ListVirtualRouterElementsParams) SetEnabled(v bool) {
 	p.p["enabled"] = v
 }
 
+func (p *ListVirtualRouterElementsParams) ResetEnabled() {
+	if p.p != nil && p.p["enabled"] != nil {
+		delete(p.p, "enabled")
+	}
+}
+
 func (p *ListVirtualRouterElementsParams) GetEnabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1170,6 +1344,12 @@ func (p *ListVirtualRouterElementsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListVirtualRouterElementsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListVirtualRouterElementsParams) GetId() (string, bool) {
@@ -1187,6 +1367,12 @@ func (p *ListVirtualRouterElementsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVirtualRouterElementsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVirtualRouterElementsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1200,6 +1386,12 @@ func (p *ListVirtualRouterElementsParams) SetNspid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nspid"] = v
+}
+
+func (p *ListVirtualRouterElementsParams) ResetNspid() {
+	if p.p != nil && p.p["nspid"] != nil {
+		delete(p.p, "nspid")
+	}
 }
 
 func (p *ListVirtualRouterElementsParams) GetNspid() (string, bool) {
@@ -1217,6 +1409,12 @@ func (p *ListVirtualRouterElementsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVirtualRouterElementsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVirtualRouterElementsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1230,6 +1428,12 @@ func (p *ListVirtualRouterElementsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVirtualRouterElementsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVirtualRouterElementsParams) GetPagesize() (int, bool) {
@@ -1340,6 +1544,12 @@ func (p *RebootRouterParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *RebootRouterParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *RebootRouterParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1353,6 +1563,12 @@ func (p *RebootRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RebootRouterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RebootRouterParams) GetId() (string, bool) {
@@ -1493,6 +1709,12 @@ func (p *StartRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *StartRouterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *StartRouterParams) GetId() (string, bool) {
@@ -1639,6 +1861,12 @@ func (p *StopRouterParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *StopRouterParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *StopRouterParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1652,6 +1880,12 @@ func (p *StopRouterParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *StopRouterParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *StopRouterParams) GetId() (string, bool) {

--- a/cloudstack/SSHService.go
+++ b/cloudstack/SSHService.go
@@ -74,6 +74,12 @@ func (p *CreateSSHKeyPairParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateSSHKeyPairParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateSSHKeyPairParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -87,6 +93,12 @@ func (p *CreateSSHKeyPairParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateSSHKeyPairParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateSSHKeyPairParams) GetDomainid() (string, bool) {
@@ -104,6 +116,12 @@ func (p *CreateSSHKeyPairParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateSSHKeyPairParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateSSHKeyPairParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -117,6 +135,12 @@ func (p *CreateSSHKeyPairParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateSSHKeyPairParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateSSHKeyPairParams) GetProjectid() (string, bool) {
@@ -201,6 +225,12 @@ func (p *DeleteSSHKeyPairParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DeleteSSHKeyPairParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DeleteSSHKeyPairParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -214,6 +244,12 @@ func (p *DeleteSSHKeyPairParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DeleteSSHKeyPairParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DeleteSSHKeyPairParams) GetDomainid() (string, bool) {
@@ -231,6 +267,12 @@ func (p *DeleteSSHKeyPairParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *DeleteSSHKeyPairParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *DeleteSSHKeyPairParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -244,6 +286,12 @@ func (p *DeleteSSHKeyPairParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *DeleteSSHKeyPairParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *DeleteSSHKeyPairParams) GetProjectid() (string, bool) {
@@ -368,6 +416,12 @@ func (p *ListSSHKeyPairsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListSSHKeyPairsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListSSHKeyPairsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -381,6 +435,12 @@ func (p *ListSSHKeyPairsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListSSHKeyPairsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListSSHKeyPairsParams) GetDomainid() (string, bool) {
@@ -398,6 +458,12 @@ func (p *ListSSHKeyPairsParams) SetFingerprint(v string) {
 	p.p["fingerprint"] = v
 }
 
+func (p *ListSSHKeyPairsParams) ResetFingerprint() {
+	if p.p != nil && p.p["fingerprint"] != nil {
+		delete(p.p, "fingerprint")
+	}
+}
+
 func (p *ListSSHKeyPairsParams) GetFingerprint() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -411,6 +477,12 @@ func (p *ListSSHKeyPairsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListSSHKeyPairsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListSSHKeyPairsParams) GetId() (string, bool) {
@@ -428,6 +500,12 @@ func (p *ListSSHKeyPairsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListSSHKeyPairsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListSSHKeyPairsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -441,6 +519,12 @@ func (p *ListSSHKeyPairsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListSSHKeyPairsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListSSHKeyPairsParams) GetKeyword() (string, bool) {
@@ -458,6 +542,12 @@ func (p *ListSSHKeyPairsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListSSHKeyPairsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListSSHKeyPairsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -471,6 +561,12 @@ func (p *ListSSHKeyPairsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListSSHKeyPairsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListSSHKeyPairsParams) GetName() (string, bool) {
@@ -488,6 +584,12 @@ func (p *ListSSHKeyPairsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListSSHKeyPairsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListSSHKeyPairsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -503,6 +605,12 @@ func (p *ListSSHKeyPairsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListSSHKeyPairsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListSSHKeyPairsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -516,6 +624,12 @@ func (p *ListSSHKeyPairsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListSSHKeyPairsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListSSHKeyPairsParams) GetProjectid() (string, bool) {
@@ -685,6 +799,12 @@ func (p *RegisterSSHKeyPairParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *RegisterSSHKeyPairParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *RegisterSSHKeyPairParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -698,6 +818,12 @@ func (p *RegisterSSHKeyPairParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *RegisterSSHKeyPairParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *RegisterSSHKeyPairParams) GetDomainid() (string, bool) {
@@ -715,6 +841,12 @@ func (p *RegisterSSHKeyPairParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *RegisterSSHKeyPairParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *RegisterSSHKeyPairParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -730,6 +862,12 @@ func (p *RegisterSSHKeyPairParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *RegisterSSHKeyPairParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *RegisterSSHKeyPairParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -743,6 +881,12 @@ func (p *RegisterSSHKeyPairParams) SetPublickey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publickey"] = v
+}
+
+func (p *RegisterSSHKeyPairParams) ResetPublickey() {
+	if p.p != nil && p.p["publickey"] != nil {
+		delete(p.p, "publickey")
+	}
 }
 
 func (p *RegisterSSHKeyPairParams) GetPublickey() (string, bool) {
@@ -834,6 +978,12 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ResetSSHKeyForVirtualMachineParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ResetSSHKeyForVirtualMachineParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -847,6 +997,12 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) GetDomainid() (string, bool) {
@@ -864,6 +1020,12 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ResetSSHKeyForVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ResetSSHKeyForVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -877,6 +1039,12 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) ResetKeypair() {
+	if p.p != nil && p.p["keypair"] != nil {
+		delete(p.p, "keypair")
+	}
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) GetKeypair() (string, bool) {
@@ -894,6 +1062,12 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetKeypairs(v []string) {
 	p.p["keypairs"] = v
 }
 
+func (p *ResetSSHKeyForVirtualMachineParams) ResetKeypairs() {
+	if p.p != nil && p.p["keypairs"] != nil {
+		delete(p.p, "keypairs")
+	}
+}
+
 func (p *ResetSSHKeyForVirtualMachineParams) GetKeypairs() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -907,6 +1081,12 @@ func (p *ResetSSHKeyForVirtualMachineParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ResetSSHKeyForVirtualMachineParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ResetSSHKeyForVirtualMachineParams) GetProjectid() (string, bool) {

--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -143,6 +143,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AuthorizeSecurityGroupEgressParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AuthorizeSecurityGroupEgressParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -156,6 +162,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) GetCidrlist() ([]string, bool) {
@@ -173,6 +185,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *AuthorizeSecurityGroupEgressParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *AuthorizeSecurityGroupEgressParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -186,6 +204,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) GetEndport() (int, bool) {
@@ -203,6 +227,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetIcmpcode(v int) {
 	p.p["icmpcode"] = v
 }
 
+func (p *AuthorizeSecurityGroupEgressParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
+}
+
 func (p *AuthorizeSecurityGroupEgressParams) GetIcmpcode() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -216,6 +246,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) GetIcmptype() (int, bool) {
@@ -233,6 +269,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *AuthorizeSecurityGroupEgressParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *AuthorizeSecurityGroupEgressParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -246,6 +288,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) GetProtocol() (string, bool) {
@@ -263,6 +311,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupid(v string) {
 	p.p["securitygroupid"] = v
 }
 
+func (p *AuthorizeSecurityGroupEgressParams) ResetSecuritygroupid() {
+	if p.p != nil && p.p["securitygroupid"] != nil {
+		delete(p.p, "securitygroupid")
+	}
+}
+
 func (p *AuthorizeSecurityGroupEgressParams) GetSecuritygroupid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -276,6 +330,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetSecuritygroupname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupname"] = v
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) ResetSecuritygroupname() {
+	if p.p != nil && p.p["securitygroupname"] != nil {
+		delete(p.p, "securitygroupname")
+	}
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) GetSecuritygroupname() (string, bool) {
@@ -293,6 +353,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *AuthorizeSecurityGroupEgressParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *AuthorizeSecurityGroupEgressParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -306,6 +372,12 @@ func (p *AuthorizeSecurityGroupEgressParams) SetUsersecuritygrouplist(v map[stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["usersecuritygrouplist"] = v
+}
+
+func (p *AuthorizeSecurityGroupEgressParams) ResetUsersecuritygrouplist() {
+	if p.p != nil && p.p["usersecuritygrouplist"] != nil {
+		delete(p.p, "usersecuritygrouplist")
+	}
 }
 
 func (p *AuthorizeSecurityGroupEgressParams) GetUsersecuritygrouplist() (map[string]string, bool) {
@@ -443,6 +515,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AuthorizeSecurityGroupIngressParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AuthorizeSecurityGroupIngressParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -456,6 +534,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetCidrlist(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) GetCidrlist() ([]string, bool) {
@@ -473,6 +557,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *AuthorizeSecurityGroupIngressParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *AuthorizeSecurityGroupIngressParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -486,6 +576,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetEndport(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endport"] = v
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) ResetEndport() {
+	if p.p != nil && p.p["endport"] != nil {
+		delete(p.p, "endport")
+	}
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) GetEndport() (int, bool) {
@@ -503,6 +599,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetIcmpcode(v int) {
 	p.p["icmpcode"] = v
 }
 
+func (p *AuthorizeSecurityGroupIngressParams) ResetIcmpcode() {
+	if p.p != nil && p.p["icmpcode"] != nil {
+		delete(p.p, "icmpcode")
+	}
+}
+
 func (p *AuthorizeSecurityGroupIngressParams) GetIcmpcode() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -516,6 +618,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetIcmptype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["icmptype"] = v
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) ResetIcmptype() {
+	if p.p != nil && p.p["icmptype"] != nil {
+		delete(p.p, "icmptype")
+	}
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) GetIcmptype() (int, bool) {
@@ -533,6 +641,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *AuthorizeSecurityGroupIngressParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *AuthorizeSecurityGroupIngressParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -546,6 +660,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetProtocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["protocol"] = v
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) ResetProtocol() {
+	if p.p != nil && p.p["protocol"] != nil {
+		delete(p.p, "protocol")
+	}
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) GetProtocol() (string, bool) {
@@ -563,6 +683,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupid(v string) {
 	p.p["securitygroupid"] = v
 }
 
+func (p *AuthorizeSecurityGroupIngressParams) ResetSecuritygroupid() {
+	if p.p != nil && p.p["securitygroupid"] != nil {
+		delete(p.p, "securitygroupid")
+	}
+}
+
 func (p *AuthorizeSecurityGroupIngressParams) GetSecuritygroupid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -576,6 +702,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetSecuritygroupname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupname"] = v
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) ResetSecuritygroupname() {
+	if p.p != nil && p.p["securitygroupname"] != nil {
+		delete(p.p, "securitygroupname")
+	}
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) GetSecuritygroupname() (string, bool) {
@@ -593,6 +725,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetStartport(v int) {
 	p.p["startport"] = v
 }
 
+func (p *AuthorizeSecurityGroupIngressParams) ResetStartport() {
+	if p.p != nil && p.p["startport"] != nil {
+		delete(p.p, "startport")
+	}
+}
+
 func (p *AuthorizeSecurityGroupIngressParams) GetStartport() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -606,6 +744,12 @@ func (p *AuthorizeSecurityGroupIngressParams) SetUsersecuritygrouplist(v map[str
 		p.p = make(map[string]interface{})
 	}
 	p.p["usersecuritygrouplist"] = v
+}
+
+func (p *AuthorizeSecurityGroupIngressParams) ResetUsersecuritygrouplist() {
+	if p.p != nil && p.p["usersecuritygrouplist"] != nil {
+		delete(p.p, "usersecuritygrouplist")
+	}
 }
 
 func (p *AuthorizeSecurityGroupIngressParams) GetUsersecuritygrouplist() (map[string]string, bool) {
@@ -713,6 +857,12 @@ func (p *CreateSecurityGroupParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateSecurityGroupParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateSecurityGroupParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -726,6 +876,12 @@ func (p *CreateSecurityGroupParams) SetDescription(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["description"] = v
+}
+
+func (p *CreateSecurityGroupParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
 }
 
 func (p *CreateSecurityGroupParams) GetDescription() (string, bool) {
@@ -743,6 +899,12 @@ func (p *CreateSecurityGroupParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateSecurityGroupParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateSecurityGroupParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -758,6 +920,12 @@ func (p *CreateSecurityGroupParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateSecurityGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateSecurityGroupParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -771,6 +939,12 @@ func (p *CreateSecurityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateSecurityGroupParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateSecurityGroupParams) GetProjectid() (string, bool) {
@@ -874,6 +1048,12 @@ func (p *DeleteSecurityGroupParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DeleteSecurityGroupParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DeleteSecurityGroupParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -887,6 +1067,12 @@ func (p *DeleteSecurityGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DeleteSecurityGroupParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DeleteSecurityGroupParams) GetDomainid() (string, bool) {
@@ -904,6 +1090,12 @@ func (p *DeleteSecurityGroupParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteSecurityGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteSecurityGroupParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -919,6 +1111,12 @@ func (p *DeleteSecurityGroupParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *DeleteSecurityGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *DeleteSecurityGroupParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -932,6 +1130,12 @@ func (p *DeleteSecurityGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *DeleteSecurityGroupParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *DeleteSecurityGroupParams) GetProjectid() (string, bool) {
@@ -1062,6 +1266,12 @@ func (p *ListSecurityGroupsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListSecurityGroupsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListSecurityGroupsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1075,6 +1285,12 @@ func (p *ListSecurityGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListSecurityGroupsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListSecurityGroupsParams) GetDomainid() (string, bool) {
@@ -1092,6 +1308,12 @@ func (p *ListSecurityGroupsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListSecurityGroupsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListSecurityGroupsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1105,6 +1327,12 @@ func (p *ListSecurityGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListSecurityGroupsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListSecurityGroupsParams) GetIsrecursive() (bool, bool) {
@@ -1122,6 +1350,12 @@ func (p *ListSecurityGroupsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListSecurityGroupsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListSecurityGroupsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1135,6 +1369,12 @@ func (p *ListSecurityGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListSecurityGroupsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListSecurityGroupsParams) GetListall() (bool, bool) {
@@ -1152,6 +1392,12 @@ func (p *ListSecurityGroupsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListSecurityGroupsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListSecurityGroupsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1165,6 +1411,12 @@ func (p *ListSecurityGroupsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListSecurityGroupsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListSecurityGroupsParams) GetPagesize() (int, bool) {
@@ -1182,6 +1434,12 @@ func (p *ListSecurityGroupsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListSecurityGroupsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListSecurityGroupsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1195,6 +1453,12 @@ func (p *ListSecurityGroupsParams) SetSecuritygroupname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupname"] = v
+}
+
+func (p *ListSecurityGroupsParams) ResetSecuritygroupname() {
+	if p.p != nil && p.p["securitygroupname"] != nil {
+		delete(p.p, "securitygroupname")
+	}
 }
 
 func (p *ListSecurityGroupsParams) GetSecuritygroupname() (string, bool) {
@@ -1212,6 +1476,12 @@ func (p *ListSecurityGroupsParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListSecurityGroupsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListSecurityGroupsParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1225,6 +1495,12 @@ func (p *ListSecurityGroupsParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *ListSecurityGroupsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *ListSecurityGroupsParams) GetVirtualmachineid() (string, bool) {
@@ -1399,6 +1675,12 @@ func (p *RevokeSecurityGroupEgressParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RevokeSecurityGroupEgressParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RevokeSecurityGroupEgressParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1473,6 +1755,12 @@ func (p *RevokeSecurityGroupIngressParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RevokeSecurityGroupIngressParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RevokeSecurityGroupIngressParams) GetId() (string, bool) {

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -240,6 +240,12 @@ func (p *CreateServiceOfferingParams) SetBytesreadrate(v int64) {
 	p.p["bytesreadrate"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetBytesreadrate() {
+	if p.p != nil && p.p["bytesreadrate"] != nil {
+		delete(p.p, "bytesreadrate")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetBytesreadrate() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -253,6 +259,12 @@ func (p *CreateServiceOfferingParams) SetBytesreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bytesreadratemax"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetBytesreadratemax() {
+	if p.p != nil && p.p["bytesreadratemax"] != nil {
+		delete(p.p, "bytesreadratemax")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetBytesreadratemax() (int64, bool) {
@@ -270,6 +282,12 @@ func (p *CreateServiceOfferingParams) SetBytesreadratemaxlength(v int64) {
 	p.p["bytesreadratemaxlength"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetBytesreadratemaxlength() {
+	if p.p != nil && p.p["bytesreadratemaxlength"] != nil {
+		delete(p.p, "bytesreadratemaxlength")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetBytesreadratemaxlength() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -283,6 +301,12 @@ func (p *CreateServiceOfferingParams) SetByteswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriterate"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetByteswriterate() {
+	if p.p != nil && p.p["byteswriterate"] != nil {
+		delete(p.p, "byteswriterate")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetByteswriterate() (int64, bool) {
@@ -300,6 +324,12 @@ func (p *CreateServiceOfferingParams) SetByteswriteratemax(v int64) {
 	p.p["byteswriteratemax"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetByteswriteratemax() {
+	if p.p != nil && p.p["byteswriteratemax"] != nil {
+		delete(p.p, "byteswriteratemax")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetByteswriteratemax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -313,6 +343,12 @@ func (p *CreateServiceOfferingParams) SetByteswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["byteswriteratemaxlength"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetByteswriteratemaxlength() {
+	if p.p != nil && p.p["byteswriteratemaxlength"] != nil {
+		delete(p.p, "byteswriteratemaxlength")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetByteswriteratemaxlength() (int64, bool) {
@@ -330,6 +366,12 @@ func (p *CreateServiceOfferingParams) SetCachemode(v string) {
 	p.p["cachemode"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetCachemode() {
+	if p.p != nil && p.p["cachemode"] != nil {
+		delete(p.p, "cachemode")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetCachemode() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -343,6 +385,12 @@ func (p *CreateServiceOfferingParams) SetCpunumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cpunumber"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetCpunumber() {
+	if p.p != nil && p.p["cpunumber"] != nil {
+		delete(p.p, "cpunumber")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetCpunumber() (int, bool) {
@@ -360,6 +408,12 @@ func (p *CreateServiceOfferingParams) SetCpuspeed(v int) {
 	p.p["cpuspeed"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetCpuspeed() {
+	if p.p != nil && p.p["cpuspeed"] != nil {
+		delete(p.p, "cpuspeed")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetCpuspeed() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -373,6 +427,12 @@ func (p *CreateServiceOfferingParams) SetCustomized(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customized"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetCustomized() {
+	if p.p != nil && p.p["customized"] != nil {
+		delete(p.p, "customized")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetCustomized() (bool, bool) {
@@ -390,6 +450,12 @@ func (p *CreateServiceOfferingParams) SetCustomizediops(v bool) {
 	p.p["customizediops"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetCustomizediops() {
+	if p.p != nil && p.p["customizediops"] != nil {
+		delete(p.p, "customizediops")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetCustomizediops() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -403,6 +469,12 @@ func (p *CreateServiceOfferingParams) SetDeploymentplanner(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deploymentplanner"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetDeploymentplanner() {
+	if p.p != nil && p.p["deploymentplanner"] != nil {
+		delete(p.p, "deploymentplanner")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetDeploymentplanner() (string, bool) {
@@ -420,6 +492,12 @@ func (p *CreateServiceOfferingParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -433,6 +511,12 @@ func (p *CreateServiceOfferingParams) SetDiskofferingstrictness(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingstrictness"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetDiskofferingstrictness() {
+	if p.p != nil && p.p["diskofferingstrictness"] != nil {
+		delete(p.p, "diskofferingstrictness")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetDiskofferingstrictness() (bool, bool) {
@@ -450,6 +534,12 @@ func (p *CreateServiceOfferingParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -463,6 +553,12 @@ func (p *CreateServiceOfferingParams) SetDomainid(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetDomainid() ([]string, bool) {
@@ -480,6 +576,12 @@ func (p *CreateServiceOfferingParams) SetDynamicscalingenabled(v bool) {
 	p.p["dynamicscalingenabled"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetDynamicscalingenabled() {
+	if p.p != nil && p.p["dynamicscalingenabled"] != nil {
+		delete(p.p, "dynamicscalingenabled")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetDynamicscalingenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -493,6 +595,12 @@ func (p *CreateServiceOfferingParams) SetEncryptroot(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["encryptroot"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetEncryptroot() {
+	if p.p != nil && p.p["encryptroot"] != nil {
+		delete(p.p, "encryptroot")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetEncryptroot() (bool, bool) {
@@ -510,6 +618,12 @@ func (p *CreateServiceOfferingParams) SetHosttags(v string) {
 	p.p["hosttags"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetHosttags() {
+	if p.p != nil && p.p["hosttags"] != nil {
+		delete(p.p, "hosttags")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetHosttags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -523,6 +637,12 @@ func (p *CreateServiceOfferingParams) SetHypervisorsnapshotreserve(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisorsnapshotreserve"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetHypervisorsnapshotreserve() {
+	if p.p != nil && p.p["hypervisorsnapshotreserve"] != nil {
+		delete(p.p, "hypervisorsnapshotreserve")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetHypervisorsnapshotreserve() (int, bool) {
@@ -540,6 +660,12 @@ func (p *CreateServiceOfferingParams) SetIopsreadrate(v int64) {
 	p.p["iopsreadrate"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetIopsreadrate() {
+	if p.p != nil && p.p["iopsreadrate"] != nil {
+		delete(p.p, "iopsreadrate")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetIopsreadrate() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -553,6 +679,12 @@ func (p *CreateServiceOfferingParams) SetIopsreadratemax(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopsreadratemax"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetIopsreadratemax() {
+	if p.p != nil && p.p["iopsreadratemax"] != nil {
+		delete(p.p, "iopsreadratemax")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetIopsreadratemax() (int64, bool) {
@@ -570,6 +702,12 @@ func (p *CreateServiceOfferingParams) SetIopsreadratemaxlength(v int64) {
 	p.p["iopsreadratemaxlength"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetIopsreadratemaxlength() {
+	if p.p != nil && p.p["iopsreadratemaxlength"] != nil {
+		delete(p.p, "iopsreadratemaxlength")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetIopsreadratemaxlength() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -583,6 +721,12 @@ func (p *CreateServiceOfferingParams) SetIopswriterate(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriterate"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetIopswriterate() {
+	if p.p != nil && p.p["iopswriterate"] != nil {
+		delete(p.p, "iopswriterate")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetIopswriterate() (int64, bool) {
@@ -600,6 +744,12 @@ func (p *CreateServiceOfferingParams) SetIopswriteratemax(v int64) {
 	p.p["iopswriteratemax"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetIopswriteratemax() {
+	if p.p != nil && p.p["iopswriteratemax"] != nil {
+		delete(p.p, "iopswriteratemax")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetIopswriteratemax() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -613,6 +763,12 @@ func (p *CreateServiceOfferingParams) SetIopswriteratemaxlength(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iopswriteratemaxlength"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetIopswriteratemaxlength() {
+	if p.p != nil && p.p["iopswriteratemaxlength"] != nil {
+		delete(p.p, "iopswriteratemaxlength")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetIopswriteratemaxlength() (int64, bool) {
@@ -630,6 +786,12 @@ func (p *CreateServiceOfferingParams) SetIssystem(v bool) {
 	p.p["issystem"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetIssystem() {
+	if p.p != nil && p.p["issystem"] != nil {
+		delete(p.p, "issystem")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetIssystem() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -643,6 +805,12 @@ func (p *CreateServiceOfferingParams) SetIsvolatile(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isvolatile"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetIsvolatile() {
+	if p.p != nil && p.p["isvolatile"] != nil {
+		delete(p.p, "isvolatile")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetIsvolatile() (bool, bool) {
@@ -660,6 +828,12 @@ func (p *CreateServiceOfferingParams) SetLimitcpuuse(v bool) {
 	p.p["limitcpuuse"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetLimitcpuuse() {
+	if p.p != nil && p.p["limitcpuuse"] != nil {
+		delete(p.p, "limitcpuuse")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetLimitcpuuse() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -673,6 +847,12 @@ func (p *CreateServiceOfferingParams) SetMaxcpunumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxcpunumber"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetMaxcpunumber() {
+	if p.p != nil && p.p["maxcpunumber"] != nil {
+		delete(p.p, "maxcpunumber")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetMaxcpunumber() (int, bool) {
@@ -690,6 +870,12 @@ func (p *CreateServiceOfferingParams) SetMaxiops(v int64) {
 	p.p["maxiops"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetMaxiops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -703,6 +889,12 @@ func (p *CreateServiceOfferingParams) SetMaxmemory(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxmemory"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetMaxmemory() {
+	if p.p != nil && p.p["maxmemory"] != nil {
+		delete(p.p, "maxmemory")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetMaxmemory() (int, bool) {
@@ -720,6 +912,12 @@ func (p *CreateServiceOfferingParams) SetMemory(v int) {
 	p.p["memory"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetMemory() {
+	if p.p != nil && p.p["memory"] != nil {
+		delete(p.p, "memory")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetMemory() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -733,6 +931,12 @@ func (p *CreateServiceOfferingParams) SetMincpunumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mincpunumber"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetMincpunumber() {
+	if p.p != nil && p.p["mincpunumber"] != nil {
+		delete(p.p, "mincpunumber")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetMincpunumber() (int, bool) {
@@ -750,6 +954,12 @@ func (p *CreateServiceOfferingParams) SetMiniops(v int64) {
 	p.p["miniops"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetMiniops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -763,6 +973,12 @@ func (p *CreateServiceOfferingParams) SetMinmemory(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["minmemory"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetMinmemory() {
+	if p.p != nil && p.p["minmemory"] != nil {
+		delete(p.p, "minmemory")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetMinmemory() (int, bool) {
@@ -780,6 +996,12 @@ func (p *CreateServiceOfferingParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -793,6 +1015,12 @@ func (p *CreateServiceOfferingParams) SetNetworkrate(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkrate"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetNetworkrate() {
+	if p.p != nil && p.p["networkrate"] != nil {
+		delete(p.p, "networkrate")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetNetworkrate() (int, bool) {
@@ -810,6 +1038,12 @@ func (p *CreateServiceOfferingParams) SetOfferha(v bool) {
 	p.p["offerha"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetOfferha() {
+	if p.p != nil && p.p["offerha"] != nil {
+		delete(p.p, "offerha")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetOfferha() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -823,6 +1057,12 @@ func (p *CreateServiceOfferingParams) SetProvisioningtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["provisioningtype"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetProvisioningtype() {
+	if p.p != nil && p.p["provisioningtype"] != nil {
+		delete(p.p, "provisioningtype")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetProvisioningtype() (string, bool) {
@@ -840,6 +1080,12 @@ func (p *CreateServiceOfferingParams) SetRootdisksize(v int64) {
 	p.p["rootdisksize"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetRootdisksize() {
+	if p.p != nil && p.p["rootdisksize"] != nil {
+		delete(p.p, "rootdisksize")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetRootdisksize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -853,6 +1099,12 @@ func (p *CreateServiceOfferingParams) SetServiceofferingdetails(v map[string]str
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingdetails"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetServiceofferingdetails() {
+	if p.p != nil && p.p["serviceofferingdetails"] != nil {
+		delete(p.p, "serviceofferingdetails")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetServiceofferingdetails() (map[string]string, bool) {
@@ -870,6 +1122,12 @@ func (p *CreateServiceOfferingParams) SetStoragepolicy(v string) {
 	p.p["storagepolicy"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetStoragepolicy() {
+	if p.p != nil && p.p["storagepolicy"] != nil {
+		delete(p.p, "storagepolicy")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetStoragepolicy() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -883,6 +1141,12 @@ func (p *CreateServiceOfferingParams) SetStoragetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storagetype"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetStoragetype() {
+	if p.p != nil && p.p["storagetype"] != nil {
+		delete(p.p, "storagetype")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetStoragetype() (string, bool) {
@@ -900,6 +1164,12 @@ func (p *CreateServiceOfferingParams) SetSystemvmtype(v string) {
 	p.p["systemvmtype"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetSystemvmtype() {
+	if p.p != nil && p.p["systemvmtype"] != nil {
+		delete(p.p, "systemvmtype")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetSystemvmtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -915,6 +1185,12 @@ func (p *CreateServiceOfferingParams) SetTags(v string) {
 	p.p["tags"] = v
 }
 
+func (p *CreateServiceOfferingParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *CreateServiceOfferingParams) GetTags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -928,6 +1204,12 @@ func (p *CreateServiceOfferingParams) SetZoneid(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateServiceOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateServiceOfferingParams) GetZoneid() ([]string, bool) {
@@ -1043,6 +1325,12 @@ func (p *DeleteServiceOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteServiceOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteServiceOfferingParams) GetId() (string, bool) {
@@ -1196,6 +1484,12 @@ func (p *ListServiceOfferingsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1209,6 +1503,12 @@ func (p *ListServiceOfferingsParams) SetCpunumber(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cpunumber"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetCpunumber() {
+	if p.p != nil && p.p["cpunumber"] != nil {
+		delete(p.p, "cpunumber")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetCpunumber() (int, bool) {
@@ -1226,6 +1526,12 @@ func (p *ListServiceOfferingsParams) SetCpuspeed(v int) {
 	p.p["cpuspeed"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetCpuspeed() {
+	if p.p != nil && p.p["cpuspeed"] != nil {
+		delete(p.p, "cpuspeed")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetCpuspeed() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1239,6 +1545,12 @@ func (p *ListServiceOfferingsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetDomainid() (string, bool) {
@@ -1256,6 +1568,12 @@ func (p *ListServiceOfferingsParams) SetEncryptroot(v bool) {
 	p.p["encryptroot"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetEncryptroot() {
+	if p.p != nil && p.p["encryptroot"] != nil {
+		delete(p.p, "encryptroot")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetEncryptroot() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1269,6 +1587,12 @@ func (p *ListServiceOfferingsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetId() (string, bool) {
@@ -1286,6 +1610,12 @@ func (p *ListServiceOfferingsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1299,6 +1629,12 @@ func (p *ListServiceOfferingsParams) SetIssystem(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["issystem"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetIssystem() {
+	if p.p != nil && p.p["issystem"] != nil {
+		delete(p.p, "issystem")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetIssystem() (bool, bool) {
@@ -1316,6 +1652,12 @@ func (p *ListServiceOfferingsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1329,6 +1671,12 @@ func (p *ListServiceOfferingsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetListall() (bool, bool) {
@@ -1346,6 +1694,12 @@ func (p *ListServiceOfferingsParams) SetMemory(v int) {
 	p.p["memory"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetMemory() {
+	if p.p != nil && p.p["memory"] != nil {
+		delete(p.p, "memory")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetMemory() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1359,6 +1713,12 @@ func (p *ListServiceOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetName() (string, bool) {
@@ -1376,6 +1736,12 @@ func (p *ListServiceOfferingsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1389,6 +1755,12 @@ func (p *ListServiceOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetPagesize() (int, bool) {
@@ -1406,6 +1778,12 @@ func (p *ListServiceOfferingsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1419,6 +1797,12 @@ func (p *ListServiceOfferingsParams) SetStoragetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storagetype"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetStoragetype() {
+	if p.p != nil && p.p["storagetype"] != nil {
+		delete(p.p, "storagetype")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetStoragetype() (string, bool) {
@@ -1436,6 +1820,12 @@ func (p *ListServiceOfferingsParams) SetSystemvmtype(v string) {
 	p.p["systemvmtype"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetSystemvmtype() {
+	if p.p != nil && p.p["systemvmtype"] != nil {
+		delete(p.p, "systemvmtype")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetSystemvmtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1451,6 +1841,12 @@ func (p *ListServiceOfferingsParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *ListServiceOfferingsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *ListServiceOfferingsParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1464,6 +1860,12 @@ func (p *ListServiceOfferingsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListServiceOfferingsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListServiceOfferingsParams) GetZoneid() (string, bool) {
@@ -1685,6 +2087,12 @@ func (p *UpdateServiceOfferingParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *UpdateServiceOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *UpdateServiceOfferingParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1698,6 +2106,12 @@ func (p *UpdateServiceOfferingParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UpdateServiceOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UpdateServiceOfferingParams) GetDomainid() (string, bool) {
@@ -1715,6 +2129,12 @@ func (p *UpdateServiceOfferingParams) SetHosttags(v string) {
 	p.p["hosttags"] = v
 }
 
+func (p *UpdateServiceOfferingParams) ResetHosttags() {
+	if p.p != nil && p.p["hosttags"] != nil {
+		delete(p.p, "hosttags")
+	}
+}
+
 func (p *UpdateServiceOfferingParams) GetHosttags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1728,6 +2148,12 @@ func (p *UpdateServiceOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateServiceOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateServiceOfferingParams) GetId() (string, bool) {
@@ -1745,6 +2171,12 @@ func (p *UpdateServiceOfferingParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateServiceOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateServiceOfferingParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1758,6 +2190,12 @@ func (p *UpdateServiceOfferingParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
+}
+
+func (p *UpdateServiceOfferingParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
 }
 
 func (p *UpdateServiceOfferingParams) GetSortkey() (int, bool) {
@@ -1775,6 +2213,12 @@ func (p *UpdateServiceOfferingParams) SetStoragetags(v string) {
 	p.p["storagetags"] = v
 }
 
+func (p *UpdateServiceOfferingParams) ResetStoragetags() {
+	if p.p != nil && p.p["storagetags"] != nil {
+		delete(p.p, "storagetags")
+	}
+}
+
 func (p *UpdateServiceOfferingParams) GetStoragetags() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1788,6 +2232,12 @@ func (p *UpdateServiceOfferingParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UpdateServiceOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UpdateServiceOfferingParams) GetZoneid() (string, bool) {

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -115,6 +115,12 @@ func (p *CreateSnapshotParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateSnapshotParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateSnapshotParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -128,6 +134,12 @@ func (p *CreateSnapshotParams) SetAsyncbackup(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["asyncbackup"] = v
+}
+
+func (p *CreateSnapshotParams) ResetAsyncbackup() {
+	if p.p != nil && p.p["asyncbackup"] != nil {
+		delete(p.p, "asyncbackup")
+	}
 }
 
 func (p *CreateSnapshotParams) GetAsyncbackup() (bool, bool) {
@@ -145,6 +157,12 @@ func (p *CreateSnapshotParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateSnapshotParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateSnapshotParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -158,6 +176,12 @@ func (p *CreateSnapshotParams) SetLocationtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["locationtype"] = v
+}
+
+func (p *CreateSnapshotParams) ResetLocationtype() {
+	if p.p != nil && p.p["locationtype"] != nil {
+		delete(p.p, "locationtype")
+	}
 }
 
 func (p *CreateSnapshotParams) GetLocationtype() (string, bool) {
@@ -175,6 +199,12 @@ func (p *CreateSnapshotParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateSnapshotParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateSnapshotParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -188,6 +218,12 @@ func (p *CreateSnapshotParams) SetPolicyid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["policyid"] = v
+}
+
+func (p *CreateSnapshotParams) ResetPolicyid() {
+	if p.p != nil && p.p["policyid"] != nil {
+		delete(p.p, "policyid")
+	}
 }
 
 func (p *CreateSnapshotParams) GetPolicyid() (string, bool) {
@@ -205,6 +241,12 @@ func (p *CreateSnapshotParams) SetQuiescevm(v bool) {
 	p.p["quiescevm"] = v
 }
 
+func (p *CreateSnapshotParams) ResetQuiescevm() {
+	if p.p != nil && p.p["quiescevm"] != nil {
+		delete(p.p, "quiescevm")
+	}
+}
+
 func (p *CreateSnapshotParams) GetQuiescevm() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -218,6 +260,12 @@ func (p *CreateSnapshotParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *CreateSnapshotParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *CreateSnapshotParams) GetTags() (map[string]string, bool) {
@@ -235,6 +283,12 @@ func (p *CreateSnapshotParams) SetVolumeid(v string) {
 	p.p["volumeid"] = v
 }
 
+func (p *CreateSnapshotParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
+}
+
 func (p *CreateSnapshotParams) GetVolumeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -248,6 +302,12 @@ func (p *CreateSnapshotParams) SetZoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneids"] = v
+}
+
+func (p *CreateSnapshotParams) ResetZoneids() {
+	if p.p != nil && p.p["zoneids"] != nil {
+		delete(p.p, "zoneids")
+	}
 }
 
 func (p *CreateSnapshotParams) GetZoneids() ([]string, bool) {
@@ -414,6 +474,12 @@ func (p *CreateSnapshotPolicyParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateSnapshotPolicyParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateSnapshotPolicyParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -427,6 +493,12 @@ func (p *CreateSnapshotPolicyParams) SetIntervaltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["intervaltype"] = v
+}
+
+func (p *CreateSnapshotPolicyParams) ResetIntervaltype() {
+	if p.p != nil && p.p["intervaltype"] != nil {
+		delete(p.p, "intervaltype")
+	}
 }
 
 func (p *CreateSnapshotPolicyParams) GetIntervaltype() (string, bool) {
@@ -444,6 +516,12 @@ func (p *CreateSnapshotPolicyParams) SetMaxsnaps(v int) {
 	p.p["maxsnaps"] = v
 }
 
+func (p *CreateSnapshotPolicyParams) ResetMaxsnaps() {
+	if p.p != nil && p.p["maxsnaps"] != nil {
+		delete(p.p, "maxsnaps")
+	}
+}
+
 func (p *CreateSnapshotPolicyParams) GetMaxsnaps() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -457,6 +535,12 @@ func (p *CreateSnapshotPolicyParams) SetSchedule(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["schedule"] = v
+}
+
+func (p *CreateSnapshotPolicyParams) ResetSchedule() {
+	if p.p != nil && p.p["schedule"] != nil {
+		delete(p.p, "schedule")
+	}
 }
 
 func (p *CreateSnapshotPolicyParams) GetSchedule() (string, bool) {
@@ -474,6 +558,12 @@ func (p *CreateSnapshotPolicyParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *CreateSnapshotPolicyParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *CreateSnapshotPolicyParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -487,6 +577,12 @@ func (p *CreateSnapshotPolicyParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
+}
+
+func (p *CreateSnapshotPolicyParams) ResetTimezone() {
+	if p.p != nil && p.p["timezone"] != nil {
+		delete(p.p, "timezone")
+	}
 }
 
 func (p *CreateSnapshotPolicyParams) GetTimezone() (string, bool) {
@@ -504,6 +600,12 @@ func (p *CreateSnapshotPolicyParams) SetVolumeid(v string) {
 	p.p["volumeid"] = v
 }
 
+func (p *CreateSnapshotPolicyParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
+}
+
 func (p *CreateSnapshotPolicyParams) GetVolumeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -517,6 +619,12 @@ func (p *CreateSnapshotPolicyParams) SetZoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneids"] = v
+}
+
+func (p *CreateSnapshotPolicyParams) ResetZoneids() {
+	if p.p != nil && p.p["zoneids"] != nil {
+		delete(p.p, "zoneids")
+	}
 }
 
 func (p *CreateSnapshotPolicyParams) GetZoneids() ([]string, bool) {
@@ -606,6 +714,12 @@ func (p *CreateVMSnapshotParams) SetDescription(v string) {
 	p.p["description"] = v
 }
 
+func (p *CreateVMSnapshotParams) ResetDescription() {
+	if p.p != nil && p.p["description"] != nil {
+		delete(p.p, "description")
+	}
+}
+
 func (p *CreateVMSnapshotParams) GetDescription() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -619,6 +733,12 @@ func (p *CreateVMSnapshotParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateVMSnapshotParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateVMSnapshotParams) GetName() (string, bool) {
@@ -636,6 +756,12 @@ func (p *CreateVMSnapshotParams) SetQuiescevm(v bool) {
 	p.p["quiescevm"] = v
 }
 
+func (p *CreateVMSnapshotParams) ResetQuiescevm() {
+	if p.p != nil && p.p["quiescevm"] != nil {
+		delete(p.p, "quiescevm")
+	}
+}
+
 func (p *CreateVMSnapshotParams) GetQuiescevm() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -651,6 +777,12 @@ func (p *CreateVMSnapshotParams) SetSnapshotmemory(v bool) {
 	p.p["snapshotmemory"] = v
 }
 
+func (p *CreateVMSnapshotParams) ResetSnapshotmemory() {
+	if p.p != nil && p.p["snapshotmemory"] != nil {
+		delete(p.p, "snapshotmemory")
+	}
+}
+
 func (p *CreateVMSnapshotParams) GetSnapshotmemory() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -664,6 +796,12 @@ func (p *CreateVMSnapshotParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *CreateVMSnapshotParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *CreateVMSnapshotParams) GetVirtualmachineid() (string, bool) {
@@ -770,6 +908,12 @@ func (p *DeleteSnapshotParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteSnapshotParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteSnapshotParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -783,6 +927,12 @@ func (p *DeleteSnapshotParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *DeleteSnapshotParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *DeleteSnapshotParams) GetZoneid() (string, bool) {
@@ -865,6 +1015,12 @@ func (p *DeleteSnapshotPoliciesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteSnapshotPoliciesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteSnapshotPoliciesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -878,6 +1034,12 @@ func (p *DeleteSnapshotPoliciesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *DeleteSnapshotPoliciesParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *DeleteSnapshotPoliciesParams) GetIds() ([]string, bool) {
@@ -965,6 +1127,12 @@ func (p *DeleteVMSnapshotParams) SetVmsnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotid"] = v
+}
+
+func (p *DeleteVMSnapshotParams) ResetVmsnapshotid() {
+	if p.p != nil && p.p["vmsnapshotid"] != nil {
+		delete(p.p, "vmsnapshotid")
+	}
 }
 
 func (p *DeleteVMSnapshotParams) GetVmsnapshotid() (string, bool) {
@@ -1061,6 +1229,12 @@ func (p *ListSnapshotPoliciesParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListSnapshotPoliciesParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListSnapshotPoliciesParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1074,6 +1248,12 @@ func (p *ListSnapshotPoliciesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListSnapshotPoliciesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListSnapshotPoliciesParams) GetId() (string, bool) {
@@ -1091,6 +1271,12 @@ func (p *ListSnapshotPoliciesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListSnapshotPoliciesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListSnapshotPoliciesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1104,6 +1290,12 @@ func (p *ListSnapshotPoliciesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListSnapshotPoliciesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListSnapshotPoliciesParams) GetPage() (int, bool) {
@@ -1121,6 +1313,12 @@ func (p *ListSnapshotPoliciesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListSnapshotPoliciesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListSnapshotPoliciesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1134,6 +1332,12 @@ func (p *ListSnapshotPoliciesParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
+}
+
+func (p *ListSnapshotPoliciesParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
 }
 
 func (p *ListSnapshotPoliciesParams) GetVolumeid() (string, bool) {
@@ -1309,6 +1513,12 @@ func (p *ListSnapshotsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListSnapshotsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListSnapshotsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1322,6 +1532,12 @@ func (p *ListSnapshotsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListSnapshotsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListSnapshotsParams) GetDomainid() (string, bool) {
@@ -1339,6 +1555,12 @@ func (p *ListSnapshotsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListSnapshotsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListSnapshotsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1352,6 +1574,12 @@ func (p *ListSnapshotsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListSnapshotsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListSnapshotsParams) GetIds() ([]string, bool) {
@@ -1369,6 +1597,12 @@ func (p *ListSnapshotsParams) SetImagestoreid(v string) {
 	p.p["imagestoreid"] = v
 }
 
+func (p *ListSnapshotsParams) ResetImagestoreid() {
+	if p.p != nil && p.p["imagestoreid"] != nil {
+		delete(p.p, "imagestoreid")
+	}
+}
+
 func (p *ListSnapshotsParams) GetImagestoreid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1382,6 +1616,12 @@ func (p *ListSnapshotsParams) SetIntervaltype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["intervaltype"] = v
+}
+
+func (p *ListSnapshotsParams) ResetIntervaltype() {
+	if p.p != nil && p.p["intervaltype"] != nil {
+		delete(p.p, "intervaltype")
+	}
 }
 
 func (p *ListSnapshotsParams) GetIntervaltype() (string, bool) {
@@ -1399,6 +1639,12 @@ func (p *ListSnapshotsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListSnapshotsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListSnapshotsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1412,6 +1658,12 @@ func (p *ListSnapshotsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListSnapshotsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListSnapshotsParams) GetKeyword() (string, bool) {
@@ -1429,6 +1681,12 @@ func (p *ListSnapshotsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListSnapshotsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListSnapshotsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1442,6 +1700,12 @@ func (p *ListSnapshotsParams) SetLocationtype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["locationtype"] = v
+}
+
+func (p *ListSnapshotsParams) ResetLocationtype() {
+	if p.p != nil && p.p["locationtype"] != nil {
+		delete(p.p, "locationtype")
+	}
 }
 
 func (p *ListSnapshotsParams) GetLocationtype() (string, bool) {
@@ -1459,6 +1723,12 @@ func (p *ListSnapshotsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListSnapshotsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListSnapshotsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1472,6 +1742,12 @@ func (p *ListSnapshotsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListSnapshotsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListSnapshotsParams) GetPage() (int, bool) {
@@ -1489,6 +1765,12 @@ func (p *ListSnapshotsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListSnapshotsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListSnapshotsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1502,6 +1784,12 @@ func (p *ListSnapshotsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListSnapshotsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListSnapshotsParams) GetProjectid() (string, bool) {
@@ -1519,6 +1807,12 @@ func (p *ListSnapshotsParams) SetShowunique(v bool) {
 	p.p["showunique"] = v
 }
 
+func (p *ListSnapshotsParams) ResetShowunique() {
+	if p.p != nil && p.p["showunique"] != nil {
+		delete(p.p, "showunique")
+	}
+}
+
 func (p *ListSnapshotsParams) GetShowunique() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1532,6 +1826,12 @@ func (p *ListSnapshotsParams) SetSnapshottype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshottype"] = v
+}
+
+func (p *ListSnapshotsParams) ResetSnapshottype() {
+	if p.p != nil && p.p["snapshottype"] != nil {
+		delete(p.p, "snapshottype")
+	}
 }
 
 func (p *ListSnapshotsParams) GetSnapshottype() (string, bool) {
@@ -1549,6 +1849,12 @@ func (p *ListSnapshotsParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *ListSnapshotsParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *ListSnapshotsParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1562,6 +1868,12 @@ func (p *ListSnapshotsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListSnapshotsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListSnapshotsParams) GetTags() (map[string]string, bool) {
@@ -1579,6 +1891,12 @@ func (p *ListSnapshotsParams) SetVolumeid(v string) {
 	p.p["volumeid"] = v
 }
 
+func (p *ListSnapshotsParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
+}
+
 func (p *ListSnapshotsParams) GetVolumeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1592,6 +1910,12 @@ func (p *ListSnapshotsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListSnapshotsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListSnapshotsParams) GetZoneid() (string, bool) {
@@ -1845,6 +2169,12 @@ func (p *ListVMSnapshotParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1858,6 +2188,12 @@ func (p *ListVMSnapshotParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetDomainid() (string, bool) {
@@ -1875,6 +2211,12 @@ func (p *ListVMSnapshotParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1888,6 +2230,12 @@ func (p *ListVMSnapshotParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetKeyword() (string, bool) {
@@ -1905,6 +2253,12 @@ func (p *ListVMSnapshotParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1918,6 +2272,12 @@ func (p *ListVMSnapshotParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetName() (string, bool) {
@@ -1935,6 +2295,12 @@ func (p *ListVMSnapshotParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1948,6 +2314,12 @@ func (p *ListVMSnapshotParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetPagesize() (int, bool) {
@@ -1965,6 +2337,12 @@ func (p *ListVMSnapshotParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1978,6 +2356,12 @@ func (p *ListVMSnapshotParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetState() (string, bool) {
@@ -1995,6 +2379,12 @@ func (p *ListVMSnapshotParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2008,6 +2398,12 @@ func (p *ListVMSnapshotParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetVirtualmachineid() (string, bool) {
@@ -2025,6 +2421,12 @@ func (p *ListVMSnapshotParams) SetVmsnapshotid(v string) {
 	p.p["vmsnapshotid"] = v
 }
 
+func (p *ListVMSnapshotParams) ResetVmsnapshotid() {
+	if p.p != nil && p.p["vmsnapshotid"] != nil {
+		delete(p.p, "vmsnapshotid")
+	}
+}
+
 func (p *ListVMSnapshotParams) GetVmsnapshotid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2038,6 +2440,12 @@ func (p *ListVMSnapshotParams) SetVmsnapshotids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotids"] = v
+}
+
+func (p *ListVMSnapshotParams) ResetVmsnapshotids() {
+	if p.p != nil && p.p["vmsnapshotids"] != nil {
+		delete(p.p, "vmsnapshotids")
+	}
 }
 
 func (p *ListVMSnapshotParams) GetVmsnapshotids() ([]string, bool) {
@@ -2159,6 +2567,12 @@ func (p *RevertSnapshotParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RevertSnapshotParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RevertSnapshotParams) GetId() (string, bool) {
@@ -2295,6 +2709,12 @@ func (p *RevertToVMSnapshotParams) SetVmsnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vmsnapshotid"] = v
+}
+
+func (p *RevertToVMSnapshotParams) ResetVmsnapshotid() {
+	if p.p != nil && p.p["vmsnapshotid"] != nil {
+		delete(p.p, "vmsnapshotid")
+	}
 }
 
 func (p *RevertToVMSnapshotParams) GetVmsnapshotid() (string, bool) {
@@ -2538,6 +2958,12 @@ func (p *UpdateSnapshotPolicyParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateSnapshotPolicyParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateSnapshotPolicyParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2553,6 +2979,12 @@ func (p *UpdateSnapshotPolicyParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateSnapshotPolicyParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateSnapshotPolicyParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2566,6 +2998,12 @@ func (p *UpdateSnapshotPolicyParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateSnapshotPolicyParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateSnapshotPolicyParams) GetId() (string, bool) {

--- a/cloudstack/StoragePoolService.go
+++ b/cloudstack/StoragePoolService.go
@@ -56,6 +56,12 @@ func (p *CancelStorageMaintenanceParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *CancelStorageMaintenanceParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *CancelStorageMaintenanceParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -160,6 +166,12 @@ func (p *EnableStorageMaintenanceParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *EnableStorageMaintenanceParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *EnableStorageMaintenanceParams) GetId() (string, bool) {
@@ -279,6 +291,12 @@ func (p *ListStorageProvidersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListStorageProvidersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListStorageProvidersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -292,6 +310,12 @@ func (p *ListStorageProvidersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListStorageProvidersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListStorageProvidersParams) GetPage() (int, bool) {
@@ -309,6 +333,12 @@ func (p *ListStorageProvidersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListStorageProvidersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListStorageProvidersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -322,6 +352,12 @@ func (p *ListStorageProvidersParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListStorageProvidersParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListStorageProvidersParams) GetType() (string, bool) {

--- a/cloudstack/StratosphereSSPService.go
+++ b/cloudstack/StratosphereSSPService.go
@@ -69,6 +69,12 @@ func (p *AddStratosphereSspParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *AddStratosphereSspParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *AddStratosphereSspParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -82,6 +88,12 @@ func (p *AddStratosphereSspParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddStratosphereSspParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddStratosphereSspParams) GetPassword() (string, bool) {
@@ -99,6 +111,12 @@ func (p *AddStratosphereSspParams) SetTenantuuid(v string) {
 	p.p["tenantuuid"] = v
 }
 
+func (p *AddStratosphereSspParams) ResetTenantuuid() {
+	if p.p != nil && p.p["tenantuuid"] != nil {
+		delete(p.p, "tenantuuid")
+	}
+}
+
 func (p *AddStratosphereSspParams) GetTenantuuid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -112,6 +130,12 @@ func (p *AddStratosphereSspParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *AddStratosphereSspParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *AddStratosphereSspParams) GetUrl() (string, bool) {
@@ -129,6 +153,12 @@ func (p *AddStratosphereSspParams) SetUsername(v string) {
 	p.p["username"] = v
 }
 
+func (p *AddStratosphereSspParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
+}
+
 func (p *AddStratosphereSspParams) GetUsername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -142,6 +172,12 @@ func (p *AddStratosphereSspParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddStratosphereSspParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddStratosphereSspParams) GetZoneid() (string, bool) {
@@ -207,6 +243,12 @@ func (p *DeleteStratosphereSspParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *DeleteStratosphereSspParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *DeleteStratosphereSspParams) GetHostid() (string, bool) {

--- a/cloudstack/SwiftService.go
+++ b/cloudstack/SwiftService.go
@@ -65,6 +65,12 @@ func (p *AddSwiftParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AddSwiftParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AddSwiftParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -78,6 +84,12 @@ func (p *AddSwiftParams) SetKey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["key"] = v
+}
+
+func (p *AddSwiftParams) ResetKey() {
+	if p.p != nil && p.p["key"] != nil {
+		delete(p.p, "key")
+	}
 }
 
 func (p *AddSwiftParams) GetKey() (string, bool) {
@@ -95,6 +107,12 @@ func (p *AddSwiftParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddSwiftParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddSwiftParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -108,6 +126,12 @@ func (p *AddSwiftParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddSwiftParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddSwiftParams) GetUsername() (string, bool) {
@@ -193,6 +217,12 @@ func (p *ListSwiftsParams) SetId(v int64) {
 	p.p["id"] = v
 }
 
+func (p *ListSwiftsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListSwiftsParams) GetId() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -206,6 +236,12 @@ func (p *ListSwiftsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListSwiftsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListSwiftsParams) GetKeyword() (string, bool) {
@@ -223,6 +259,12 @@ func (p *ListSwiftsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListSwiftsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListSwiftsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -236,6 +278,12 @@ func (p *ListSwiftsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListSwiftsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListSwiftsParams) GetPagesize() (int, bool) {

--- a/cloudstack/SystemCapacityService.go
+++ b/cloudstack/SystemCapacityService.go
@@ -80,6 +80,12 @@ func (p *ListCapacityParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *ListCapacityParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *ListCapacityParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -93,6 +99,12 @@ func (p *ListCapacityParams) SetFetchlatest(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["fetchlatest"] = v
+}
+
+func (p *ListCapacityParams) ResetFetchlatest() {
+	if p.p != nil && p.p["fetchlatest"] != nil {
+		delete(p.p, "fetchlatest")
+	}
 }
 
 func (p *ListCapacityParams) GetFetchlatest() (bool, bool) {
@@ -110,6 +122,12 @@ func (p *ListCapacityParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListCapacityParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListCapacityParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -123,6 +141,12 @@ func (p *ListCapacityParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListCapacityParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListCapacityParams) GetPage() (int, bool) {
@@ -140,6 +164,12 @@ func (p *ListCapacityParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListCapacityParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListCapacityParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -153,6 +183,12 @@ func (p *ListCapacityParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListCapacityParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListCapacityParams) GetPodid() (string, bool) {
@@ -170,6 +206,12 @@ func (p *ListCapacityParams) SetSortby(v string) {
 	p.p["sortby"] = v
 }
 
+func (p *ListCapacityParams) ResetSortby() {
+	if p.p != nil && p.p["sortby"] != nil {
+		delete(p.p, "sortby")
+	}
+}
+
 func (p *ListCapacityParams) GetSortby() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -185,6 +227,12 @@ func (p *ListCapacityParams) SetType(v int) {
 	p.p["type"] = v
 }
 
+func (p *ListCapacityParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
+}
+
 func (p *ListCapacityParams) GetType() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -198,6 +246,12 @@ func (p *ListCapacityParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListCapacityParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListCapacityParams) GetZoneid() (string, bool) {

--- a/cloudstack/SystemVMService.go
+++ b/cloudstack/SystemVMService.go
@@ -82,6 +82,12 @@ func (p *ChangeServiceForSystemVmParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *ChangeServiceForSystemVmParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *ChangeServiceForSystemVmParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -97,6 +103,12 @@ func (p *ChangeServiceForSystemVmParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ChangeServiceForSystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ChangeServiceForSystemVmParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -110,6 +122,12 @@ func (p *ChangeServiceForSystemVmParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *ChangeServiceForSystemVmParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *ChangeServiceForSystemVmParams) GetServiceofferingid() (string, bool) {
@@ -208,6 +226,12 @@ func (p *DestroySystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DestroySystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DestroySystemVmParams) GetId() (string, bool) {
@@ -359,6 +383,12 @@ func (p *ListSystemVmsParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ListSystemVmsParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ListSystemVmsParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -372,6 +402,12 @@ func (p *ListSystemVmsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListSystemVmsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListSystemVmsParams) GetId() (string, bool) {
@@ -389,6 +425,12 @@ func (p *ListSystemVmsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListSystemVmsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListSystemVmsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -402,6 +444,12 @@ func (p *ListSystemVmsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListSystemVmsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListSystemVmsParams) GetName() (string, bool) {
@@ -419,6 +467,12 @@ func (p *ListSystemVmsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListSystemVmsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListSystemVmsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -432,6 +486,12 @@ func (p *ListSystemVmsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListSystemVmsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListSystemVmsParams) GetPagesize() (int, bool) {
@@ -449,6 +509,12 @@ func (p *ListSystemVmsParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *ListSystemVmsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *ListSystemVmsParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -462,6 +528,12 @@ func (p *ListSystemVmsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListSystemVmsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListSystemVmsParams) GetState() (string, bool) {
@@ -479,6 +551,12 @@ func (p *ListSystemVmsParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *ListSystemVmsParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *ListSystemVmsParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -494,6 +572,12 @@ func (p *ListSystemVmsParams) SetSystemvmtype(v string) {
 	p.p["systemvmtype"] = v
 }
 
+func (p *ListSystemVmsParams) ResetSystemvmtype() {
+	if p.p != nil && p.p["systemvmtype"] != nil {
+		delete(p.p, "systemvmtype")
+	}
+}
+
 func (p *ListSystemVmsParams) GetSystemvmtype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -507,6 +591,12 @@ func (p *ListSystemVmsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListSystemVmsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListSystemVmsParams) GetZoneid() (string, bool) {
@@ -703,6 +793,12 @@ func (p *MigrateSystemVmParams) SetAutoselect(v bool) {
 	p.p["autoselect"] = v
 }
 
+func (p *MigrateSystemVmParams) ResetAutoselect() {
+	if p.p != nil && p.p["autoselect"] != nil {
+		delete(p.p, "autoselect")
+	}
+}
+
 func (p *MigrateSystemVmParams) GetAutoselect() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -716,6 +812,12 @@ func (p *MigrateSystemVmParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *MigrateSystemVmParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *MigrateSystemVmParams) GetHostid() (string, bool) {
@@ -733,6 +835,12 @@ func (p *MigrateSystemVmParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *MigrateSystemVmParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *MigrateSystemVmParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -746,6 +854,12 @@ func (p *MigrateSystemVmParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *MigrateSystemVmParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *MigrateSystemVmParams) GetVirtualmachineid() (string, bool) {
@@ -869,6 +983,12 @@ func (p *RebootSystemVmParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *RebootSystemVmParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *RebootSystemVmParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -882,6 +1002,12 @@ func (p *RebootSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RebootSystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RebootSystemVmParams) GetId() (string, bool) {
@@ -1010,6 +1136,12 @@ func (p *ScaleSystemVmParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *ScaleSystemVmParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *ScaleSystemVmParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1025,6 +1157,12 @@ func (p *ScaleSystemVmParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ScaleSystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ScaleSystemVmParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1038,6 +1176,12 @@ func (p *ScaleSystemVmParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *ScaleSystemVmParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *ScaleSystemVmParams) GetServiceofferingid() (string, bool) {
@@ -1156,6 +1300,12 @@ func (p *StartSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *StartSystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *StartSystemVmParams) GetId() (string, bool) {
@@ -1279,6 +1429,12 @@ func (p *StopSystemVmParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *StopSystemVmParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *StopSystemVmParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1292,6 +1448,12 @@ func (p *StopSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *StopSystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *StopSystemVmParams) GetId() (string, bool) {
@@ -1415,6 +1577,12 @@ func (p *PatchSystemVmParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *PatchSystemVmParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *PatchSystemVmParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1428,6 +1596,12 @@ func (p *PatchSystemVmParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *PatchSystemVmParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *PatchSystemVmParams) GetId() (string, bool) {

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -95,6 +95,12 @@ func (p *CopyTemplateParams) SetDestzoneid(v string) {
 	p.p["destzoneid"] = v
 }
 
+func (p *CopyTemplateParams) ResetDestzoneid() {
+	if p.p != nil && p.p["destzoneid"] != nil {
+		delete(p.p, "destzoneid")
+	}
+}
+
 func (p *CopyTemplateParams) GetDestzoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -108,6 +114,12 @@ func (p *CopyTemplateParams) SetDestzoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["destzoneids"] = v
+}
+
+func (p *CopyTemplateParams) ResetDestzoneids() {
+	if p.p != nil && p.p["destzoneids"] != nil {
+		delete(p.p, "destzoneids")
+	}
 }
 
 func (p *CopyTemplateParams) GetDestzoneids() ([]string, bool) {
@@ -125,6 +137,12 @@ func (p *CopyTemplateParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *CopyTemplateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *CopyTemplateParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -138,6 +156,12 @@ func (p *CopyTemplateParams) SetSourcezoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcezoneid"] = v
+}
+
+func (p *CopyTemplateParams) ResetSourcezoneid() {
+	if p.p != nil && p.p["sourcezoneid"] != nil {
+		delete(p.p, "sourcezoneid")
+	}
 }
 
 func (p *CopyTemplateParams) GetSourcezoneid() (string, bool) {
@@ -365,6 +389,12 @@ func (p *CreateTemplateParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateTemplateParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateTemplateParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -378,6 +408,12 @@ func (p *CreateTemplateParams) SetBits(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bits"] = v
+}
+
+func (p *CreateTemplateParams) ResetBits() {
+	if p.p != nil && p.p["bits"] != nil {
+		delete(p.p, "bits")
+	}
 }
 
 func (p *CreateTemplateParams) GetBits() (int, bool) {
@@ -395,6 +431,12 @@ func (p *CreateTemplateParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *CreateTemplateParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *CreateTemplateParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -408,6 +450,12 @@ func (p *CreateTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *CreateTemplateParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *CreateTemplateParams) GetDisplaytext() (string, bool) {
@@ -425,6 +473,12 @@ func (p *CreateTemplateParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateTemplateParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateTemplateParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -438,6 +492,12 @@ func (p *CreateTemplateParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
+}
+
+func (p *CreateTemplateParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
 }
 
 func (p *CreateTemplateParams) GetIsdynamicallyscalable() (bool, bool) {
@@ -455,6 +515,12 @@ func (p *CreateTemplateParams) SetIsfeatured(v bool) {
 	p.p["isfeatured"] = v
 }
 
+func (p *CreateTemplateParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
+}
+
 func (p *CreateTemplateParams) GetIsfeatured() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -468,6 +534,12 @@ func (p *CreateTemplateParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
+}
+
+func (p *CreateTemplateParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
 }
 
 func (p *CreateTemplateParams) GetIspublic() (bool, bool) {
@@ -485,6 +557,12 @@ func (p *CreateTemplateParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateTemplateParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateTemplateParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -498,6 +576,12 @@ func (p *CreateTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
+}
+
+func (p *CreateTemplateParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
 }
 
 func (p *CreateTemplateParams) GetOstypeid() (string, bool) {
@@ -515,6 +599,12 @@ func (p *CreateTemplateParams) SetPasswordenabled(v bool) {
 	p.p["passwordenabled"] = v
 }
 
+func (p *CreateTemplateParams) ResetPasswordenabled() {
+	if p.p != nil && p.p["passwordenabled"] != nil {
+		delete(p.p, "passwordenabled")
+	}
+}
+
 func (p *CreateTemplateParams) GetPasswordenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -528,6 +618,12 @@ func (p *CreateTemplateParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateTemplateParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateTemplateParams) GetProjectid() (string, bool) {
@@ -545,6 +641,12 @@ func (p *CreateTemplateParams) SetRequireshvm(v bool) {
 	p.p["requireshvm"] = v
 }
 
+func (p *CreateTemplateParams) ResetRequireshvm() {
+	if p.p != nil && p.p["requireshvm"] != nil {
+		delete(p.p, "requireshvm")
+	}
+}
+
 func (p *CreateTemplateParams) GetRequireshvm() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -558,6 +660,12 @@ func (p *CreateTemplateParams) SetSnapshotid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["snapshotid"] = v
+}
+
+func (p *CreateTemplateParams) ResetSnapshotid() {
+	if p.p != nil && p.p["snapshotid"] != nil {
+		delete(p.p, "snapshotid")
+	}
 }
 
 func (p *CreateTemplateParams) GetSnapshotid() (string, bool) {
@@ -575,6 +683,12 @@ func (p *CreateTemplateParams) SetSshkeyenabled(v bool) {
 	p.p["sshkeyenabled"] = v
 }
 
+func (p *CreateTemplateParams) ResetSshkeyenabled() {
+	if p.p != nil && p.p["sshkeyenabled"] != nil {
+		delete(p.p, "sshkeyenabled")
+	}
+}
+
 func (p *CreateTemplateParams) GetSshkeyenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -588,6 +702,12 @@ func (p *CreateTemplateParams) SetTemplatetag(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatetag"] = v
+}
+
+func (p *CreateTemplateParams) ResetTemplatetag() {
+	if p.p != nil && p.p["templatetag"] != nil {
+		delete(p.p, "templatetag")
+	}
 }
 
 func (p *CreateTemplateParams) GetTemplatetag() (string, bool) {
@@ -605,6 +725,12 @@ func (p *CreateTemplateParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *CreateTemplateParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *CreateTemplateParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -618,6 +744,12 @@ func (p *CreateTemplateParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *CreateTemplateParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *CreateTemplateParams) GetVirtualmachineid() (string, bool) {
@@ -635,6 +767,12 @@ func (p *CreateTemplateParams) SetVolumeid(v string) {
 	p.p["volumeid"] = v
 }
 
+func (p *CreateTemplateParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
+}
+
 func (p *CreateTemplateParams) GetVolumeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -648,6 +786,12 @@ func (p *CreateTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateTemplateParams) GetZoneid() (string, bool) {
@@ -817,6 +961,12 @@ func (p *DeleteTemplateParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *DeleteTemplateParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *DeleteTemplateParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -832,6 +982,12 @@ func (p *DeleteTemplateParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteTemplateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteTemplateParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -845,6 +1001,12 @@ func (p *DeleteTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *DeleteTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *DeleteTemplateParams) GetZoneid() (string, bool) {
@@ -932,6 +1094,12 @@ func (p *ExtractTemplateParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ExtractTemplateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ExtractTemplateParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -945,6 +1113,12 @@ func (p *ExtractTemplateParams) SetMode(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mode"] = v
+}
+
+func (p *ExtractTemplateParams) ResetMode() {
+	if p.p != nil && p.p["mode"] != nil {
+		delete(p.p, "mode")
+	}
 }
 
 func (p *ExtractTemplateParams) GetMode() (string, bool) {
@@ -962,6 +1136,12 @@ func (p *ExtractTemplateParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *ExtractTemplateParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *ExtractTemplateParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -975,6 +1155,12 @@ func (p *ExtractTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ExtractTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ExtractTemplateParams) GetZoneid() (string, bool) {
@@ -1147,6 +1333,12 @@ func (p *GetUploadParamsForTemplateParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1160,6 +1352,12 @@ func (p *GetUploadParamsForTemplateParams) SetBits(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bits"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetBits() {
+	if p.p != nil && p.p["bits"] != nil {
+		delete(p.p, "bits")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetBits() (int, bool) {
@@ -1177,6 +1375,12 @@ func (p *GetUploadParamsForTemplateParams) SetChecksum(v string) {
 	p.p["checksum"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetChecksum() {
+	if p.p != nil && p.p["checksum"] != nil {
+		delete(p.p, "checksum")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetChecksum() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1190,6 +1394,12 @@ func (p *GetUploadParamsForTemplateParams) SetDeployasis(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deployasis"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetDeployasis() {
+	if p.p != nil && p.p["deployasis"] != nil {
+		delete(p.p, "deployasis")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetDeployasis() (bool, bool) {
@@ -1207,6 +1417,12 @@ func (p *GetUploadParamsForTemplateParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1220,6 +1436,12 @@ func (p *GetUploadParamsForTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetDisplaytext() (string, bool) {
@@ -1237,6 +1459,12 @@ func (p *GetUploadParamsForTemplateParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1250,6 +1478,12 @@ func (p *GetUploadParamsForTemplateParams) SetFormat(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["format"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetFormat() {
+	if p.p != nil && p.p["format"] != nil {
+		delete(p.p, "format")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetFormat() (string, bool) {
@@ -1267,6 +1501,12 @@ func (p *GetUploadParamsForTemplateParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1280,6 +1520,12 @@ func (p *GetUploadParamsForTemplateParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetIsdynamicallyscalable() (bool, bool) {
@@ -1297,6 +1543,12 @@ func (p *GetUploadParamsForTemplateParams) SetIsextractable(v bool) {
 	p.p["isextractable"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetIsextractable() {
+	if p.p != nil && p.p["isextractable"] != nil {
+		delete(p.p, "isextractable")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetIsextractable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1310,6 +1562,12 @@ func (p *GetUploadParamsForTemplateParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetIsfeatured() (bool, bool) {
@@ -1327,6 +1585,12 @@ func (p *GetUploadParamsForTemplateParams) SetIspublic(v bool) {
 	p.p["ispublic"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetIspublic() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1340,6 +1604,12 @@ func (p *GetUploadParamsForTemplateParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetIsrouting() {
+	if p.p != nil && p.p["isrouting"] != nil {
+		delete(p.p, "isrouting")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetIsrouting() (bool, bool) {
@@ -1357,6 +1627,12 @@ func (p *GetUploadParamsForTemplateParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1370,6 +1646,12 @@ func (p *GetUploadParamsForTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetOstypeid() (string, bool) {
@@ -1387,6 +1669,12 @@ func (p *GetUploadParamsForTemplateParams) SetPasswordenabled(v bool) {
 	p.p["passwordenabled"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetPasswordenabled() {
+	if p.p != nil && p.p["passwordenabled"] != nil {
+		delete(p.p, "passwordenabled")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetPasswordenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1400,6 +1688,12 @@ func (p *GetUploadParamsForTemplateParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetProjectid() (string, bool) {
@@ -1417,6 +1711,12 @@ func (p *GetUploadParamsForTemplateParams) SetRequireshvm(v bool) {
 	p.p["requireshvm"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetRequireshvm() {
+	if p.p != nil && p.p["requireshvm"] != nil {
+		delete(p.p, "requireshvm")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetRequireshvm() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1430,6 +1730,12 @@ func (p *GetUploadParamsForTemplateParams) SetSshkeyenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sshkeyenabled"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetSshkeyenabled() {
+	if p.p != nil && p.p["sshkeyenabled"] != nil {
+		delete(p.p, "sshkeyenabled")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetSshkeyenabled() (bool, bool) {
@@ -1447,6 +1753,12 @@ func (p *GetUploadParamsForTemplateParams) SetTemplatetag(v string) {
 	p.p["templatetag"] = v
 }
 
+func (p *GetUploadParamsForTemplateParams) ResetTemplatetag() {
+	if p.p != nil && p.p["templatetag"] != nil {
+		delete(p.p, "templatetag")
+	}
+}
+
 func (p *GetUploadParamsForTemplateParams) GetTemplatetag() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1460,6 +1772,12 @@ func (p *GetUploadParamsForTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *GetUploadParamsForTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *GetUploadParamsForTemplateParams) GetZoneid() (string, bool) {
@@ -1531,6 +1849,12 @@ func (p *ListTemplatePermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListTemplatePermissionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListTemplatePermissionsParams) GetId() (string, bool) {
@@ -1718,6 +2042,12 @@ func (p *ListTemplatesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListTemplatesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListTemplatesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1731,6 +2061,12 @@ func (p *ListTemplatesParams) SetDetails(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ListTemplatesParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ListTemplatesParams) GetDetails() ([]string, bool) {
@@ -1748,6 +2084,12 @@ func (p *ListTemplatesParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListTemplatesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListTemplatesParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1761,6 +2103,12 @@ func (p *ListTemplatesParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *ListTemplatesParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *ListTemplatesParams) GetHypervisor() (string, bool) {
@@ -1778,6 +2126,12 @@ func (p *ListTemplatesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListTemplatesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListTemplatesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1791,6 +2145,12 @@ func (p *ListTemplatesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListTemplatesParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListTemplatesParams) GetIds() ([]string, bool) {
@@ -1808,6 +2168,12 @@ func (p *ListTemplatesParams) SetImagestoreid(v string) {
 	p.p["imagestoreid"] = v
 }
 
+func (p *ListTemplatesParams) ResetImagestoreid() {
+	if p.p != nil && p.p["imagestoreid"] != nil {
+		delete(p.p, "imagestoreid")
+	}
+}
+
 func (p *ListTemplatesParams) GetImagestoreid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1821,6 +2187,12 @@ func (p *ListTemplatesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListTemplatesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListTemplatesParams) GetIsrecursive() (bool, bool) {
@@ -1838,6 +2210,12 @@ func (p *ListTemplatesParams) SetIsvnf(v bool) {
 	p.p["isvnf"] = v
 }
 
+func (p *ListTemplatesParams) ResetIsvnf() {
+	if p.p != nil && p.p["isvnf"] != nil {
+		delete(p.p, "isvnf")
+	}
+}
+
 func (p *ListTemplatesParams) GetIsvnf() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1851,6 +2229,12 @@ func (p *ListTemplatesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListTemplatesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListTemplatesParams) GetKeyword() (string, bool) {
@@ -1868,6 +2252,12 @@ func (p *ListTemplatesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListTemplatesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListTemplatesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1881,6 +2271,12 @@ func (p *ListTemplatesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListTemplatesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListTemplatesParams) GetName() (string, bool) {
@@ -1898,6 +2294,12 @@ func (p *ListTemplatesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListTemplatesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListTemplatesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1911,6 +2313,12 @@ func (p *ListTemplatesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListTemplatesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListTemplatesParams) GetPagesize() (int, bool) {
@@ -1928,6 +2336,12 @@ func (p *ListTemplatesParams) SetParenttemplateid(v string) {
 	p.p["parenttemplateid"] = v
 }
 
+func (p *ListTemplatesParams) ResetParenttemplateid() {
+	if p.p != nil && p.p["parenttemplateid"] != nil {
+		delete(p.p, "parenttemplateid")
+	}
+}
+
 func (p *ListTemplatesParams) GetParenttemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1941,6 +2355,12 @@ func (p *ListTemplatesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListTemplatesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListTemplatesParams) GetProjectid() (string, bool) {
@@ -1958,6 +2378,12 @@ func (p *ListTemplatesParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListTemplatesParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListTemplatesParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1971,6 +2397,12 @@ func (p *ListTemplatesParams) SetShowremoved(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showremoved"] = v
+}
+
+func (p *ListTemplatesParams) ResetShowremoved() {
+	if p.p != nil && p.p["showremoved"] != nil {
+		delete(p.p, "showremoved")
+	}
 }
 
 func (p *ListTemplatesParams) GetShowremoved() (bool, bool) {
@@ -1988,6 +2420,12 @@ func (p *ListTemplatesParams) SetShowunique(v bool) {
 	p.p["showunique"] = v
 }
 
+func (p *ListTemplatesParams) ResetShowunique() {
+	if p.p != nil && p.p["showunique"] != nil {
+		delete(p.p, "showunique")
+	}
+}
+
 func (p *ListTemplatesParams) GetShowunique() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2001,6 +2439,12 @@ func (p *ListTemplatesParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListTemplatesParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListTemplatesParams) GetStorageid() (string, bool) {
@@ -2018,6 +2462,12 @@ func (p *ListTemplatesParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListTemplatesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListTemplatesParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2031,6 +2481,12 @@ func (p *ListTemplatesParams) SetTemplatefilter(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatefilter"] = v
+}
+
+func (p *ListTemplatesParams) ResetTemplatefilter() {
+	if p.p != nil && p.p["templatefilter"] != nil {
+		delete(p.p, "templatefilter")
+	}
 }
 
 func (p *ListTemplatesParams) GetTemplatefilter() (string, bool) {
@@ -2048,6 +2504,12 @@ func (p *ListTemplatesParams) SetTemplatetype(v string) {
 	p.p["templatetype"] = v
 }
 
+func (p *ListTemplatesParams) ResetTemplatetype() {
+	if p.p != nil && p.p["templatetype"] != nil {
+		delete(p.p, "templatetype")
+	}
+}
+
 func (p *ListTemplatesParams) GetTemplatetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2061,6 +2523,12 @@ func (p *ListTemplatesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListTemplatesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListTemplatesParams) GetZoneid() (string, bool) {
@@ -2298,6 +2766,12 @@ func (p *PrepareTemplateParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *PrepareTemplateParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *PrepareTemplateParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2313,6 +2787,12 @@ func (p *PrepareTemplateParams) SetTemplateid(v string) {
 	p.p["templateid"] = v
 }
 
+func (p *PrepareTemplateParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
+}
+
 func (p *PrepareTemplateParams) GetTemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2326,6 +2806,12 @@ func (p *PrepareTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *PrepareTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *PrepareTemplateParams) GetZoneid() (string, bool) {
@@ -2557,6 +3043,12 @@ func (p *RegisterTemplateParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *RegisterTemplateParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *RegisterTemplateParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2570,6 +3062,12 @@ func (p *RegisterTemplateParams) SetBits(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bits"] = v
+}
+
+func (p *RegisterTemplateParams) ResetBits() {
+	if p.p != nil && p.p["bits"] != nil {
+		delete(p.p, "bits")
+	}
 }
 
 func (p *RegisterTemplateParams) GetBits() (int, bool) {
@@ -2587,6 +3085,12 @@ func (p *RegisterTemplateParams) SetChecksum(v string) {
 	p.p["checksum"] = v
 }
 
+func (p *RegisterTemplateParams) ResetChecksum() {
+	if p.p != nil && p.p["checksum"] != nil {
+		delete(p.p, "checksum")
+	}
+}
+
 func (p *RegisterTemplateParams) GetChecksum() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2600,6 +3104,12 @@ func (p *RegisterTemplateParams) SetDeployasis(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deployasis"] = v
+}
+
+func (p *RegisterTemplateParams) ResetDeployasis() {
+	if p.p != nil && p.p["deployasis"] != nil {
+		delete(p.p, "deployasis")
+	}
 }
 
 func (p *RegisterTemplateParams) GetDeployasis() (bool, bool) {
@@ -2617,6 +3127,12 @@ func (p *RegisterTemplateParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *RegisterTemplateParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *RegisterTemplateParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2630,6 +3146,12 @@ func (p *RegisterTemplateParams) SetDirectdownload(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["directdownload"] = v
+}
+
+func (p *RegisterTemplateParams) ResetDirectdownload() {
+	if p.p != nil && p.p["directdownload"] != nil {
+		delete(p.p, "directdownload")
+	}
 }
 
 func (p *RegisterTemplateParams) GetDirectdownload() (bool, bool) {
@@ -2647,6 +3169,12 @@ func (p *RegisterTemplateParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *RegisterTemplateParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *RegisterTemplateParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2660,6 +3188,12 @@ func (p *RegisterTemplateParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *RegisterTemplateParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *RegisterTemplateParams) GetDomainid() (string, bool) {
@@ -2677,6 +3211,12 @@ func (p *RegisterTemplateParams) SetFormat(v string) {
 	p.p["format"] = v
 }
 
+func (p *RegisterTemplateParams) ResetFormat() {
+	if p.p != nil && p.p["format"] != nil {
+		delete(p.p, "format")
+	}
+}
+
 func (p *RegisterTemplateParams) GetFormat() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2690,6 +3230,12 @@ func (p *RegisterTemplateParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *RegisterTemplateParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *RegisterTemplateParams) GetHypervisor() (string, bool) {
@@ -2707,6 +3253,12 @@ func (p *RegisterTemplateParams) SetIsdynamicallyscalable(v bool) {
 	p.p["isdynamicallyscalable"] = v
 }
 
+func (p *RegisterTemplateParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
+}
+
 func (p *RegisterTemplateParams) GetIsdynamicallyscalable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2720,6 +3272,12 @@ func (p *RegisterTemplateParams) SetIsextractable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isextractable"] = v
+}
+
+func (p *RegisterTemplateParams) ResetIsextractable() {
+	if p.p != nil && p.p["isextractable"] != nil {
+		delete(p.p, "isextractable")
+	}
 }
 
 func (p *RegisterTemplateParams) GetIsextractable() (bool, bool) {
@@ -2737,6 +3295,12 @@ func (p *RegisterTemplateParams) SetIsfeatured(v bool) {
 	p.p["isfeatured"] = v
 }
 
+func (p *RegisterTemplateParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
+}
+
 func (p *RegisterTemplateParams) GetIsfeatured() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2750,6 +3314,12 @@ func (p *RegisterTemplateParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
+}
+
+func (p *RegisterTemplateParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
 }
 
 func (p *RegisterTemplateParams) GetIspublic() (bool, bool) {
@@ -2767,6 +3337,12 @@ func (p *RegisterTemplateParams) SetIsrouting(v bool) {
 	p.p["isrouting"] = v
 }
 
+func (p *RegisterTemplateParams) ResetIsrouting() {
+	if p.p != nil && p.p["isrouting"] != nil {
+		delete(p.p, "isrouting")
+	}
+}
+
 func (p *RegisterTemplateParams) GetIsrouting() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2780,6 +3356,12 @@ func (p *RegisterTemplateParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *RegisterTemplateParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *RegisterTemplateParams) GetName() (string, bool) {
@@ -2797,6 +3379,12 @@ func (p *RegisterTemplateParams) SetOstypeid(v string) {
 	p.p["ostypeid"] = v
 }
 
+func (p *RegisterTemplateParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
+}
+
 func (p *RegisterTemplateParams) GetOstypeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2810,6 +3398,12 @@ func (p *RegisterTemplateParams) SetPasswordenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passwordenabled"] = v
+}
+
+func (p *RegisterTemplateParams) ResetPasswordenabled() {
+	if p.p != nil && p.p["passwordenabled"] != nil {
+		delete(p.p, "passwordenabled")
+	}
 }
 
 func (p *RegisterTemplateParams) GetPasswordenabled() (bool, bool) {
@@ -2827,6 +3421,12 @@ func (p *RegisterTemplateParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *RegisterTemplateParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *RegisterTemplateParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2840,6 +3440,12 @@ func (p *RegisterTemplateParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
+}
+
+func (p *RegisterTemplateParams) ResetRequireshvm() {
+	if p.p != nil && p.p["requireshvm"] != nil {
+		delete(p.p, "requireshvm")
+	}
 }
 
 func (p *RegisterTemplateParams) GetRequireshvm() (bool, bool) {
@@ -2857,6 +3463,12 @@ func (p *RegisterTemplateParams) SetSshkeyenabled(v bool) {
 	p.p["sshkeyenabled"] = v
 }
 
+func (p *RegisterTemplateParams) ResetSshkeyenabled() {
+	if p.p != nil && p.p["sshkeyenabled"] != nil {
+		delete(p.p, "sshkeyenabled")
+	}
+}
+
 func (p *RegisterTemplateParams) GetSshkeyenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2870,6 +3482,12 @@ func (p *RegisterTemplateParams) SetTemplatetag(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatetag"] = v
+}
+
+func (p *RegisterTemplateParams) ResetTemplatetag() {
+	if p.p != nil && p.p["templatetag"] != nil {
+		delete(p.p, "templatetag")
+	}
 }
 
 func (p *RegisterTemplateParams) GetTemplatetag() (string, bool) {
@@ -2887,6 +3505,12 @@ func (p *RegisterTemplateParams) SetTemplatetype(v string) {
 	p.p["templatetype"] = v
 }
 
+func (p *RegisterTemplateParams) ResetTemplatetype() {
+	if p.p != nil && p.p["templatetype"] != nil {
+		delete(p.p, "templatetype")
+	}
+}
+
 func (p *RegisterTemplateParams) GetTemplatetype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2900,6 +3524,12 @@ func (p *RegisterTemplateParams) SetUrl(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["url"] = v
+}
+
+func (p *RegisterTemplateParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
 }
 
 func (p *RegisterTemplateParams) GetUrl() (string, bool) {
@@ -2917,6 +3547,12 @@ func (p *RegisterTemplateParams) SetZoneid(v string) {
 	p.p["zoneid"] = v
 }
 
+func (p *RegisterTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
+}
+
 func (p *RegisterTemplateParams) GetZoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2930,6 +3566,12 @@ func (p *RegisterTemplateParams) SetZoneids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneids"] = v
+}
+
+func (p *RegisterTemplateParams) ResetZoneids() {
+	if p.p != nil && p.p["zoneids"] != nil {
+		delete(p.p, "zoneids")
+	}
 }
 
 func (p *RegisterTemplateParams) GetZoneids() ([]string, bool) {
@@ -3132,6 +3774,12 @@ func (p *UpdateTemplateParams) SetBootable(v bool) {
 	p.p["bootable"] = v
 }
 
+func (p *UpdateTemplateParams) ResetBootable() {
+	if p.p != nil && p.p["bootable"] != nil {
+		delete(p.p, "bootable")
+	}
+}
+
 func (p *UpdateTemplateParams) GetBootable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3145,6 +3793,12 @@ func (p *UpdateTemplateParams) SetCleanupdetails(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cleanupdetails"] = v
+}
+
+func (p *UpdateTemplateParams) ResetCleanupdetails() {
+	if p.p != nil && p.p["cleanupdetails"] != nil {
+		delete(p.p, "cleanupdetails")
+	}
 }
 
 func (p *UpdateTemplateParams) GetCleanupdetails() (bool, bool) {
@@ -3162,6 +3816,12 @@ func (p *UpdateTemplateParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *UpdateTemplateParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *UpdateTemplateParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3175,6 +3835,12 @@ func (p *UpdateTemplateParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *UpdateTemplateParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *UpdateTemplateParams) GetDisplaytext() (string, bool) {
@@ -3192,6 +3858,12 @@ func (p *UpdateTemplateParams) SetFormat(v string) {
 	p.p["format"] = v
 }
 
+func (p *UpdateTemplateParams) ResetFormat() {
+	if p.p != nil && p.p["format"] != nil {
+		delete(p.p, "format")
+	}
+}
+
 func (p *UpdateTemplateParams) GetFormat() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3205,6 +3877,12 @@ func (p *UpdateTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateTemplateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateTemplateParams) GetId() (string, bool) {
@@ -3222,6 +3900,12 @@ func (p *UpdateTemplateParams) SetIsdynamicallyscalable(v bool) {
 	p.p["isdynamicallyscalable"] = v
 }
 
+func (p *UpdateTemplateParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
+}
+
 func (p *UpdateTemplateParams) GetIsdynamicallyscalable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3235,6 +3919,12 @@ func (p *UpdateTemplateParams) SetIsrouting(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrouting"] = v
+}
+
+func (p *UpdateTemplateParams) ResetIsrouting() {
+	if p.p != nil && p.p["isrouting"] != nil {
+		delete(p.p, "isrouting")
+	}
 }
 
 func (p *UpdateTemplateParams) GetIsrouting() (bool, bool) {
@@ -3252,6 +3942,12 @@ func (p *UpdateTemplateParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateTemplateParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateTemplateParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3265,6 +3961,12 @@ func (p *UpdateTemplateParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
+}
+
+func (p *UpdateTemplateParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
 }
 
 func (p *UpdateTemplateParams) GetOstypeid() (string, bool) {
@@ -3282,6 +3984,12 @@ func (p *UpdateTemplateParams) SetPasswordenabled(v bool) {
 	p.p["passwordenabled"] = v
 }
 
+func (p *UpdateTemplateParams) ResetPasswordenabled() {
+	if p.p != nil && p.p["passwordenabled"] != nil {
+		delete(p.p, "passwordenabled")
+	}
+}
+
 func (p *UpdateTemplateParams) GetPasswordenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3295,6 +4003,12 @@ func (p *UpdateTemplateParams) SetRequireshvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["requireshvm"] = v
+}
+
+func (p *UpdateTemplateParams) ResetRequireshvm() {
+	if p.p != nil && p.p["requireshvm"] != nil {
+		delete(p.p, "requireshvm")
+	}
 }
 
 func (p *UpdateTemplateParams) GetRequireshvm() (bool, bool) {
@@ -3312,6 +4026,12 @@ func (p *UpdateTemplateParams) SetSortkey(v int) {
 	p.p["sortkey"] = v
 }
 
+func (p *UpdateTemplateParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
+}
+
 func (p *UpdateTemplateParams) GetSortkey() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3327,6 +4047,12 @@ func (p *UpdateTemplateParams) SetSshkeyenabled(v bool) {
 	p.p["sshkeyenabled"] = v
 }
 
+func (p *UpdateTemplateParams) ResetSshkeyenabled() {
+	if p.p != nil && p.p["sshkeyenabled"] != nil {
+		delete(p.p, "sshkeyenabled")
+	}
+}
+
 func (p *UpdateTemplateParams) GetSshkeyenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3340,6 +4066,12 @@ func (p *UpdateTemplateParams) SetTemplatetype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templatetype"] = v
+}
+
+func (p *UpdateTemplateParams) ResetTemplatetype() {
+	if p.p != nil && p.p["templatetype"] != nil {
+		delete(p.p, "templatetype")
+	}
 }
 
 func (p *UpdateTemplateParams) GetTemplatetype() (string, bool) {
@@ -3503,6 +4235,12 @@ func (p *UpdateTemplatePermissionsParams) SetAccounts(v []string) {
 	p.p["accounts"] = v
 }
 
+func (p *UpdateTemplatePermissionsParams) ResetAccounts() {
+	if p.p != nil && p.p["accounts"] != nil {
+		delete(p.p, "accounts")
+	}
+}
+
 func (p *UpdateTemplatePermissionsParams) GetAccounts() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3516,6 +4254,12 @@ func (p *UpdateTemplatePermissionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateTemplatePermissionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateTemplatePermissionsParams) GetId() (string, bool) {
@@ -3533,6 +4277,12 @@ func (p *UpdateTemplatePermissionsParams) SetIsextractable(v bool) {
 	p.p["isextractable"] = v
 }
 
+func (p *UpdateTemplatePermissionsParams) ResetIsextractable() {
+	if p.p != nil && p.p["isextractable"] != nil {
+		delete(p.p, "isextractable")
+	}
+}
+
 func (p *UpdateTemplatePermissionsParams) GetIsextractable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3546,6 +4296,12 @@ func (p *UpdateTemplatePermissionsParams) SetIsfeatured(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isfeatured"] = v
+}
+
+func (p *UpdateTemplatePermissionsParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
 }
 
 func (p *UpdateTemplatePermissionsParams) GetIsfeatured() (bool, bool) {
@@ -3563,6 +4319,12 @@ func (p *UpdateTemplatePermissionsParams) SetIspublic(v bool) {
 	p.p["ispublic"] = v
 }
 
+func (p *UpdateTemplatePermissionsParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
+}
+
 func (p *UpdateTemplatePermissionsParams) GetIspublic() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3578,6 +4340,12 @@ func (p *UpdateTemplatePermissionsParams) SetOp(v string) {
 	p.p["op"] = v
 }
 
+func (p *UpdateTemplatePermissionsParams) ResetOp() {
+	if p.p != nil && p.p["op"] != nil {
+		delete(p.p, "op")
+	}
+}
+
 func (p *UpdateTemplatePermissionsParams) GetOp() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3591,6 +4359,12 @@ func (p *UpdateTemplatePermissionsParams) SetProjectids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectids"] = v
+}
+
+func (p *UpdateTemplatePermissionsParams) ResetProjectids() {
+	if p.p != nil && p.p["projectids"] != nil {
+		delete(p.p, "projectids")
+	}
 }
 
 func (p *UpdateTemplatePermissionsParams) GetProjectids() ([]string, bool) {
@@ -3696,6 +4470,12 @@ func (p *UpgradeRouterTemplateParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UpgradeRouterTemplateParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UpgradeRouterTemplateParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3709,6 +4489,12 @@ func (p *UpgradeRouterTemplateParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *UpgradeRouterTemplateParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *UpgradeRouterTemplateParams) GetClusterid() (string, bool) {
@@ -3726,6 +4512,12 @@ func (p *UpgradeRouterTemplateParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *UpgradeRouterTemplateParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *UpgradeRouterTemplateParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3739,6 +4531,12 @@ func (p *UpgradeRouterTemplateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpgradeRouterTemplateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpgradeRouterTemplateParams) GetId() (string, bool) {
@@ -3756,6 +4554,12 @@ func (p *UpgradeRouterTemplateParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *UpgradeRouterTemplateParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *UpgradeRouterTemplateParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3769,6 +4573,12 @@ func (p *UpgradeRouterTemplateParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UpgradeRouterTemplateParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UpgradeRouterTemplateParams) GetZoneid() (string, bool) {
@@ -3847,6 +4657,12 @@ func (p *ListTemplateDirectDownloadCertificatesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListTemplateDirectDownloadCertificatesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListTemplateDirectDownloadCertificatesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3860,6 +4676,12 @@ func (p *ListTemplateDirectDownloadCertificatesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListTemplateDirectDownloadCertificatesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListTemplateDirectDownloadCertificatesParams) GetKeyword() (string, bool) {
@@ -3877,6 +4699,12 @@ func (p *ListTemplateDirectDownloadCertificatesParams) SetListhosts(v bool) {
 	p.p["listhosts"] = v
 }
 
+func (p *ListTemplateDirectDownloadCertificatesParams) ResetListhosts() {
+	if p.p != nil && p.p["listhosts"] != nil {
+		delete(p.p, "listhosts")
+	}
+}
+
 func (p *ListTemplateDirectDownloadCertificatesParams) GetListhosts() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3890,6 +4718,12 @@ func (p *ListTemplateDirectDownloadCertificatesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListTemplateDirectDownloadCertificatesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListTemplateDirectDownloadCertificatesParams) GetPage() (int, bool) {
@@ -3907,6 +4741,12 @@ func (p *ListTemplateDirectDownloadCertificatesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListTemplateDirectDownloadCertificatesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListTemplateDirectDownloadCertificatesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3920,6 +4760,12 @@ func (p *ListTemplateDirectDownloadCertificatesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListTemplateDirectDownloadCertificatesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListTemplateDirectDownloadCertificatesParams) GetZoneid() (string, bool) {
@@ -4032,6 +4878,12 @@ func (p *ProvisionTemplateDirectDownloadCertificateParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ProvisionTemplateDirectDownloadCertificateParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ProvisionTemplateDirectDownloadCertificateParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4045,6 +4897,12 @@ func (p *ProvisionTemplateDirectDownloadCertificateParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ProvisionTemplateDirectDownloadCertificateParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ProvisionTemplateDirectDownloadCertificateParams) GetId() (string, bool) {

--- a/cloudstack/UCSService.go
+++ b/cloudstack/UCSService.go
@@ -79,6 +79,12 @@ func (p *AddUcsManagerParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *AddUcsManagerParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *AddUcsManagerParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -92,6 +98,12 @@ func (p *AddUcsManagerParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *AddUcsManagerParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *AddUcsManagerParams) GetPassword() (string, bool) {
@@ -109,6 +121,12 @@ func (p *AddUcsManagerParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddUcsManagerParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddUcsManagerParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -124,6 +142,12 @@ func (p *AddUcsManagerParams) SetUsername(v string) {
 	p.p["username"] = v
 }
 
+func (p *AddUcsManagerParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
+}
+
 func (p *AddUcsManagerParams) GetUsername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -137,6 +161,12 @@ func (p *AddUcsManagerParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddUcsManagerParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddUcsManagerParams) GetZoneid() (string, bool) {
@@ -211,6 +241,12 @@ func (p *AssociateUcsProfileToBladeParams) SetBladeid(v string) {
 	p.p["bladeid"] = v
 }
 
+func (p *AssociateUcsProfileToBladeParams) ResetBladeid() {
+	if p.p != nil && p.p["bladeid"] != nil {
+		delete(p.p, "bladeid")
+	}
+}
+
 func (p *AssociateUcsProfileToBladeParams) GetBladeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -226,6 +262,12 @@ func (p *AssociateUcsProfileToBladeParams) SetProfiledn(v string) {
 	p.p["profiledn"] = v
 }
 
+func (p *AssociateUcsProfileToBladeParams) ResetProfiledn() {
+	if p.p != nil && p.p["profiledn"] != nil {
+		delete(p.p, "profiledn")
+	}
+}
+
 func (p *AssociateUcsProfileToBladeParams) GetProfiledn() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -239,6 +281,12 @@ func (p *AssociateUcsProfileToBladeParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
+}
+
+func (p *AssociateUcsProfileToBladeParams) ResetUcsmanagerid() {
+	if p.p != nil && p.p["ucsmanagerid"] != nil {
+		delete(p.p, "ucsmanagerid")
+	}
 }
 
 func (p *AssociateUcsProfileToBladeParams) GetUcsmanagerid() (string, bool) {
@@ -325,6 +373,12 @@ func (p *DeleteUcsManagerParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
+}
+
+func (p *DeleteUcsManagerParams) ResetUcsmanagerid() {
+	if p.p != nil && p.p["ucsmanagerid"] != nil {
+		delete(p.p, "ucsmanagerid")
+	}
 }
 
 func (p *DeleteUcsManagerParams) GetUcsmanagerid() (string, bool) {
@@ -426,6 +480,12 @@ func (p *ListUcsBladesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListUcsBladesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListUcsBladesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -439,6 +499,12 @@ func (p *ListUcsBladesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListUcsBladesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListUcsBladesParams) GetPage() (int, bool) {
@@ -456,6 +522,12 @@ func (p *ListUcsBladesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListUcsBladesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListUcsBladesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -469,6 +541,12 @@ func (p *ListUcsBladesParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
+}
+
+func (p *ListUcsBladesParams) ResetUcsmanagerid() {
+	if p.p != nil && p.p["ucsmanagerid"] != nil {
+		delete(p.p, "ucsmanagerid")
+	}
 }
 
 func (p *ListUcsBladesParams) GetUcsmanagerid() (string, bool) {
@@ -554,6 +632,12 @@ func (p *ListUcsManagersParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListUcsManagersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListUcsManagersParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -567,6 +651,12 @@ func (p *ListUcsManagersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListUcsManagersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListUcsManagersParams) GetKeyword() (string, bool) {
@@ -584,6 +674,12 @@ func (p *ListUcsManagersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListUcsManagersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListUcsManagersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -599,6 +695,12 @@ func (p *ListUcsManagersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListUcsManagersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListUcsManagersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -612,6 +714,12 @@ func (p *ListUcsManagersParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListUcsManagersParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListUcsManagersParams) GetZoneid() (string, bool) {
@@ -775,6 +883,12 @@ func (p *ListUcsProfilesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListUcsProfilesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListUcsProfilesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -788,6 +902,12 @@ func (p *ListUcsProfilesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListUcsProfilesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListUcsProfilesParams) GetPage() (int, bool) {
@@ -805,6 +925,12 @@ func (p *ListUcsProfilesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListUcsProfilesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListUcsProfilesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -818,6 +944,12 @@ func (p *ListUcsProfilesParams) SetUcsmanagerid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ucsmanagerid"] = v
+}
+
+func (p *ListUcsProfilesParams) ResetUcsmanagerid() {
+	if p.p != nil && p.p["ucsmanagerid"] != nil {
+		delete(p.p, "ucsmanagerid")
+	}
 }
 
 func (p *ListUcsProfilesParams) GetUcsmanagerid() (string, bool) {

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -87,6 +87,12 @@ func (p *AddTrafficMonitorParams) SetExcludezones(v string) {
 	p.p["excludezones"] = v
 }
 
+func (p *AddTrafficMonitorParams) ResetExcludezones() {
+	if p.p != nil && p.p["excludezones"] != nil {
+		delete(p.p, "excludezones")
+	}
+}
+
 func (p *AddTrafficMonitorParams) GetExcludezones() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -100,6 +106,12 @@ func (p *AddTrafficMonitorParams) SetIncludezones(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["includezones"] = v
+}
+
+func (p *AddTrafficMonitorParams) ResetIncludezones() {
+	if p.p != nil && p.p["includezones"] != nil {
+		delete(p.p, "includezones")
+	}
 }
 
 func (p *AddTrafficMonitorParams) GetIncludezones() (string, bool) {
@@ -117,6 +129,12 @@ func (p *AddTrafficMonitorParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *AddTrafficMonitorParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *AddTrafficMonitorParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -130,6 +148,12 @@ func (p *AddTrafficMonitorParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *AddTrafficMonitorParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *AddTrafficMonitorParams) GetZoneid() (string, bool) {
@@ -221,6 +245,12 @@ func (p *AddTrafficTypeParams) SetHypervnetworklabel(v string) {
 	p.p["hypervnetworklabel"] = v
 }
 
+func (p *AddTrafficTypeParams) ResetHypervnetworklabel() {
+	if p.p != nil && p.p["hypervnetworklabel"] != nil {
+		delete(p.p, "hypervnetworklabel")
+	}
+}
+
 func (p *AddTrafficTypeParams) GetHypervnetworklabel() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -234,6 +264,12 @@ func (p *AddTrafficTypeParams) SetIsolationmethod(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isolationmethod"] = v
+}
+
+func (p *AddTrafficTypeParams) ResetIsolationmethod() {
+	if p.p != nil && p.p["isolationmethod"] != nil {
+		delete(p.p, "isolationmethod")
+	}
 }
 
 func (p *AddTrafficTypeParams) GetIsolationmethod() (string, bool) {
@@ -251,6 +287,12 @@ func (p *AddTrafficTypeParams) SetKvmnetworklabel(v string) {
 	p.p["kvmnetworklabel"] = v
 }
 
+func (p *AddTrafficTypeParams) ResetKvmnetworklabel() {
+	if p.p != nil && p.p["kvmnetworklabel"] != nil {
+		delete(p.p, "kvmnetworklabel")
+	}
+}
+
 func (p *AddTrafficTypeParams) GetKvmnetworklabel() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -264,6 +306,12 @@ func (p *AddTrafficTypeParams) SetOvm3networklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3networklabel"] = v
+}
+
+func (p *AddTrafficTypeParams) ResetOvm3networklabel() {
+	if p.p != nil && p.p["ovm3networklabel"] != nil {
+		delete(p.p, "ovm3networklabel")
+	}
 }
 
 func (p *AddTrafficTypeParams) GetOvm3networklabel() (string, bool) {
@@ -281,6 +329,12 @@ func (p *AddTrafficTypeParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *AddTrafficTypeParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *AddTrafficTypeParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -294,6 +348,12 @@ func (p *AddTrafficTypeParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *AddTrafficTypeParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *AddTrafficTypeParams) GetTraffictype() (string, bool) {
@@ -311,6 +371,12 @@ func (p *AddTrafficTypeParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *AddTrafficTypeParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *AddTrafficTypeParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -326,6 +392,12 @@ func (p *AddTrafficTypeParams) SetVmwarenetworklabel(v string) {
 	p.p["vmwarenetworklabel"] = v
 }
 
+func (p *AddTrafficTypeParams) ResetVmwarenetworklabel() {
+	if p.p != nil && p.p["vmwarenetworklabel"] != nil {
+		delete(p.p, "vmwarenetworklabel")
+	}
+}
+
 func (p *AddTrafficTypeParams) GetVmwarenetworklabel() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -339,6 +411,12 @@ func (p *AddTrafficTypeParams) SetXennetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["xennetworklabel"] = v
+}
+
+func (p *AddTrafficTypeParams) ResetXennetworklabel() {
+	if p.p != nil && p.p["xennetworklabel"] != nil {
+		delete(p.p, "xennetworklabel")
+	}
 }
 
 func (p *AddTrafficTypeParams) GetXennetworklabel() (string, bool) {
@@ -429,6 +507,12 @@ func (p *DeleteTrafficMonitorParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteTrafficMonitorParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteTrafficMonitorParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -517,6 +601,12 @@ func (p *DeleteTrafficTypeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteTrafficTypeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteTrafficTypeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -599,6 +689,12 @@ func (p *GenerateUsageRecordsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *GenerateUsageRecordsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *GenerateUsageRecordsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -614,6 +710,12 @@ func (p *GenerateUsageRecordsParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *GenerateUsageRecordsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *GenerateUsageRecordsParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -627,6 +729,12 @@ func (p *GenerateUsageRecordsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
+}
+
+func (p *GenerateUsageRecordsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
 }
 
 func (p *GenerateUsageRecordsParams) GetStartdate() (string, bool) {
@@ -729,6 +837,12 @@ func (p *ListTrafficMonitorsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListTrafficMonitorsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListTrafficMonitorsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -742,6 +856,12 @@ func (p *ListTrafficMonitorsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListTrafficMonitorsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListTrafficMonitorsParams) GetPage() (int, bool) {
@@ -759,6 +879,12 @@ func (p *ListTrafficMonitorsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListTrafficMonitorsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListTrafficMonitorsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -772,6 +898,12 @@ func (p *ListTrafficMonitorsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListTrafficMonitorsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListTrafficMonitorsParams) GetZoneid() (string, bool) {
@@ -854,6 +986,12 @@ func (p *ListTrafficTypeImplementorsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListTrafficTypeImplementorsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListTrafficTypeImplementorsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -867,6 +1005,12 @@ func (p *ListTrafficTypeImplementorsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListTrafficTypeImplementorsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListTrafficTypeImplementorsParams) GetPage() (int, bool) {
@@ -884,6 +1028,12 @@ func (p *ListTrafficTypeImplementorsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListTrafficTypeImplementorsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListTrafficTypeImplementorsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -897,6 +1047,12 @@ func (p *ListTrafficTypeImplementorsParams) SetTraffictype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["traffictype"] = v
+}
+
+func (p *ListTrafficTypeImplementorsParams) ResetTraffictype() {
+	if p.p != nil && p.p["traffictype"] != nil {
+		delete(p.p, "traffictype")
+	}
 }
 
 func (p *ListTrafficTypeImplementorsParams) GetTraffictype() (string, bool) {
@@ -975,6 +1131,12 @@ func (p *ListTrafficTypesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListTrafficTypesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListTrafficTypesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -988,6 +1150,12 @@ func (p *ListTrafficTypesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListTrafficTypesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListTrafficTypesParams) GetPage() (int, bool) {
@@ -1005,6 +1173,12 @@ func (p *ListTrafficTypesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListTrafficTypesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListTrafficTypesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1018,6 +1192,12 @@ func (p *ListTrafficTypesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListTrafficTypesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListTrafficTypesParams) GetPhysicalnetworkid() (string, bool) {
@@ -1173,6 +1353,12 @@ func (p *ListUsageRecordsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1186,6 +1372,12 @@ func (p *ListUsageRecordsParams) SetAccountid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accountid"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetAccountid() {
+	if p.p != nil && p.p["accountid"] != nil {
+		delete(p.p, "accountid")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetAccountid() (string, bool) {
@@ -1203,6 +1395,12 @@ func (p *ListUsageRecordsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1216,6 +1414,12 @@ func (p *ListUsageRecordsParams) SetEnddate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["enddate"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetEnddate() (string, bool) {
@@ -1233,6 +1437,12 @@ func (p *ListUsageRecordsParams) SetIncludetags(v bool) {
 	p.p["includetags"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetIncludetags() {
+	if p.p != nil && p.p["includetags"] != nil {
+		delete(p.p, "includetags")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetIncludetags() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1246,6 +1456,12 @@ func (p *ListUsageRecordsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetIsrecursive() (bool, bool) {
@@ -1263,6 +1479,12 @@ func (p *ListUsageRecordsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1276,6 +1498,12 @@ func (p *ListUsageRecordsParams) SetOldformat(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["oldformat"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetOldformat() {
+	if p.p != nil && p.p["oldformat"] != nil {
+		delete(p.p, "oldformat")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetOldformat() (bool, bool) {
@@ -1293,6 +1521,12 @@ func (p *ListUsageRecordsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1306,6 +1540,12 @@ func (p *ListUsageRecordsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetPagesize() (int, bool) {
@@ -1323,6 +1563,12 @@ func (p *ListUsageRecordsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1336,6 +1582,12 @@ func (p *ListUsageRecordsParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetStartdate() (string, bool) {
@@ -1353,6 +1605,12 @@ func (p *ListUsageRecordsParams) SetType(v int64) {
 	p.p["type"] = v
 }
 
+func (p *ListUsageRecordsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
+}
+
 func (p *ListUsageRecordsParams) GetType() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1366,6 +1624,12 @@ func (p *ListUsageRecordsParams) SetUsageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usageid"] = v
+}
+
+func (p *ListUsageRecordsParams) ResetUsageid() {
+	if p.p != nil && p.p["usageid"] != nil {
+		delete(p.p, "usageid")
+	}
 }
 
 func (p *ListUsageRecordsParams) GetUsageid() (string, bool) {
@@ -1543,6 +1807,12 @@ func (p *RemoveRawUsageRecordsParams) SetInterval(v int) {
 	p.p["interval"] = v
 }
 
+func (p *RemoveRawUsageRecordsParams) ResetInterval() {
+	if p.p != nil && p.p["interval"] != nil {
+		delete(p.p, "interval")
+	}
+}
+
 func (p *RemoveRawUsageRecordsParams) GetInterval() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1646,6 +1916,12 @@ func (p *UpdateTrafficTypeParams) SetHypervnetworklabel(v string) {
 	p.p["hypervnetworklabel"] = v
 }
 
+func (p *UpdateTrafficTypeParams) ResetHypervnetworklabel() {
+	if p.p != nil && p.p["hypervnetworklabel"] != nil {
+		delete(p.p, "hypervnetworklabel")
+	}
+}
+
 func (p *UpdateTrafficTypeParams) GetHypervnetworklabel() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1659,6 +1935,12 @@ func (p *UpdateTrafficTypeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateTrafficTypeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateTrafficTypeParams) GetId() (string, bool) {
@@ -1676,6 +1958,12 @@ func (p *UpdateTrafficTypeParams) SetKvmnetworklabel(v string) {
 	p.p["kvmnetworklabel"] = v
 }
 
+func (p *UpdateTrafficTypeParams) ResetKvmnetworklabel() {
+	if p.p != nil && p.p["kvmnetworklabel"] != nil {
+		delete(p.p, "kvmnetworklabel")
+	}
+}
+
 func (p *UpdateTrafficTypeParams) GetKvmnetworklabel() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1689,6 +1977,12 @@ func (p *UpdateTrafficTypeParams) SetOvm3networklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ovm3networklabel"] = v
+}
+
+func (p *UpdateTrafficTypeParams) ResetOvm3networklabel() {
+	if p.p != nil && p.p["ovm3networklabel"] != nil {
+		delete(p.p, "ovm3networklabel")
+	}
 }
 
 func (p *UpdateTrafficTypeParams) GetOvm3networklabel() (string, bool) {
@@ -1706,6 +2000,12 @@ func (p *UpdateTrafficTypeParams) SetVmwarenetworklabel(v string) {
 	p.p["vmwarenetworklabel"] = v
 }
 
+func (p *UpdateTrafficTypeParams) ResetVmwarenetworklabel() {
+	if p.p != nil && p.p["vmwarenetworklabel"] != nil {
+		delete(p.p, "vmwarenetworklabel")
+	}
+}
+
 func (p *UpdateTrafficTypeParams) GetVmwarenetworklabel() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1719,6 +2019,12 @@ func (p *UpdateTrafficTypeParams) SetXennetworklabel(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["xennetworklabel"] = v
+}
+
+func (p *UpdateTrafficTypeParams) ResetXennetworklabel() {
+	if p.p != nil && p.p["xennetworklabel"] != nil {
+		delete(p.p, "xennetworklabel")
+	}
 }
 
 func (p *UpdateTrafficTypeParams) GetXennetworklabel() (string, bool) {

--- a/cloudstack/UserService.go
+++ b/cloudstack/UserService.go
@@ -99,6 +99,12 @@ func (p *CreateUserParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateUserParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateUserParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -112,6 +118,12 @@ func (p *CreateUserParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateUserParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateUserParams) GetDomainid() (string, bool) {
@@ -129,6 +141,12 @@ func (p *CreateUserParams) SetEmail(v string) {
 	p.p["email"] = v
 }
 
+func (p *CreateUserParams) ResetEmail() {
+	if p.p != nil && p.p["email"] != nil {
+		delete(p.p, "email")
+	}
+}
+
 func (p *CreateUserParams) GetEmail() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -142,6 +160,12 @@ func (p *CreateUserParams) SetFirstname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["firstname"] = v
+}
+
+func (p *CreateUserParams) ResetFirstname() {
+	if p.p != nil && p.p["firstname"] != nil {
+		delete(p.p, "firstname")
+	}
 }
 
 func (p *CreateUserParams) GetFirstname() (string, bool) {
@@ -159,6 +183,12 @@ func (p *CreateUserParams) SetLastname(v string) {
 	p.p["lastname"] = v
 }
 
+func (p *CreateUserParams) ResetLastname() {
+	if p.p != nil && p.p["lastname"] != nil {
+		delete(p.p, "lastname")
+	}
+}
+
 func (p *CreateUserParams) GetLastname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -172,6 +202,12 @@ func (p *CreateUserParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *CreateUserParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *CreateUserParams) GetPassword() (string, bool) {
@@ -189,6 +225,12 @@ func (p *CreateUserParams) SetTimezone(v string) {
 	p.p["timezone"] = v
 }
 
+func (p *CreateUserParams) ResetTimezone() {
+	if p.p != nil && p.p["timezone"] != nil {
+		delete(p.p, "timezone")
+	}
+}
+
 func (p *CreateUserParams) GetTimezone() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -204,6 +246,12 @@ func (p *CreateUserParams) SetUserid(v string) {
 	p.p["userid"] = v
 }
 
+func (p *CreateUserParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
+}
+
 func (p *CreateUserParams) GetUserid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -217,6 +265,12 @@ func (p *CreateUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *CreateUserParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *CreateUserParams) GetUsername() (string, bool) {
@@ -311,6 +365,12 @@ func (p *DeleteUserParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteUserParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteUserParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -397,6 +457,12 @@ func (p *DisableUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DisableUserParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DisableUserParams) GetId() (string, bool) {
@@ -502,6 +568,12 @@ func (p *EnableUserParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *EnableUserParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *EnableUserParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -589,6 +661,12 @@ func (p *GetUserParams) SetUserapikey(v string) {
 	p.p["userapikey"] = v
 }
 
+func (p *GetUserParams) ResetUserapikey() {
+	if p.p != nil && p.p["userapikey"] != nil {
+		delete(p.p, "userapikey")
+	}
+}
+
 func (p *GetUserParams) GetUserapikey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -672,6 +750,12 @@ func (p *GetUserKeysParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *GetUserKeysParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *GetUserKeysParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -735,6 +819,12 @@ func (p *GetVirtualMachineUserDataParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *GetVirtualMachineUserDataParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *GetVirtualMachineUserDataParams) GetVirtualmachineid() (string, bool) {
@@ -841,6 +931,12 @@ func (p *ListUsersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListUsersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListUsersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -854,6 +950,12 @@ func (p *ListUsersParams) SetAccounttype(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accounttype"] = v
+}
+
+func (p *ListUsersParams) ResetAccounttype() {
+	if p.p != nil && p.p["accounttype"] != nil {
+		delete(p.p, "accounttype")
+	}
 }
 
 func (p *ListUsersParams) GetAccounttype() (int, bool) {
@@ -871,6 +973,12 @@ func (p *ListUsersParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListUsersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListUsersParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -884,6 +992,12 @@ func (p *ListUsersParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListUsersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListUsersParams) GetId() (string, bool) {
@@ -901,6 +1015,12 @@ func (p *ListUsersParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListUsersParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListUsersParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -914,6 +1034,12 @@ func (p *ListUsersParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListUsersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListUsersParams) GetKeyword() (string, bool) {
@@ -931,6 +1057,12 @@ func (p *ListUsersParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListUsersParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListUsersParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -944,6 +1076,12 @@ func (p *ListUsersParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListUsersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListUsersParams) GetPage() (int, bool) {
@@ -961,6 +1099,12 @@ func (p *ListUsersParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListUsersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListUsersParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -974,6 +1118,12 @@ func (p *ListUsersParams) SetShowicon(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showicon"] = v
+}
+
+func (p *ListUsersParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
 }
 
 func (p *ListUsersParams) GetShowicon() (bool, bool) {
@@ -991,6 +1141,12 @@ func (p *ListUsersParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListUsersParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListUsersParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1004,6 +1160,12 @@ func (p *ListUsersParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *ListUsersParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *ListUsersParams) GetUsername() (string, bool) {
@@ -1126,6 +1288,12 @@ func (p *LockUserParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *LockUserParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *LockUserParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1211,6 +1379,12 @@ func (p *RegisterUserKeysParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RegisterUserKeysParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RegisterUserKeysParams) GetId() (string, bool) {
@@ -1309,6 +1483,12 @@ func (p *UpdateUserParams) SetCurrentpassword(v string) {
 	p.p["currentpassword"] = v
 }
 
+func (p *UpdateUserParams) ResetCurrentpassword() {
+	if p.p != nil && p.p["currentpassword"] != nil {
+		delete(p.p, "currentpassword")
+	}
+}
+
 func (p *UpdateUserParams) GetCurrentpassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1322,6 +1502,12 @@ func (p *UpdateUserParams) SetEmail(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["email"] = v
+}
+
+func (p *UpdateUserParams) ResetEmail() {
+	if p.p != nil && p.p["email"] != nil {
+		delete(p.p, "email")
+	}
 }
 
 func (p *UpdateUserParams) GetEmail() (string, bool) {
@@ -1339,6 +1525,12 @@ func (p *UpdateUserParams) SetFirstname(v string) {
 	p.p["firstname"] = v
 }
 
+func (p *UpdateUserParams) ResetFirstname() {
+	if p.p != nil && p.p["firstname"] != nil {
+		delete(p.p, "firstname")
+	}
+}
+
 func (p *UpdateUserParams) GetFirstname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1352,6 +1544,12 @@ func (p *UpdateUserParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateUserParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateUserParams) GetId() (string, bool) {
@@ -1369,6 +1567,12 @@ func (p *UpdateUserParams) SetLastname(v string) {
 	p.p["lastname"] = v
 }
 
+func (p *UpdateUserParams) ResetLastname() {
+	if p.p != nil && p.p["lastname"] != nil {
+		delete(p.p, "lastname")
+	}
+}
+
 func (p *UpdateUserParams) GetLastname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1382,6 +1586,12 @@ func (p *UpdateUserParams) SetMandate2fa(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mandate2fa"] = v
+}
+
+func (p *UpdateUserParams) ResetMandate2fa() {
+	if p.p != nil && p.p["mandate2fa"] != nil {
+		delete(p.p, "mandate2fa")
+	}
 }
 
 func (p *UpdateUserParams) GetMandate2fa() (bool, bool) {
@@ -1399,6 +1609,12 @@ func (p *UpdateUserParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *UpdateUserParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *UpdateUserParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1412,6 +1628,12 @@ func (p *UpdateUserParams) SetTimezone(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["timezone"] = v
+}
+
+func (p *UpdateUserParams) ResetTimezone() {
+	if p.p != nil && p.p["timezone"] != nil {
+		delete(p.p, "timezone")
+	}
 }
 
 func (p *UpdateUserParams) GetTimezone() (string, bool) {
@@ -1429,6 +1651,12 @@ func (p *UpdateUserParams) SetUserapikey(v string) {
 	p.p["userapikey"] = v
 }
 
+func (p *UpdateUserParams) ResetUserapikey() {
+	if p.p != nil && p.p["userapikey"] != nil {
+		delete(p.p, "userapikey")
+	}
+}
+
 func (p *UpdateUserParams) GetUserapikey() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1444,6 +1672,12 @@ func (p *UpdateUserParams) SetUsername(v string) {
 	p.p["username"] = v
 }
 
+func (p *UpdateUserParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
+}
+
 func (p *UpdateUserParams) GetUsername() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1457,6 +1691,12 @@ func (p *UpdateUserParams) SetUsersecretkey(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["usersecretkey"] = v
+}
+
+func (p *UpdateUserParams) ResetUsersecretkey() {
+	if p.p != nil && p.p["usersecretkey"] != nil {
+		delete(p.p, "usersecretkey")
+	}
 }
 
 func (p *UpdateUserParams) GetUsersecretkey() (string, bool) {

--- a/cloudstack/VLANService.go
+++ b/cloudstack/VLANService.go
@@ -123,6 +123,12 @@ func (p *CreateVlanIpRangeParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -136,6 +142,12 @@ func (p *CreateVlanIpRangeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetDomainid() (string, bool) {
@@ -153,6 +165,12 @@ func (p *CreateVlanIpRangeParams) SetEndip(v string) {
 	p.p["endip"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetEndip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -166,6 +184,12 @@ func (p *CreateVlanIpRangeParams) SetEndipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endipv6"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetEndipv6() {
+	if p.p != nil && p.p["endipv6"] != nil {
+		delete(p.p, "endipv6")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetEndipv6() (string, bool) {
@@ -183,6 +207,12 @@ func (p *CreateVlanIpRangeParams) SetForsystemvms(v bool) {
 	p.p["forsystemvms"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetForsystemvms() {
+	if p.p != nil && p.p["forsystemvms"] != nil {
+		delete(p.p, "forsystemvms")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetForsystemvms() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -196,6 +226,12 @@ func (p *CreateVlanIpRangeParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetForvirtualnetwork() {
+	if p.p != nil && p.p["forvirtualnetwork"] != nil {
+		delete(p.p, "forvirtualnetwork")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetForvirtualnetwork() (bool, bool) {
@@ -213,6 +249,12 @@ func (p *CreateVlanIpRangeParams) SetGateway(v string) {
 	p.p["gateway"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetGateway() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -226,6 +268,12 @@ func (p *CreateVlanIpRangeParams) SetIp6cidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6cidr"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetIp6cidr() {
+	if p.p != nil && p.p["ip6cidr"] != nil {
+		delete(p.p, "ip6cidr")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetIp6cidr() (string, bool) {
@@ -243,6 +291,12 @@ func (p *CreateVlanIpRangeParams) SetIp6gateway(v string) {
 	p.p["ip6gateway"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetIp6gateway() {
+	if p.p != nil && p.p["ip6gateway"] != nil {
+		delete(p.p, "ip6gateway")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetIp6gateway() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -256,6 +310,12 @@ func (p *CreateVlanIpRangeParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetNetmask() (string, bool) {
@@ -273,6 +333,12 @@ func (p *CreateVlanIpRangeParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -286,6 +352,12 @@ func (p *CreateVlanIpRangeParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetPhysicalnetworkid() (string, bool) {
@@ -303,6 +375,12 @@ func (p *CreateVlanIpRangeParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -316,6 +394,12 @@ func (p *CreateVlanIpRangeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetProjectid() (string, bool) {
@@ -333,6 +417,12 @@ func (p *CreateVlanIpRangeParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -346,6 +436,12 @@ func (p *CreateVlanIpRangeParams) SetStartipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startipv6"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetStartipv6() {
+	if p.p != nil && p.p["startipv6"] != nil {
+		delete(p.p, "startipv6")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetStartipv6() (string, bool) {
@@ -363,6 +459,12 @@ func (p *CreateVlanIpRangeParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *CreateVlanIpRangeParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *CreateVlanIpRangeParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -376,6 +478,12 @@ func (p *CreateVlanIpRangeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateVlanIpRangeParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateVlanIpRangeParams) GetZoneid() (string, bool) {
@@ -476,6 +584,12 @@ func (p *DedicateGuestVlanRangeParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DedicateGuestVlanRangeParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DedicateGuestVlanRangeParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -489,6 +603,12 @@ func (p *DedicateGuestVlanRangeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DedicateGuestVlanRangeParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DedicateGuestVlanRangeParams) GetDomainid() (string, bool) {
@@ -506,6 +626,12 @@ func (p *DedicateGuestVlanRangeParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *DedicateGuestVlanRangeParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *DedicateGuestVlanRangeParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -521,6 +647,12 @@ func (p *DedicateGuestVlanRangeParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *DedicateGuestVlanRangeParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *DedicateGuestVlanRangeParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -534,6 +666,12 @@ func (p *DedicateGuestVlanRangeParams) SetVlanrange(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vlanrange"] = v
+}
+
+func (p *DedicateGuestVlanRangeParams) ResetVlanrange() {
+	if p.p != nil && p.p["vlanrange"] != nil {
+		delete(p.p, "vlanrange")
+	}
 }
 
 func (p *DedicateGuestVlanRangeParams) GetVlanrange() (string, bool) {
@@ -607,6 +745,12 @@ func (p *DeleteVlanIpRangeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteVlanIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteVlanIpRangeParams) GetId() (string, bool) {
@@ -726,6 +870,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListDedicatedGuestVlanRangesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListDedicatedGuestVlanRangesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -739,6 +889,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) GetDomainid() (string, bool) {
@@ -756,6 +912,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetGuestvlanrange(v string) {
 	p.p["guestvlanrange"] = v
 }
 
+func (p *ListDedicatedGuestVlanRangesParams) ResetGuestvlanrange() {
+	if p.p != nil && p.p["guestvlanrange"] != nil {
+		delete(p.p, "guestvlanrange")
+	}
+}
+
 func (p *ListDedicatedGuestVlanRangesParams) GetGuestvlanrange() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -769,6 +931,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) GetId() (string, bool) {
@@ -786,6 +954,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListDedicatedGuestVlanRangesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListDedicatedGuestVlanRangesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -799,6 +973,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) GetPage() (int, bool) {
@@ -816,6 +996,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListDedicatedGuestVlanRangesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListDedicatedGuestVlanRangesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -829,6 +1015,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) GetPhysicalnetworkid() (string, bool) {
@@ -846,6 +1038,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListDedicatedGuestVlanRangesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListDedicatedGuestVlanRangesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -859,6 +1057,12 @@ func (p *ListDedicatedGuestVlanRangesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListDedicatedGuestVlanRangesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListDedicatedGuestVlanRangesParams) GetZoneid() (string, bool) {
@@ -1005,6 +1209,12 @@ func (p *ListVlanIpRangesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1018,6 +1228,12 @@ func (p *ListVlanIpRangesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVlanIpRangesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVlanIpRangesParams) GetDomainid() (string, bool) {
@@ -1035,6 +1251,12 @@ func (p *ListVlanIpRangesParams) SetForvirtualnetwork(v bool) {
 	p.p["forvirtualnetwork"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetForvirtualnetwork() {
+	if p.p != nil && p.p["forvirtualnetwork"] != nil {
+		delete(p.p, "forvirtualnetwork")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetForvirtualnetwork() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1048,6 +1270,12 @@ func (p *ListVlanIpRangesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListVlanIpRangesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListVlanIpRangesParams) GetId() (string, bool) {
@@ -1065,6 +1293,12 @@ func (p *ListVlanIpRangesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1078,6 +1312,12 @@ func (p *ListVlanIpRangesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ListVlanIpRangesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ListVlanIpRangesParams) GetNetworkid() (string, bool) {
@@ -1095,6 +1335,12 @@ func (p *ListVlanIpRangesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1108,6 +1354,12 @@ func (p *ListVlanIpRangesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVlanIpRangesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVlanIpRangesParams) GetPagesize() (int, bool) {
@@ -1125,6 +1377,12 @@ func (p *ListVlanIpRangesParams) SetPhysicalnetworkid(v string) {
 	p.p["physicalnetworkid"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetPhysicalnetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1138,6 +1396,12 @@ func (p *ListVlanIpRangesParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListVlanIpRangesParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListVlanIpRangesParams) GetPodid() (string, bool) {
@@ -1155,6 +1419,12 @@ func (p *ListVlanIpRangesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1170,6 +1440,12 @@ func (p *ListVlanIpRangesParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *ListVlanIpRangesParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *ListVlanIpRangesParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1183,6 +1459,12 @@ func (p *ListVlanIpRangesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVlanIpRangesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVlanIpRangesParams) GetZoneid() (string, bool) {
@@ -1305,6 +1587,12 @@ func (p *ReleaseDedicatedGuestVlanRangeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ReleaseDedicatedGuestVlanRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ReleaseDedicatedGuestVlanRangeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1406,6 +1694,12 @@ func (p *ListGuestVlansParams) SetAllocatedonly(v bool) {
 	p.p["allocatedonly"] = v
 }
 
+func (p *ListGuestVlansParams) ResetAllocatedonly() {
+	if p.p != nil && p.p["allocatedonly"] != nil {
+		delete(p.p, "allocatedonly")
+	}
+}
+
 func (p *ListGuestVlansParams) GetAllocatedonly() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1419,6 +1713,12 @@ func (p *ListGuestVlansParams) SetId(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListGuestVlansParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListGuestVlansParams) GetId() (int64, bool) {
@@ -1436,6 +1736,12 @@ func (p *ListGuestVlansParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListGuestVlansParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListGuestVlansParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1449,6 +1755,12 @@ func (p *ListGuestVlansParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListGuestVlansParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListGuestVlansParams) GetPage() (int, bool) {
@@ -1466,6 +1778,12 @@ func (p *ListGuestVlansParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListGuestVlansParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListGuestVlansParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1479,6 +1797,12 @@ func (p *ListGuestVlansParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *ListGuestVlansParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *ListGuestVlansParams) GetPhysicalnetworkid() (string, bool) {
@@ -1496,6 +1820,12 @@ func (p *ListGuestVlansParams) SetVnet(v string) {
 	p.p["vnet"] = v
 }
 
+func (p *ListGuestVlansParams) ResetVnet() {
+	if p.p != nil && p.p["vnet"] != nil {
+		delete(p.p, "vnet")
+	}
+}
+
 func (p *ListGuestVlansParams) GetVnet() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1509,6 +1839,12 @@ func (p *ListGuestVlansParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListGuestVlansParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListGuestVlansParams) GetZoneid() (string, bool) {
@@ -1617,6 +1953,12 @@ func (p *UpdateVlanIpRangeParams) SetEndip(v string) {
 	p.p["endip"] = v
 }
 
+func (p *UpdateVlanIpRangeParams) ResetEndip() {
+	if p.p != nil && p.p["endip"] != nil {
+		delete(p.p, "endip")
+	}
+}
+
 func (p *UpdateVlanIpRangeParams) GetEndip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1630,6 +1972,12 @@ func (p *UpdateVlanIpRangeParams) SetEndipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["endipv6"] = v
+}
+
+func (p *UpdateVlanIpRangeParams) ResetEndipv6() {
+	if p.p != nil && p.p["endipv6"] != nil {
+		delete(p.p, "endipv6")
+	}
 }
 
 func (p *UpdateVlanIpRangeParams) GetEndipv6() (string, bool) {
@@ -1647,6 +1995,12 @@ func (p *UpdateVlanIpRangeParams) SetForsystemvms(v bool) {
 	p.p["forsystemvms"] = v
 }
 
+func (p *UpdateVlanIpRangeParams) ResetForsystemvms() {
+	if p.p != nil && p.p["forsystemvms"] != nil {
+		delete(p.p, "forsystemvms")
+	}
+}
+
 func (p *UpdateVlanIpRangeParams) GetForsystemvms() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1660,6 +2014,12 @@ func (p *UpdateVlanIpRangeParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *UpdateVlanIpRangeParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *UpdateVlanIpRangeParams) GetGateway() (string, bool) {
@@ -1677,6 +2037,12 @@ func (p *UpdateVlanIpRangeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateVlanIpRangeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateVlanIpRangeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1690,6 +2056,12 @@ func (p *UpdateVlanIpRangeParams) SetIp6cidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6cidr"] = v
+}
+
+func (p *UpdateVlanIpRangeParams) ResetIp6cidr() {
+	if p.p != nil && p.p["ip6cidr"] != nil {
+		delete(p.p, "ip6cidr")
+	}
 }
 
 func (p *UpdateVlanIpRangeParams) GetIp6cidr() (string, bool) {
@@ -1707,6 +2079,12 @@ func (p *UpdateVlanIpRangeParams) SetIp6gateway(v string) {
 	p.p["ip6gateway"] = v
 }
 
+func (p *UpdateVlanIpRangeParams) ResetIp6gateway() {
+	if p.p != nil && p.p["ip6gateway"] != nil {
+		delete(p.p, "ip6gateway")
+	}
+}
+
 func (p *UpdateVlanIpRangeParams) GetIp6gateway() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1720,6 +2098,12 @@ func (p *UpdateVlanIpRangeParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
+}
+
+func (p *UpdateVlanIpRangeParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
 }
 
 func (p *UpdateVlanIpRangeParams) GetNetmask() (string, bool) {
@@ -1737,6 +2121,12 @@ func (p *UpdateVlanIpRangeParams) SetStartip(v string) {
 	p.p["startip"] = v
 }
 
+func (p *UpdateVlanIpRangeParams) ResetStartip() {
+	if p.p != nil && p.p["startip"] != nil {
+		delete(p.p, "startip")
+	}
+}
+
 func (p *UpdateVlanIpRangeParams) GetStartip() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1750,6 +2140,12 @@ func (p *UpdateVlanIpRangeParams) SetStartipv6(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startipv6"] = v
+}
+
+func (p *UpdateVlanIpRangeParams) ResetStartipv6() {
+	if p.p != nil && p.p["startipv6"] != nil {
+		delete(p.p, "startipv6")
+	}
 }
 
 func (p *UpdateVlanIpRangeParams) GetStartipv6() (string, bool) {

--- a/cloudstack/VMGroupService.go
+++ b/cloudstack/VMGroupService.go
@@ -72,6 +72,12 @@ func (p *CreateInstanceGroupParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateInstanceGroupParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateInstanceGroupParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -85,6 +91,12 @@ func (p *CreateInstanceGroupParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateInstanceGroupParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateInstanceGroupParams) GetDomainid() (string, bool) {
@@ -102,6 +114,12 @@ func (p *CreateInstanceGroupParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateInstanceGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateInstanceGroupParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -115,6 +133,12 @@ func (p *CreateInstanceGroupParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateInstanceGroupParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateInstanceGroupParams) GetProjectid() (string, bool) {
@@ -183,6 +207,12 @@ func (p *DeleteInstanceGroupParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteInstanceGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteInstanceGroupParams) GetId() (string, bool) {
@@ -304,6 +334,12 @@ func (p *ListInstanceGroupsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListInstanceGroupsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListInstanceGroupsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -317,6 +353,12 @@ func (p *ListInstanceGroupsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListInstanceGroupsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListInstanceGroupsParams) GetDomainid() (string, bool) {
@@ -334,6 +376,12 @@ func (p *ListInstanceGroupsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListInstanceGroupsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListInstanceGroupsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -347,6 +395,12 @@ func (p *ListInstanceGroupsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListInstanceGroupsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListInstanceGroupsParams) GetIsrecursive() (bool, bool) {
@@ -364,6 +418,12 @@ func (p *ListInstanceGroupsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListInstanceGroupsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListInstanceGroupsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -377,6 +437,12 @@ func (p *ListInstanceGroupsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListInstanceGroupsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListInstanceGroupsParams) GetListall() (bool, bool) {
@@ -394,6 +460,12 @@ func (p *ListInstanceGroupsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListInstanceGroupsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListInstanceGroupsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -407,6 +479,12 @@ func (p *ListInstanceGroupsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListInstanceGroupsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListInstanceGroupsParams) GetPage() (int, bool) {
@@ -424,6 +502,12 @@ func (p *ListInstanceGroupsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListInstanceGroupsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListInstanceGroupsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -437,6 +521,12 @@ func (p *ListInstanceGroupsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListInstanceGroupsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListInstanceGroupsParams) GetProjectid() (string, bool) {
@@ -597,6 +687,12 @@ func (p *UpdateInstanceGroupParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateInstanceGroupParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateInstanceGroupParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -610,6 +706,12 @@ func (p *UpdateInstanceGroupParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateInstanceGroupParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateInstanceGroupParams) GetName() (string, bool) {

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -122,6 +122,12 @@ func (p *CreatePrivateGatewayParams) SetAclid(v string) {
 	p.p["aclid"] = v
 }
 
+func (p *CreatePrivateGatewayParams) ResetAclid() {
+	if p.p != nil && p.p["aclid"] != nil {
+		delete(p.p, "aclid")
+	}
+}
+
 func (p *CreatePrivateGatewayParams) GetAclid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -135,6 +141,12 @@ func (p *CreatePrivateGatewayParams) SetAssociatednetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["associatednetworkid"] = v
+}
+
+func (p *CreatePrivateGatewayParams) ResetAssociatednetworkid() {
+	if p.p != nil && p.p["associatednetworkid"] != nil {
+		delete(p.p, "associatednetworkid")
+	}
 }
 
 func (p *CreatePrivateGatewayParams) GetAssociatednetworkid() (string, bool) {
@@ -152,6 +164,12 @@ func (p *CreatePrivateGatewayParams) SetBypassvlanoverlapcheck(v bool) {
 	p.p["bypassvlanoverlapcheck"] = v
 }
 
+func (p *CreatePrivateGatewayParams) ResetBypassvlanoverlapcheck() {
+	if p.p != nil && p.p["bypassvlanoverlapcheck"] != nil {
+		delete(p.p, "bypassvlanoverlapcheck")
+	}
+}
+
 func (p *CreatePrivateGatewayParams) GetBypassvlanoverlapcheck() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -165,6 +183,12 @@ func (p *CreatePrivateGatewayParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *CreatePrivateGatewayParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *CreatePrivateGatewayParams) GetGateway() (string, bool) {
@@ -182,6 +206,12 @@ func (p *CreatePrivateGatewayParams) SetIpaddress(v string) {
 	p.p["ipaddress"] = v
 }
 
+func (p *CreatePrivateGatewayParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
+}
+
 func (p *CreatePrivateGatewayParams) GetIpaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -195,6 +225,12 @@ func (p *CreatePrivateGatewayParams) SetNetmask(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["netmask"] = v
+}
+
+func (p *CreatePrivateGatewayParams) ResetNetmask() {
+	if p.p != nil && p.p["netmask"] != nil {
+		delete(p.p, "netmask")
+	}
 }
 
 func (p *CreatePrivateGatewayParams) GetNetmask() (string, bool) {
@@ -212,6 +248,12 @@ func (p *CreatePrivateGatewayParams) SetNetworkofferingid(v string) {
 	p.p["networkofferingid"] = v
 }
 
+func (p *CreatePrivateGatewayParams) ResetNetworkofferingid() {
+	if p.p != nil && p.p["networkofferingid"] != nil {
+		delete(p.p, "networkofferingid")
+	}
+}
+
 func (p *CreatePrivateGatewayParams) GetNetworkofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -225,6 +267,12 @@ func (p *CreatePrivateGatewayParams) SetPhysicalnetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["physicalnetworkid"] = v
+}
+
+func (p *CreatePrivateGatewayParams) ResetPhysicalnetworkid() {
+	if p.p != nil && p.p["physicalnetworkid"] != nil {
+		delete(p.p, "physicalnetworkid")
+	}
 }
 
 func (p *CreatePrivateGatewayParams) GetPhysicalnetworkid() (string, bool) {
@@ -242,6 +290,12 @@ func (p *CreatePrivateGatewayParams) SetSourcenatsupported(v bool) {
 	p.p["sourcenatsupported"] = v
 }
 
+func (p *CreatePrivateGatewayParams) ResetSourcenatsupported() {
+	if p.p != nil && p.p["sourcenatsupported"] != nil {
+		delete(p.p, "sourcenatsupported")
+	}
+}
+
 func (p *CreatePrivateGatewayParams) GetSourcenatsupported() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -257,6 +311,12 @@ func (p *CreatePrivateGatewayParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *CreatePrivateGatewayParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *CreatePrivateGatewayParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -270,6 +330,12 @@ func (p *CreatePrivateGatewayParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *CreatePrivateGatewayParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *CreatePrivateGatewayParams) GetVpcid() (string, bool) {
@@ -379,6 +445,12 @@ func (p *CreateStaticRouteParams) SetCidr(v string) {
 	p.p["cidr"] = v
 }
 
+func (p *CreateStaticRouteParams) ResetCidr() {
+	if p.p != nil && p.p["cidr"] != nil {
+		delete(p.p, "cidr")
+	}
+}
+
 func (p *CreateStaticRouteParams) GetCidr() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -392,6 +464,12 @@ func (p *CreateStaticRouteParams) SetGatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gatewayid"] = v
+}
+
+func (p *CreateStaticRouteParams) ResetGatewayid() {
+	if p.p != nil && p.p["gatewayid"] != nil {
+		delete(p.p, "gatewayid")
+	}
 }
 
 func (p *CreateStaticRouteParams) GetGatewayid() (string, bool) {
@@ -536,6 +614,12 @@ func (p *CreateVPCParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateVPCParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateVPCParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -549,6 +633,12 @@ func (p *CreateVPCParams) SetCidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidr"] = v
+}
+
+func (p *CreateVPCParams) ResetCidr() {
+	if p.p != nil && p.p["cidr"] != nil {
+		delete(p.p, "cidr")
+	}
 }
 
 func (p *CreateVPCParams) GetCidr() (string, bool) {
@@ -566,6 +656,12 @@ func (p *CreateVPCParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *CreateVPCParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *CreateVPCParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -579,6 +675,12 @@ func (p *CreateVPCParams) SetDns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns1"] = v
+}
+
+func (p *CreateVPCParams) ResetDns1() {
+	if p.p != nil && p.p["dns1"] != nil {
+		delete(p.p, "dns1")
+	}
 }
 
 func (p *CreateVPCParams) GetDns1() (string, bool) {
@@ -596,6 +698,12 @@ func (p *CreateVPCParams) SetDns2(v string) {
 	p.p["dns2"] = v
 }
 
+func (p *CreateVPCParams) ResetDns2() {
+	if p.p != nil && p.p["dns2"] != nil {
+		delete(p.p, "dns2")
+	}
+}
+
 func (p *CreateVPCParams) GetDns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -609,6 +717,12 @@ func (p *CreateVPCParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateVPCParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateVPCParams) GetDomainid() (string, bool) {
@@ -626,6 +740,12 @@ func (p *CreateVPCParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateVPCParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateVPCParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -639,6 +759,12 @@ func (p *CreateVPCParams) SetIp6dns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns1"] = v
+}
+
+func (p *CreateVPCParams) ResetIp6dns1() {
+	if p.p != nil && p.p["ip6dns1"] != nil {
+		delete(p.p, "ip6dns1")
+	}
 }
 
 func (p *CreateVPCParams) GetIp6dns1() (string, bool) {
@@ -656,6 +782,12 @@ func (p *CreateVPCParams) SetIp6dns2(v string) {
 	p.p["ip6dns2"] = v
 }
 
+func (p *CreateVPCParams) ResetIp6dns2() {
+	if p.p != nil && p.p["ip6dns2"] != nil {
+		delete(p.p, "ip6dns2")
+	}
+}
+
 func (p *CreateVPCParams) GetIp6dns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -669,6 +801,12 @@ func (p *CreateVPCParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateVPCParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateVPCParams) GetName() (string, bool) {
@@ -686,6 +824,12 @@ func (p *CreateVPCParams) SetNetworkdomain(v string) {
 	p.p["networkdomain"] = v
 }
 
+func (p *CreateVPCParams) ResetNetworkdomain() {
+	if p.p != nil && p.p["networkdomain"] != nil {
+		delete(p.p, "networkdomain")
+	}
+}
+
 func (p *CreateVPCParams) GetNetworkdomain() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -699,6 +843,12 @@ func (p *CreateVPCParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *CreateVPCParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *CreateVPCParams) GetProjectid() (string, bool) {
@@ -716,6 +866,12 @@ func (p *CreateVPCParams) SetPublicmtu(v int) {
 	p.p["publicmtu"] = v
 }
 
+func (p *CreateVPCParams) ResetPublicmtu() {
+	if p.p != nil && p.p["publicmtu"] != nil {
+		delete(p.p, "publicmtu")
+	}
+}
+
 func (p *CreateVPCParams) GetPublicmtu() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -729,6 +885,12 @@ func (p *CreateVPCParams) SetSourcenatipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcenatipaddress"] = v
+}
+
+func (p *CreateVPCParams) ResetSourcenatipaddress() {
+	if p.p != nil && p.p["sourcenatipaddress"] != nil {
+		delete(p.p, "sourcenatipaddress")
+	}
 }
 
 func (p *CreateVPCParams) GetSourcenatipaddress() (string, bool) {
@@ -746,6 +908,12 @@ func (p *CreateVPCParams) SetStart(v bool) {
 	p.p["start"] = v
 }
 
+func (p *CreateVPCParams) ResetStart() {
+	if p.p != nil && p.p["start"] != nil {
+		delete(p.p, "start")
+	}
+}
+
 func (p *CreateVPCParams) GetStart() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -761,6 +929,12 @@ func (p *CreateVPCParams) SetVpcofferingid(v string) {
 	p.p["vpcofferingid"] = v
 }
 
+func (p *CreateVPCParams) ResetVpcofferingid() {
+	if p.p != nil && p.p["vpcofferingid"] != nil {
+		delete(p.p, "vpcofferingid")
+	}
+}
+
 func (p *CreateVPCParams) GetVpcofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -774,6 +948,12 @@ func (p *CreateVPCParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateVPCParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateVPCParams) GetZoneid() (string, bool) {
@@ -952,6 +1132,12 @@ func (p *CreateVPCOfferingParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *CreateVPCOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *CreateVPCOfferingParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -965,6 +1151,12 @@ func (p *CreateVPCOfferingParams) SetDomainid(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateVPCOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateVPCOfferingParams) GetDomainid() ([]string, bool) {
@@ -982,6 +1174,12 @@ func (p *CreateVPCOfferingParams) SetEnable(v bool) {
 	p.p["enable"] = v
 }
 
+func (p *CreateVPCOfferingParams) ResetEnable() {
+	if p.p != nil && p.p["enable"] != nil {
+		delete(p.p, "enable")
+	}
+}
+
 func (p *CreateVPCOfferingParams) GetEnable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -995,6 +1193,12 @@ func (p *CreateVPCOfferingParams) SetInternetprotocol(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internetprotocol"] = v
+}
+
+func (p *CreateVPCOfferingParams) ResetInternetprotocol() {
+	if p.p != nil && p.p["internetprotocol"] != nil {
+		delete(p.p, "internetprotocol")
+	}
 }
 
 func (p *CreateVPCOfferingParams) GetInternetprotocol() (string, bool) {
@@ -1012,6 +1216,12 @@ func (p *CreateVPCOfferingParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateVPCOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateVPCOfferingParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1025,6 +1235,12 @@ func (p *CreateVPCOfferingParams) SetServicecapabilitylist(v map[string]string) 
 		p.p = make(map[string]interface{})
 	}
 	p.p["servicecapabilitylist"] = v
+}
+
+func (p *CreateVPCOfferingParams) ResetServicecapabilitylist() {
+	if p.p != nil && p.p["servicecapabilitylist"] != nil {
+		delete(p.p, "servicecapabilitylist")
+	}
 }
 
 func (p *CreateVPCOfferingParams) GetServicecapabilitylist() (map[string]string, bool) {
@@ -1042,6 +1258,12 @@ func (p *CreateVPCOfferingParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *CreateVPCOfferingParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *CreateVPCOfferingParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1055,6 +1277,12 @@ func (p *CreateVPCOfferingParams) SetServiceproviderlist(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceproviderlist"] = v
+}
+
+func (p *CreateVPCOfferingParams) ResetServiceproviderlist() {
+	if p.p != nil && p.p["serviceproviderlist"] != nil {
+		delete(p.p, "serviceproviderlist")
+	}
 }
 
 func (p *CreateVPCOfferingParams) GetServiceproviderlist() (map[string]string, bool) {
@@ -1072,6 +1300,12 @@ func (p *CreateVPCOfferingParams) SetSupportedservices(v []string) {
 	p.p["supportedservices"] = v
 }
 
+func (p *CreateVPCOfferingParams) ResetSupportedservices() {
+	if p.p != nil && p.p["supportedservices"] != nil {
+		delete(p.p, "supportedservices")
+	}
+}
+
 func (p *CreateVPCOfferingParams) GetSupportedservices() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1085,6 +1319,12 @@ func (p *CreateVPCOfferingParams) SetZoneid(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateVPCOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateVPCOfferingParams) GetZoneid() ([]string, bool) {
@@ -1204,6 +1444,12 @@ func (p *DeletePrivateGatewayParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeletePrivateGatewayParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeletePrivateGatewayParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1278,6 +1524,12 @@ func (p *DeleteStaticRouteParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteStaticRouteParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteStaticRouteParams) GetId() (string, bool) {
@@ -1356,6 +1608,12 @@ func (p *DeleteVPCParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteVPCParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteVPCParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1430,6 +1688,12 @@ func (p *DeleteVPCOfferingParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteVPCOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteVPCOfferingParams) GetId() (string, bool) {
@@ -1548,6 +1812,12 @@ func (p *ListPrivateGatewaysParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1561,6 +1831,12 @@ func (p *ListPrivateGatewaysParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListPrivateGatewaysParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListPrivateGatewaysParams) GetDomainid() (string, bool) {
@@ -1578,6 +1854,12 @@ func (p *ListPrivateGatewaysParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1591,6 +1873,12 @@ func (p *ListPrivateGatewaysParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+}
+
+func (p *ListPrivateGatewaysParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
 }
 
 func (p *ListPrivateGatewaysParams) GetIpaddress() (string, bool) {
@@ -1608,6 +1896,12 @@ func (p *ListPrivateGatewaysParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1621,6 +1915,12 @@ func (p *ListPrivateGatewaysParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListPrivateGatewaysParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListPrivateGatewaysParams) GetKeyword() (string, bool) {
@@ -1638,6 +1938,12 @@ func (p *ListPrivateGatewaysParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1651,6 +1957,12 @@ func (p *ListPrivateGatewaysParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListPrivateGatewaysParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListPrivateGatewaysParams) GetPage() (int, bool) {
@@ -1668,6 +1980,12 @@ func (p *ListPrivateGatewaysParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1681,6 +1999,12 @@ func (p *ListPrivateGatewaysParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListPrivateGatewaysParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListPrivateGatewaysParams) GetProjectid() (string, bool) {
@@ -1698,6 +2022,12 @@ func (p *ListPrivateGatewaysParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1713,6 +2043,12 @@ func (p *ListPrivateGatewaysParams) SetVlan(v string) {
 	p.p["vlan"] = v
 }
 
+func (p *ListPrivateGatewaysParams) ResetVlan() {
+	if p.p != nil && p.p["vlan"] != nil {
+		delete(p.p, "vlan")
+	}
+}
+
 func (p *ListPrivateGatewaysParams) GetVlan() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1726,6 +2062,12 @@ func (p *ListPrivateGatewaysParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *ListPrivateGatewaysParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *ListPrivateGatewaysParams) GetVpcid() (string, bool) {
@@ -1890,6 +2232,12 @@ func (p *ListStaticRoutesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1903,6 +2251,12 @@ func (p *ListStaticRoutesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListStaticRoutesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListStaticRoutesParams) GetDomainid() (string, bool) {
@@ -1920,6 +2274,12 @@ func (p *ListStaticRoutesParams) SetGatewayid(v string) {
 	p.p["gatewayid"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetGatewayid() {
+	if p.p != nil && p.p["gatewayid"] != nil {
+		delete(p.p, "gatewayid")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetGatewayid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1933,6 +2293,12 @@ func (p *ListStaticRoutesParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListStaticRoutesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListStaticRoutesParams) GetId() (string, bool) {
@@ -1950,6 +2316,12 @@ func (p *ListStaticRoutesParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1963,6 +2335,12 @@ func (p *ListStaticRoutesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListStaticRoutesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListStaticRoutesParams) GetKeyword() (string, bool) {
@@ -1980,6 +2358,12 @@ func (p *ListStaticRoutesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1993,6 +2377,12 @@ func (p *ListStaticRoutesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListStaticRoutesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListStaticRoutesParams) GetPage() (int, bool) {
@@ -2010,6 +2400,12 @@ func (p *ListStaticRoutesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2023,6 +2419,12 @@ func (p *ListStaticRoutesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListStaticRoutesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListStaticRoutesParams) GetProjectid() (string, bool) {
@@ -2040,6 +2442,12 @@ func (p *ListStaticRoutesParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2055,6 +2463,12 @@ func (p *ListStaticRoutesParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListStaticRoutesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListStaticRoutesParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2068,6 +2482,12 @@ func (p *ListStaticRoutesParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *ListStaticRoutesParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *ListStaticRoutesParams) GetVpcid() (string, bool) {
@@ -2211,6 +2631,12 @@ func (p *ListVPCOfferingsParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *ListVPCOfferingsParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *ListVPCOfferingsParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2224,6 +2650,12 @@ func (p *ListVPCOfferingsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVPCOfferingsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVPCOfferingsParams) GetDomainid() (string, bool) {
@@ -2241,6 +2673,12 @@ func (p *ListVPCOfferingsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVPCOfferingsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVPCOfferingsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2254,6 +2692,12 @@ func (p *ListVPCOfferingsParams) SetIsdefault(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdefault"] = v
+}
+
+func (p *ListVPCOfferingsParams) ResetIsdefault() {
+	if p.p != nil && p.p["isdefault"] != nil {
+		delete(p.p, "isdefault")
+	}
 }
 
 func (p *ListVPCOfferingsParams) GetIsdefault() (bool, bool) {
@@ -2271,6 +2715,12 @@ func (p *ListVPCOfferingsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVPCOfferingsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVPCOfferingsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2284,6 +2734,12 @@ func (p *ListVPCOfferingsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListVPCOfferingsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListVPCOfferingsParams) GetName() (string, bool) {
@@ -2301,6 +2757,12 @@ func (p *ListVPCOfferingsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVPCOfferingsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVPCOfferingsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2314,6 +2776,12 @@ func (p *ListVPCOfferingsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVPCOfferingsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVPCOfferingsParams) GetPagesize() (int, bool) {
@@ -2331,6 +2799,12 @@ func (p *ListVPCOfferingsParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListVPCOfferingsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListVPCOfferingsParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2346,6 +2820,12 @@ func (p *ListVPCOfferingsParams) SetSupportedservices(v []string) {
 	p.p["supportedservices"] = v
 }
 
+func (p *ListVPCOfferingsParams) ResetSupportedservices() {
+	if p.p != nil && p.p["supportedservices"] != nil {
+		delete(p.p, "supportedservices")
+	}
+}
+
 func (p *ListVPCOfferingsParams) GetSupportedservices() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2359,6 +2839,12 @@ func (p *ListVPCOfferingsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVPCOfferingsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVPCOfferingsParams) GetZoneid() (string, bool) {
@@ -2612,6 +3098,12 @@ func (p *ListVPCsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVPCsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVPCsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2625,6 +3117,12 @@ func (p *ListVPCsParams) SetCidr(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidr"] = v
+}
+
+func (p *ListVPCsParams) ResetCidr() {
+	if p.p != nil && p.p["cidr"] != nil {
+		delete(p.p, "cidr")
+	}
 }
 
 func (p *ListVPCsParams) GetCidr() (string, bool) {
@@ -2642,6 +3140,12 @@ func (p *ListVPCsParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *ListVPCsParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *ListVPCsParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2655,6 +3159,12 @@ func (p *ListVPCsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVPCsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVPCsParams) GetDomainid() (string, bool) {
@@ -2672,6 +3182,12 @@ func (p *ListVPCsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListVPCsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListVPCsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2685,6 +3201,12 @@ func (p *ListVPCsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListVPCsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListVPCsParams) GetId() (string, bool) {
@@ -2702,6 +3224,12 @@ func (p *ListVPCsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListVPCsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListVPCsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2715,6 +3243,12 @@ func (p *ListVPCsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVPCsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVPCsParams) GetKeyword() (string, bool) {
@@ -2732,6 +3266,12 @@ func (p *ListVPCsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListVPCsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListVPCsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2745,6 +3285,12 @@ func (p *ListVPCsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListVPCsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListVPCsParams) GetName() (string, bool) {
@@ -2762,6 +3308,12 @@ func (p *ListVPCsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVPCsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVPCsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2775,6 +3327,12 @@ func (p *ListVPCsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVPCsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVPCsParams) GetPagesize() (int, bool) {
@@ -2792,6 +3350,12 @@ func (p *ListVPCsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVPCsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVPCsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2805,6 +3369,12 @@ func (p *ListVPCsParams) SetRestartrequired(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["restartrequired"] = v
+}
+
+func (p *ListVPCsParams) ResetRestartrequired() {
+	if p.p != nil && p.p["restartrequired"] != nil {
+		delete(p.p, "restartrequired")
+	}
 }
 
 func (p *ListVPCsParams) GetRestartrequired() (bool, bool) {
@@ -2822,6 +3392,12 @@ func (p *ListVPCsParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListVPCsParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListVPCsParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2835,6 +3411,12 @@ func (p *ListVPCsParams) SetState(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["state"] = v
+}
+
+func (p *ListVPCsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
 }
 
 func (p *ListVPCsParams) GetState() (string, bool) {
@@ -2852,6 +3434,12 @@ func (p *ListVPCsParams) SetSupportedservices(v []string) {
 	p.p["supportedservices"] = v
 }
 
+func (p *ListVPCsParams) ResetSupportedservices() {
+	if p.p != nil && p.p["supportedservices"] != nil {
+		delete(p.p, "supportedservices")
+	}
+}
+
 func (p *ListVPCsParams) GetSupportedservices() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2865,6 +3453,12 @@ func (p *ListVPCsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListVPCsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListVPCsParams) GetTags() (map[string]string, bool) {
@@ -2882,6 +3476,12 @@ func (p *ListVPCsParams) SetVpcofferingid(v string) {
 	p.p["vpcofferingid"] = v
 }
 
+func (p *ListVPCsParams) ResetVpcofferingid() {
+	if p.p != nil && p.p["vpcofferingid"] != nil {
+		delete(p.p, "vpcofferingid")
+	}
+}
+
 func (p *ListVPCsParams) GetVpcofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2895,6 +3495,12 @@ func (p *ListVPCsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVPCsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVPCsParams) GetZoneid() (string, bool) {
@@ -3109,6 +3715,12 @@ func (p *RestartVPCParams) SetCleanup(v bool) {
 	p.p["cleanup"] = v
 }
 
+func (p *RestartVPCParams) ResetCleanup() {
+	if p.p != nil && p.p["cleanup"] != nil {
+		delete(p.p, "cleanup")
+	}
+}
+
 func (p *RestartVPCParams) GetCleanup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3122,6 +3734,12 @@ func (p *RestartVPCParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RestartVPCParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RestartVPCParams) GetId() (string, bool) {
@@ -3139,6 +3757,12 @@ func (p *RestartVPCParams) SetLivepatch(v bool) {
 	p.p["livepatch"] = v
 }
 
+func (p *RestartVPCParams) ResetLivepatch() {
+	if p.p != nil && p.p["livepatch"] != nil {
+		delete(p.p, "livepatch")
+	}
+}
+
 func (p *RestartVPCParams) GetLivepatch() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3152,6 +3776,12 @@ func (p *RestartVPCParams) SetMakeredundant(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["makeredundant"] = v
+}
+
+func (p *RestartVPCParams) ResetMakeredundant() {
+	if p.p != nil && p.p["makeredundant"] != nil {
+		delete(p.p, "makeredundant")
+	}
 }
 
 func (p *RestartVPCParams) GetMakeredundant() (bool, bool) {
@@ -3250,6 +3880,12 @@ func (p *UpdateVPCParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateVPCParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateVPCParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3263,6 +3899,12 @@ func (p *UpdateVPCParams) SetDisplaytext(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displaytext"] = v
+}
+
+func (p *UpdateVPCParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
 }
 
 func (p *UpdateVPCParams) GetDisplaytext() (string, bool) {
@@ -3280,6 +3922,12 @@ func (p *UpdateVPCParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateVPCParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateVPCParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3293,6 +3941,12 @@ func (p *UpdateVPCParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateVPCParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateVPCParams) GetId() (string, bool) {
@@ -3310,6 +3964,12 @@ func (p *UpdateVPCParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateVPCParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateVPCParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3325,6 +3985,12 @@ func (p *UpdateVPCParams) SetPublicmtu(v int) {
 	p.p["publicmtu"] = v
 }
 
+func (p *UpdateVPCParams) ResetPublicmtu() {
+	if p.p != nil && p.p["publicmtu"] != nil {
+		delete(p.p, "publicmtu")
+	}
+}
+
 func (p *UpdateVPCParams) GetPublicmtu() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3338,6 +4004,12 @@ func (p *UpdateVPCParams) SetSourcenatipaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sourcenatipaddress"] = v
+}
+
+func (p *UpdateVPCParams) ResetSourcenatipaddress() {
+	if p.p != nil && p.p["sourcenatipaddress"] != nil {
+		delete(p.p, "sourcenatipaddress")
+	}
 }
 
 func (p *UpdateVPCParams) GetSourcenatipaddress() (string, bool) {
@@ -3492,6 +4164,12 @@ func (p *UpdateVPCOfferingParams) SetDisplaytext(v string) {
 	p.p["displaytext"] = v
 }
 
+func (p *UpdateVPCOfferingParams) ResetDisplaytext() {
+	if p.p != nil && p.p["displaytext"] != nil {
+		delete(p.p, "displaytext")
+	}
+}
+
 func (p *UpdateVPCOfferingParams) GetDisplaytext() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3505,6 +4183,12 @@ func (p *UpdateVPCOfferingParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UpdateVPCOfferingParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UpdateVPCOfferingParams) GetDomainid() (string, bool) {
@@ -3522,6 +4206,12 @@ func (p *UpdateVPCOfferingParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateVPCOfferingParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateVPCOfferingParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3535,6 +4225,12 @@ func (p *UpdateVPCOfferingParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *UpdateVPCOfferingParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *UpdateVPCOfferingParams) GetName() (string, bool) {
@@ -3552,6 +4248,12 @@ func (p *UpdateVPCOfferingParams) SetSortkey(v int) {
 	p.p["sortkey"] = v
 }
 
+func (p *UpdateVPCOfferingParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
+}
+
 func (p *UpdateVPCOfferingParams) GetSortkey() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3567,6 +4269,12 @@ func (p *UpdateVPCOfferingParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *UpdateVPCOfferingParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *UpdateVPCOfferingParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3580,6 +4288,12 @@ func (p *UpdateVPCOfferingParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UpdateVPCOfferingParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UpdateVPCOfferingParams) GetZoneid() (string, bool) {

--- a/cloudstack/VPNService.go
+++ b/cloudstack/VPNService.go
@@ -111,6 +111,12 @@ func (p *AddVpnUserParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AddVpnUserParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AddVpnUserParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -124,6 +130,12 @@ func (p *AddVpnUserParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *AddVpnUserParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *AddVpnUserParams) GetDomainid() (string, bool) {
@@ -141,6 +153,12 @@ func (p *AddVpnUserParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *AddVpnUserParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *AddVpnUserParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -156,6 +174,12 @@ func (p *AddVpnUserParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *AddVpnUserParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *AddVpnUserParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -169,6 +193,12 @@ func (p *AddVpnUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *AddVpnUserParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *AddVpnUserParams) GetUsername() (string, bool) {
@@ -276,6 +306,12 @@ func (p *CreateRemoteAccessVpnParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateRemoteAccessVpnParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateRemoteAccessVpnParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -289,6 +325,12 @@ func (p *CreateRemoteAccessVpnParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *CreateRemoteAccessVpnParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *CreateRemoteAccessVpnParams) GetDomainid() (string, bool) {
@@ -306,6 +348,12 @@ func (p *CreateRemoteAccessVpnParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateRemoteAccessVpnParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateRemoteAccessVpnParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -319,6 +367,12 @@ func (p *CreateRemoteAccessVpnParams) SetIprange(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iprange"] = v
+}
+
+func (p *CreateRemoteAccessVpnParams) ResetIprange() {
+	if p.p != nil && p.p["iprange"] != nil {
+		delete(p.p, "iprange")
+	}
 }
 
 func (p *CreateRemoteAccessVpnParams) GetIprange() (string, bool) {
@@ -336,6 +390,12 @@ func (p *CreateRemoteAccessVpnParams) SetOpenfirewall(v bool) {
 	p.p["openfirewall"] = v
 }
 
+func (p *CreateRemoteAccessVpnParams) ResetOpenfirewall() {
+	if p.p != nil && p.p["openfirewall"] != nil {
+		delete(p.p, "openfirewall")
+	}
+}
+
 func (p *CreateRemoteAccessVpnParams) GetOpenfirewall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -349,6 +409,12 @@ func (p *CreateRemoteAccessVpnParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
+}
+
+func (p *CreateRemoteAccessVpnParams) ResetPublicipid() {
+	if p.p != nil && p.p["publicipid"] != nil {
+		delete(p.p, "publicipid")
+	}
 }
 
 func (p *CreateRemoteAccessVpnParams) GetPublicipid() (string, bool) {
@@ -453,6 +519,12 @@ func (p *CreateVpnConnectionParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateVpnConnectionParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateVpnConnectionParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -466,6 +538,12 @@ func (p *CreateVpnConnectionParams) SetPassive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["passive"] = v
+}
+
+func (p *CreateVpnConnectionParams) ResetPassive() {
+	if p.p != nil && p.p["passive"] != nil {
+		delete(p.p, "passive")
+	}
 }
 
 func (p *CreateVpnConnectionParams) GetPassive() (bool, bool) {
@@ -483,6 +561,12 @@ func (p *CreateVpnConnectionParams) SetS2scustomergatewayid(v string) {
 	p.p["s2scustomergatewayid"] = v
 }
 
+func (p *CreateVpnConnectionParams) ResetS2scustomergatewayid() {
+	if p.p != nil && p.p["s2scustomergatewayid"] != nil {
+		delete(p.p, "s2scustomergatewayid")
+	}
+}
+
 func (p *CreateVpnConnectionParams) GetS2scustomergatewayid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -496,6 +580,12 @@ func (p *CreateVpnConnectionParams) SetS2svpngatewayid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["s2svpngatewayid"] = v
+}
+
+func (p *CreateVpnConnectionParams) ResetS2svpngatewayid() {
+	if p.p != nil && p.p["s2svpngatewayid"] != nil {
+		delete(p.p, "s2svpngatewayid")
+	}
 }
 
 func (p *CreateVpnConnectionParams) GetS2svpngatewayid() (string, bool) {
@@ -650,6 +740,12 @@ func (p *CreateVpnCustomerGatewayParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -663,6 +759,12 @@ func (p *CreateVpnCustomerGatewayParams) SetCidrlist(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetCidrlist() (string, bool) {
@@ -680,6 +782,12 @@ func (p *CreateVpnCustomerGatewayParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -693,6 +801,12 @@ func (p *CreateVpnCustomerGatewayParams) SetDpd(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dpd"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetDpd() {
+	if p.p != nil && p.p["dpd"] != nil {
+		delete(p.p, "dpd")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetDpd() (bool, bool) {
@@ -710,6 +824,12 @@ func (p *CreateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
 	p.p["esplifetime"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetEsplifetime() {
+	if p.p != nil && p.p["esplifetime"] != nil {
+		delete(p.p, "esplifetime")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetEsplifetime() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -723,6 +843,12 @@ func (p *CreateVpnCustomerGatewayParams) SetEsppolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["esppolicy"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetEsppolicy() {
+	if p.p != nil && p.p["esppolicy"] != nil {
+		delete(p.p, "esppolicy")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetEsppolicy() (string, bool) {
@@ -740,6 +866,12 @@ func (p *CreateVpnCustomerGatewayParams) SetForceencap(v bool) {
 	p.p["forceencap"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetForceencap() {
+	if p.p != nil && p.p["forceencap"] != nil {
+		delete(p.p, "forceencap")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetForceencap() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -753,6 +885,12 @@ func (p *CreateVpnCustomerGatewayParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetGateway() (string, bool) {
@@ -770,6 +908,12 @@ func (p *CreateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
 	p.p["ikelifetime"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetIkelifetime() {
+	if p.p != nil && p.p["ikelifetime"] != nil {
+		delete(p.p, "ikelifetime")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetIkelifetime() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -783,6 +927,12 @@ func (p *CreateVpnCustomerGatewayParams) SetIkepolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikepolicy"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetIkepolicy() {
+	if p.p != nil && p.p["ikepolicy"] != nil {
+		delete(p.p, "ikepolicy")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetIkepolicy() (string, bool) {
@@ -800,6 +950,12 @@ func (p *CreateVpnCustomerGatewayParams) SetIkeversion(v string) {
 	p.p["ikeversion"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetIkeversion() {
+	if p.p != nil && p.p["ikeversion"] != nil {
+		delete(p.p, "ikeversion")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetIkeversion() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -813,6 +969,12 @@ func (p *CreateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipsecpsk"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetIpsecpsk() {
+	if p.p != nil && p.p["ipsecpsk"] != nil {
+		delete(p.p, "ipsecpsk")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetIpsecpsk() (string, bool) {
@@ -830,6 +992,12 @@ func (p *CreateVpnCustomerGatewayParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -845,6 +1013,12 @@ func (p *CreateVpnCustomerGatewayParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *CreateVpnCustomerGatewayParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *CreateVpnCustomerGatewayParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -858,6 +1032,12 @@ func (p *CreateVpnCustomerGatewayParams) SetSplitconnections(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["splitconnections"] = v
+}
+
+func (p *CreateVpnCustomerGatewayParams) ResetSplitconnections() {
+	if p.p != nil && p.p["splitconnections"] != nil {
+		delete(p.p, "splitconnections")
+	}
 }
 
 func (p *CreateVpnCustomerGatewayParams) GetSplitconnections() (bool, bool) {
@@ -968,6 +1148,12 @@ func (p *CreateVpnGatewayParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *CreateVpnGatewayParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *CreateVpnGatewayParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -981,6 +1167,12 @@ func (p *CreateVpnGatewayParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *CreateVpnGatewayParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *CreateVpnGatewayParams) GetVpcid() (string, bool) {
@@ -1073,6 +1265,12 @@ func (p *DeleteRemoteAccessVpnParams) SetPublicipid(v string) {
 	p.p["publicipid"] = v
 }
 
+func (p *DeleteRemoteAccessVpnParams) ResetPublicipid() {
+	if p.p != nil && p.p["publicipid"] != nil {
+		delete(p.p, "publicipid")
+	}
+}
+
 func (p *DeleteRemoteAccessVpnParams) GetPublicipid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1147,6 +1345,12 @@ func (p *DeleteVpnConnectionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteVpnConnectionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteVpnConnectionParams) GetId() (string, bool) {
@@ -1225,6 +1429,12 @@ func (p *DeleteVpnCustomerGatewayParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteVpnCustomerGatewayParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteVpnCustomerGatewayParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1299,6 +1509,12 @@ func (p *DeleteVpnGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DeleteVpnGatewayParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DeleteVpnGatewayParams) GetId() (string, bool) {
@@ -1415,6 +1631,12 @@ func (p *ListRemoteAccessVpnsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListRemoteAccessVpnsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListRemoteAccessVpnsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1428,6 +1650,12 @@ func (p *ListRemoteAccessVpnsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListRemoteAccessVpnsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListRemoteAccessVpnsParams) GetDomainid() (string, bool) {
@@ -1445,6 +1673,12 @@ func (p *ListRemoteAccessVpnsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListRemoteAccessVpnsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListRemoteAccessVpnsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1458,6 +1692,12 @@ func (p *ListRemoteAccessVpnsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListRemoteAccessVpnsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListRemoteAccessVpnsParams) GetId() (string, bool) {
@@ -1475,6 +1715,12 @@ func (p *ListRemoteAccessVpnsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListRemoteAccessVpnsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListRemoteAccessVpnsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1488,6 +1734,12 @@ func (p *ListRemoteAccessVpnsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListRemoteAccessVpnsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListRemoteAccessVpnsParams) GetKeyword() (string, bool) {
@@ -1505,6 +1757,12 @@ func (p *ListRemoteAccessVpnsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListRemoteAccessVpnsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListRemoteAccessVpnsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1518,6 +1776,12 @@ func (p *ListRemoteAccessVpnsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ListRemoteAccessVpnsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ListRemoteAccessVpnsParams) GetNetworkid() (string, bool) {
@@ -1535,6 +1799,12 @@ func (p *ListRemoteAccessVpnsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListRemoteAccessVpnsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListRemoteAccessVpnsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1548,6 +1818,12 @@ func (p *ListRemoteAccessVpnsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListRemoteAccessVpnsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListRemoteAccessVpnsParams) GetPagesize() (int, bool) {
@@ -1565,6 +1841,12 @@ func (p *ListRemoteAccessVpnsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListRemoteAccessVpnsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListRemoteAccessVpnsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1578,6 +1860,12 @@ func (p *ListRemoteAccessVpnsParams) SetPublicipid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["publicipid"] = v
+}
+
+func (p *ListRemoteAccessVpnsParams) ResetPublicipid() {
+	if p.p != nil && p.p["publicipid"] != nil {
+		delete(p.p, "publicipid")
+	}
 }
 
 func (p *ListRemoteAccessVpnsParams) GetPublicipid() (string, bool) {
@@ -1723,6 +2011,12 @@ func (p *ListVpnConnectionsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVpnConnectionsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVpnConnectionsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1736,6 +2030,12 @@ func (p *ListVpnConnectionsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVpnConnectionsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVpnConnectionsParams) GetDomainid() (string, bool) {
@@ -1753,6 +2053,12 @@ func (p *ListVpnConnectionsParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListVpnConnectionsParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListVpnConnectionsParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1766,6 +2072,12 @@ func (p *ListVpnConnectionsParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListVpnConnectionsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListVpnConnectionsParams) GetId() (string, bool) {
@@ -1783,6 +2095,12 @@ func (p *ListVpnConnectionsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListVpnConnectionsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListVpnConnectionsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1796,6 +2114,12 @@ func (p *ListVpnConnectionsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVpnConnectionsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVpnConnectionsParams) GetKeyword() (string, bool) {
@@ -1813,6 +2137,12 @@ func (p *ListVpnConnectionsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListVpnConnectionsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListVpnConnectionsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1826,6 +2156,12 @@ func (p *ListVpnConnectionsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListVpnConnectionsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListVpnConnectionsParams) GetPage() (int, bool) {
@@ -1843,6 +2179,12 @@ func (p *ListVpnConnectionsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListVpnConnectionsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListVpnConnectionsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1858,6 +2200,12 @@ func (p *ListVpnConnectionsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVpnConnectionsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVpnConnectionsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1871,6 +2219,12 @@ func (p *ListVpnConnectionsParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *ListVpnConnectionsParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *ListVpnConnectionsParams) GetVpcid() (string, bool) {
@@ -2022,6 +2376,12 @@ func (p *ListVpnCustomerGatewaysParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVpnCustomerGatewaysParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVpnCustomerGatewaysParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2035,6 +2395,12 @@ func (p *ListVpnCustomerGatewaysParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVpnCustomerGatewaysParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVpnCustomerGatewaysParams) GetDomainid() (string, bool) {
@@ -2052,6 +2418,12 @@ func (p *ListVpnCustomerGatewaysParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVpnCustomerGatewaysParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVpnCustomerGatewaysParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2065,6 +2437,12 @@ func (p *ListVpnCustomerGatewaysParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListVpnCustomerGatewaysParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListVpnCustomerGatewaysParams) GetIsrecursive() (bool, bool) {
@@ -2082,6 +2460,12 @@ func (p *ListVpnCustomerGatewaysParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVpnCustomerGatewaysParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVpnCustomerGatewaysParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2095,6 +2479,12 @@ func (p *ListVpnCustomerGatewaysParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListVpnCustomerGatewaysParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListVpnCustomerGatewaysParams) GetListall() (bool, bool) {
@@ -2112,6 +2502,12 @@ func (p *ListVpnCustomerGatewaysParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVpnCustomerGatewaysParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVpnCustomerGatewaysParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2127,6 +2523,12 @@ func (p *ListVpnCustomerGatewaysParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListVpnCustomerGatewaysParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListVpnCustomerGatewaysParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2140,6 +2542,12 @@ func (p *ListVpnCustomerGatewaysParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListVpnCustomerGatewaysParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListVpnCustomerGatewaysParams) GetProjectid() (string, bool) {
@@ -2344,6 +2752,12 @@ func (p *ListVpnGatewaysParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVpnGatewaysParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVpnGatewaysParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2357,6 +2771,12 @@ func (p *ListVpnGatewaysParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVpnGatewaysParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVpnGatewaysParams) GetDomainid() (string, bool) {
@@ -2374,6 +2794,12 @@ func (p *ListVpnGatewaysParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *ListVpnGatewaysParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *ListVpnGatewaysParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2387,6 +2813,12 @@ func (p *ListVpnGatewaysParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListVpnGatewaysParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListVpnGatewaysParams) GetId() (string, bool) {
@@ -2404,6 +2836,12 @@ func (p *ListVpnGatewaysParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListVpnGatewaysParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListVpnGatewaysParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2417,6 +2855,12 @@ func (p *ListVpnGatewaysParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVpnGatewaysParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVpnGatewaysParams) GetKeyword() (string, bool) {
@@ -2434,6 +2878,12 @@ func (p *ListVpnGatewaysParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListVpnGatewaysParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListVpnGatewaysParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2447,6 +2897,12 @@ func (p *ListVpnGatewaysParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListVpnGatewaysParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListVpnGatewaysParams) GetPage() (int, bool) {
@@ -2464,6 +2920,12 @@ func (p *ListVpnGatewaysParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListVpnGatewaysParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListVpnGatewaysParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2479,6 +2941,12 @@ func (p *ListVpnGatewaysParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVpnGatewaysParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVpnGatewaysParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2492,6 +2960,12 @@ func (p *ListVpnGatewaysParams) SetVpcid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["vpcid"] = v
+}
+
+func (p *ListVpnGatewaysParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
 }
 
 func (p *ListVpnGatewaysParams) GetVpcid() (string, bool) {
@@ -2632,6 +3106,12 @@ func (p *ListVpnUsersParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVpnUsersParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVpnUsersParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2645,6 +3125,12 @@ func (p *ListVpnUsersParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListVpnUsersParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListVpnUsersParams) GetDomainid() (string, bool) {
@@ -2662,6 +3148,12 @@ func (p *ListVpnUsersParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVpnUsersParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVpnUsersParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2675,6 +3167,12 @@ func (p *ListVpnUsersParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListVpnUsersParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListVpnUsersParams) GetIsrecursive() (bool, bool) {
@@ -2692,6 +3190,12 @@ func (p *ListVpnUsersParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVpnUsersParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVpnUsersParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2705,6 +3209,12 @@ func (p *ListVpnUsersParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListVpnUsersParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListVpnUsersParams) GetListall() (bool, bool) {
@@ -2722,6 +3232,12 @@ func (p *ListVpnUsersParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVpnUsersParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVpnUsersParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2735,6 +3251,12 @@ func (p *ListVpnUsersParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVpnUsersParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVpnUsersParams) GetPagesize() (int, bool) {
@@ -2752,6 +3274,12 @@ func (p *ListVpnUsersParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVpnUsersParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVpnUsersParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2765,6 +3293,12 @@ func (p *ListVpnUsersParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *ListVpnUsersParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *ListVpnUsersParams) GetUsername() (string, bool) {
@@ -2880,6 +3414,12 @@ func (p *RemoveVpnUserParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *RemoveVpnUserParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *RemoveVpnUserParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2893,6 +3433,12 @@ func (p *RemoveVpnUserParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *RemoveVpnUserParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *RemoveVpnUserParams) GetDomainid() (string, bool) {
@@ -2910,6 +3456,12 @@ func (p *RemoveVpnUserParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *RemoveVpnUserParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *RemoveVpnUserParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2923,6 +3475,12 @@ func (p *RemoveVpnUserParams) SetUsername(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["username"] = v
+}
+
+func (p *RemoveVpnUserParams) ResetUsername() {
+	if p.p != nil && p.p["username"] != nil {
+		delete(p.p, "username")
+	}
 }
 
 func (p *RemoveVpnUserParams) GetUsername() (string, bool) {
@@ -3007,6 +3565,12 @@ func (p *ResetVpnConnectionParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ResetVpnConnectionParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ResetVpnConnectionParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3022,6 +3586,12 @@ func (p *ResetVpnConnectionParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ResetVpnConnectionParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ResetVpnConnectionParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3035,6 +3605,12 @@ func (p *ResetVpnConnectionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ResetVpnConnectionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ResetVpnConnectionParams) GetId() (string, bool) {
@@ -3148,6 +3724,12 @@ func (p *UpdateRemoteAccessVpnParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateRemoteAccessVpnParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateRemoteAccessVpnParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3163,6 +3745,12 @@ func (p *UpdateRemoteAccessVpnParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateRemoteAccessVpnParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateRemoteAccessVpnParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3176,6 +3764,12 @@ func (p *UpdateRemoteAccessVpnParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateRemoteAccessVpnParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateRemoteAccessVpnParams) GetId() (string, bool) {
@@ -3276,6 +3870,12 @@ func (p *UpdateVpnConnectionParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateVpnConnectionParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateVpnConnectionParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3291,6 +3891,12 @@ func (p *UpdateVpnConnectionParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateVpnConnectionParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateVpnConnectionParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3304,6 +3910,12 @@ func (p *UpdateVpnConnectionParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateVpnConnectionParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateVpnConnectionParams) GetId() (string, bool) {
@@ -3457,6 +4069,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3470,6 +4088,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetCidrlist(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["cidrlist"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetCidrlist() {
+	if p.p != nil && p.p["cidrlist"] != nil {
+		delete(p.p, "cidrlist")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetCidrlist() (string, bool) {
@@ -3487,6 +4111,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3500,6 +4130,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetDpd(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dpd"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetDpd() {
+	if p.p != nil && p.p["dpd"] != nil {
+		delete(p.p, "dpd")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetDpd() (bool, bool) {
@@ -3517,6 +4153,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetEsplifetime(v int64) {
 	p.p["esplifetime"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetEsplifetime() {
+	if p.p != nil && p.p["esplifetime"] != nil {
+		delete(p.p, "esplifetime")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetEsplifetime() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3530,6 +4172,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetEsppolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["esppolicy"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetEsppolicy() {
+	if p.p != nil && p.p["esppolicy"] != nil {
+		delete(p.p, "esppolicy")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetEsppolicy() (string, bool) {
@@ -3547,6 +4195,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetForceencap(v bool) {
 	p.p["forceencap"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetForceencap() {
+	if p.p != nil && p.p["forceencap"] != nil {
+		delete(p.p, "forceencap")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetForceencap() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3560,6 +4214,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetGateway(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["gateway"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetGateway() {
+	if p.p != nil && p.p["gateway"] != nil {
+		delete(p.p, "gateway")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetGateway() (string, bool) {
@@ -3577,6 +4237,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3590,6 +4256,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetIkelifetime(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikelifetime"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetIkelifetime() {
+	if p.p != nil && p.p["ikelifetime"] != nil {
+		delete(p.p, "ikelifetime")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetIkelifetime() (int64, bool) {
@@ -3607,6 +4279,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetIkepolicy(v string) {
 	p.p["ikepolicy"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetIkepolicy() {
+	if p.p != nil && p.p["ikepolicy"] != nil {
+		delete(p.p, "ikepolicy")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetIkepolicy() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3620,6 +4298,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetIkeversion(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ikeversion"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetIkeversion() {
+	if p.p != nil && p.p["ikeversion"] != nil {
+		delete(p.p, "ikeversion")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetIkeversion() (string, bool) {
@@ -3637,6 +4321,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetIpsecpsk(v string) {
 	p.p["ipsecpsk"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetIpsecpsk() {
+	if p.p != nil && p.p["ipsecpsk"] != nil {
+		delete(p.p, "ipsecpsk")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetIpsecpsk() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3652,6 +4342,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateVpnCustomerGatewayParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateVpnCustomerGatewayParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3665,6 +4361,12 @@ func (p *UpdateVpnCustomerGatewayParams) SetSplitconnections(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["splitconnections"] = v
+}
+
+func (p *UpdateVpnCustomerGatewayParams) ResetSplitconnections() {
+	if p.p != nil && p.p["splitconnections"] != nil {
+		delete(p.p, "splitconnections")
+	}
 }
 
 func (p *UpdateVpnCustomerGatewayParams) GetSplitconnections() (bool, bool) {
@@ -3779,6 +4481,12 @@ func (p *UpdateVpnGatewayParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *UpdateVpnGatewayParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *UpdateVpnGatewayParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3794,6 +4502,12 @@ func (p *UpdateVpnGatewayParams) SetFordisplay(v bool) {
 	p.p["fordisplay"] = v
 }
 
+func (p *UpdateVpnGatewayParams) ResetFordisplay() {
+	if p.p != nil && p.p["fordisplay"] != nil {
+		delete(p.p, "fordisplay")
+	}
+}
+
 func (p *UpdateVpnGatewayParams) GetFordisplay() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3807,6 +4521,12 @@ func (p *UpdateVpnGatewayParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateVpnGatewayParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateVpnGatewayParams) GetId() (string, bool) {

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -123,6 +123,12 @@ func (p *AddNicToVirtualMachineParams) SetDhcpoptions(v map[string]string) {
 	p.p["dhcpoptions"] = v
 }
 
+func (p *AddNicToVirtualMachineParams) ResetDhcpoptions() {
+	if p.p != nil && p.p["dhcpoptions"] != nil {
+		delete(p.p, "dhcpoptions")
+	}
+}
+
 func (p *AddNicToVirtualMachineParams) GetDhcpoptions() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -136,6 +142,12 @@ func (p *AddNicToVirtualMachineParams) SetIpaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ipaddress"] = v
+}
+
+func (p *AddNicToVirtualMachineParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
 }
 
 func (p *AddNicToVirtualMachineParams) GetIpaddress() (string, bool) {
@@ -153,6 +165,12 @@ func (p *AddNicToVirtualMachineParams) SetMacaddress(v string) {
 	p.p["macaddress"] = v
 }
 
+func (p *AddNicToVirtualMachineParams) ResetMacaddress() {
+	if p.p != nil && p.p["macaddress"] != nil {
+		delete(p.p, "macaddress")
+	}
+}
+
 func (p *AddNicToVirtualMachineParams) GetMacaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -168,6 +186,12 @@ func (p *AddNicToVirtualMachineParams) SetNetworkid(v string) {
 	p.p["networkid"] = v
 }
 
+func (p *AddNicToVirtualMachineParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
+}
+
 func (p *AddNicToVirtualMachineParams) GetNetworkid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -181,6 +205,12 @@ func (p *AddNicToVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *AddNicToVirtualMachineParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *AddNicToVirtualMachineParams) GetVirtualmachineid() (string, bool) {
@@ -435,6 +465,12 @@ func (p *AssignVirtualMachineParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *AssignVirtualMachineParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *AssignVirtualMachineParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -448,6 +484,12 @@ func (p *AssignVirtualMachineParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *AssignVirtualMachineParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *AssignVirtualMachineParams) GetDomainid() (string, bool) {
@@ -465,6 +507,12 @@ func (p *AssignVirtualMachineParams) SetNetworkids(v []string) {
 	p.p["networkids"] = v
 }
 
+func (p *AssignVirtualMachineParams) ResetNetworkids() {
+	if p.p != nil && p.p["networkids"] != nil {
+		delete(p.p, "networkids")
+	}
+}
+
 func (p *AssignVirtualMachineParams) GetNetworkids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -478,6 +526,12 @@ func (p *AssignVirtualMachineParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *AssignVirtualMachineParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *AssignVirtualMachineParams) GetProjectid() (string, bool) {
@@ -495,6 +549,12 @@ func (p *AssignVirtualMachineParams) SetSecuritygroupids(v []string) {
 	p.p["securitygroupids"] = v
 }
 
+func (p *AssignVirtualMachineParams) ResetSecuritygroupids() {
+	if p.p != nil && p.p["securitygroupids"] != nil {
+		delete(p.p, "securitygroupids")
+	}
+}
+
 func (p *AssignVirtualMachineParams) GetSecuritygroupids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -508,6 +568,12 @@ func (p *AssignVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *AssignVirtualMachineParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *AssignVirtualMachineParams) GetVirtualmachineid() (string, bool) {
@@ -749,6 +815,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetAutomigrate(v bool) {
 	p.p["automigrate"] = v
 }
 
+func (p *ChangeServiceForVirtualMachineParams) ResetAutomigrate() {
+	if p.p != nil && p.p["automigrate"] != nil {
+		delete(p.p, "automigrate")
+	}
+}
+
 func (p *ChangeServiceForVirtualMachineParams) GetAutomigrate() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -762,6 +834,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ChangeServiceForVirtualMachineParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ChangeServiceForVirtualMachineParams) GetDetails() (map[string]string, bool) {
@@ -779,6 +857,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ChangeServiceForVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ChangeServiceForVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -792,6 +876,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
+}
+
+func (p *ChangeServiceForVirtualMachineParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
 }
 
 func (p *ChangeServiceForVirtualMachineParams) GetMaxiops() (int64, bool) {
@@ -809,6 +899,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetMiniops(v int64) {
 	p.p["miniops"] = v
 }
 
+func (p *ChangeServiceForVirtualMachineParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
+}
+
 func (p *ChangeServiceForVirtualMachineParams) GetMiniops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -824,6 +920,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *ChangeServiceForVirtualMachineParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *ChangeServiceForVirtualMachineParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -837,6 +939,12 @@ func (p *ChangeServiceForVirtualMachineParams) SetShrinkok(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["shrinkok"] = v
+}
+
+func (p *ChangeServiceForVirtualMachineParams) ResetShrinkok() {
+	if p.p != nil && p.p["shrinkok"] != nil {
+		delete(p.p, "shrinkok")
+	}
 }
 
 func (p *ChangeServiceForVirtualMachineParams) GetShrinkok() (bool, bool) {
@@ -1310,6 +1418,12 @@ func (p *DeployVirtualMachineParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1323,6 +1437,12 @@ func (p *DeployVirtualMachineParams) SetAffinitygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupids"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetAffinitygroupids() {
+	if p.p != nil && p.p["affinitygroupids"] != nil {
+		delete(p.p, "affinitygroupids")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetAffinitygroupids() ([]string, bool) {
@@ -1340,6 +1460,12 @@ func (p *DeployVirtualMachineParams) SetAffinitygroupnames(v []string) {
 	p.p["affinitygroupnames"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetAffinitygroupnames() {
+	if p.p != nil && p.p["affinitygroupnames"] != nil {
+		delete(p.p, "affinitygroupnames")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetAffinitygroupnames() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1353,6 +1479,12 @@ func (p *DeployVirtualMachineParams) SetBootintosetup(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["bootintosetup"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetBootintosetup() {
+	if p.p != nil && p.p["bootintosetup"] != nil {
+		delete(p.p, "bootintosetup")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetBootintosetup() (bool, bool) {
@@ -1370,6 +1502,12 @@ func (p *DeployVirtualMachineParams) SetBootmode(v string) {
 	p.p["bootmode"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetBootmode() {
+	if p.p != nil && p.p["bootmode"] != nil {
+		delete(p.p, "bootmode")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetBootmode() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1383,6 +1521,12 @@ func (p *DeployVirtualMachineParams) SetBoottype(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["boottype"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetBoottype() {
+	if p.p != nil && p.p["boottype"] != nil {
+		delete(p.p, "boottype")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetBoottype() (string, bool) {
@@ -1400,6 +1544,12 @@ func (p *DeployVirtualMachineParams) SetClusterid(v string) {
 	p.p["clusterid"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetClusterid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1413,6 +1563,12 @@ func (p *DeployVirtualMachineParams) SetCopyimagetags(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["copyimagetags"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetCopyimagetags() {
+	if p.p != nil && p.p["copyimagetags"] != nil {
+		delete(p.p, "copyimagetags")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetCopyimagetags() (bool, bool) {
@@ -1430,6 +1586,12 @@ func (p *DeployVirtualMachineParams) SetCustomid(v string) {
 	p.p["customid"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetCustomid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1443,6 +1605,12 @@ func (p *DeployVirtualMachineParams) SetDatadiskofferinglist(v map[string]string
 		p.p = make(map[string]interface{})
 	}
 	p.p["datadiskofferinglist"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetDatadiskofferinglist() {
+	if p.p != nil && p.p["datadiskofferinglist"] != nil {
+		delete(p.p, "datadiskofferinglist")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetDatadiskofferinglist() (map[string]string, bool) {
@@ -1460,6 +1628,12 @@ func (p *DeployVirtualMachineParams) SetDeploymentplanner(v string) {
 	p.p["deploymentplanner"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetDeploymentplanner() {
+	if p.p != nil && p.p["deploymentplanner"] != nil {
+		delete(p.p, "deploymentplanner")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetDeploymentplanner() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1475,6 +1649,12 @@ func (p *DeployVirtualMachineParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1488,6 +1668,12 @@ func (p *DeployVirtualMachineParams) SetDhcpoptionsnetworklist(v []map[string]st
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpoptionsnetworklist"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetDhcpoptionsnetworklist() {
+	if p.p != nil && p.p["dhcpoptionsnetworklist"] != nil {
+		delete(p.p, "dhcpoptionsnetworklist")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetDhcpoptionsnetworklist() ([]map[string]string, bool) {
@@ -1519,6 +1705,12 @@ func (p *DeployVirtualMachineParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1532,6 +1724,12 @@ func (p *DeployVirtualMachineParams) SetDisplayname(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayname"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetDisplayname() {
+	if p.p != nil && p.p["displayname"] != nil {
+		delete(p.p, "displayname")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetDisplayname() (string, bool) {
@@ -1549,6 +1747,12 @@ func (p *DeployVirtualMachineParams) SetDisplayvm(v bool) {
 	p.p["displayvm"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetDisplayvm() {
+	if p.p != nil && p.p["displayvm"] != nil {
+		delete(p.p, "displayvm")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetDisplayvm() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1562,6 +1766,12 @@ func (p *DeployVirtualMachineParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetDomainid() (string, bool) {
@@ -1579,6 +1789,12 @@ func (p *DeployVirtualMachineParams) SetDynamicscalingenabled(v bool) {
 	p.p["dynamicscalingenabled"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetDynamicscalingenabled() {
+	if p.p != nil && p.p["dynamicscalingenabled"] != nil {
+		delete(p.p, "dynamicscalingenabled")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetDynamicscalingenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1592,6 +1808,12 @@ func (p *DeployVirtualMachineParams) SetExtraconfig(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["extraconfig"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetExtraconfig() {
+	if p.p != nil && p.p["extraconfig"] != nil {
+		delete(p.p, "extraconfig")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetExtraconfig() (string, bool) {
@@ -1609,6 +1831,12 @@ func (p *DeployVirtualMachineParams) SetGroup(v string) {
 	p.p["group"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetGroup() {
+	if p.p != nil && p.p["group"] != nil {
+		delete(p.p, "group")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetGroup() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1622,6 +1850,12 @@ func (p *DeployVirtualMachineParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetHostid() (string, bool) {
@@ -1639,6 +1873,12 @@ func (p *DeployVirtualMachineParams) SetHypervisor(v string) {
 	p.p["hypervisor"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetHypervisor() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1652,6 +1892,12 @@ func (p *DeployVirtualMachineParams) SetIodriverpolicy(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iodriverpolicy"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetIodriverpolicy() {
+	if p.p != nil && p.p["iodriverpolicy"] != nil {
+		delete(p.p, "iodriverpolicy")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetIodriverpolicy() (string, bool) {
@@ -1669,6 +1915,12 @@ func (p *DeployVirtualMachineParams) SetIothreadsenabled(v bool) {
 	p.p["iothreadsenabled"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetIothreadsenabled() {
+	if p.p != nil && p.p["iothreadsenabled"] != nil {
+		delete(p.p, "iothreadsenabled")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetIothreadsenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1682,6 +1934,12 @@ func (p *DeployVirtualMachineParams) SetIp6address(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6address"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetIp6address() {
+	if p.p != nil && p.p["ip6address"] != nil {
+		delete(p.p, "ip6address")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetIp6address() (string, bool) {
@@ -1699,6 +1957,12 @@ func (p *DeployVirtualMachineParams) SetIpaddress(v string) {
 	p.p["ipaddress"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetIpaddress() {
+	if p.p != nil && p.p["ipaddress"] != nil {
+		delete(p.p, "ipaddress")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetIpaddress() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1712,6 +1976,12 @@ func (p *DeployVirtualMachineParams) SetIptonetworklist(v []map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["iptonetworklist"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetIptonetworklist() {
+	if p.p != nil && p.p["iptonetworklist"] != nil {
+		delete(p.p, "iptonetworklist")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetIptonetworklist() ([]map[string]string, bool) {
@@ -1743,6 +2013,12 @@ func (p *DeployVirtualMachineParams) SetKeyboard(v string) {
 	p.p["keyboard"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetKeyboard() {
+	if p.p != nil && p.p["keyboard"] != nil {
+		delete(p.p, "keyboard")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetKeyboard() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1756,6 +2032,12 @@ func (p *DeployVirtualMachineParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetKeypair() {
+	if p.p != nil && p.p["keypair"] != nil {
+		delete(p.p, "keypair")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetKeypair() (string, bool) {
@@ -1773,6 +2055,12 @@ func (p *DeployVirtualMachineParams) SetKeypairs(v []string) {
 	p.p["keypairs"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetKeypairs() {
+	if p.p != nil && p.p["keypairs"] != nil {
+		delete(p.p, "keypairs")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetKeypairs() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1786,6 +2074,12 @@ func (p *DeployVirtualMachineParams) SetMacaddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["macaddress"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetMacaddress() {
+	if p.p != nil && p.p["macaddress"] != nil {
+		delete(p.p, "macaddress")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetMacaddress() (string, bool) {
@@ -1803,6 +2097,12 @@ func (p *DeployVirtualMachineParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1816,6 +2116,12 @@ func (p *DeployVirtualMachineParams) SetNetworkids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkids"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetNetworkids() {
+	if p.p != nil && p.p["networkids"] != nil {
+		delete(p.p, "networkids")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetNetworkids() ([]string, bool) {
@@ -1833,6 +2139,12 @@ func (p *DeployVirtualMachineParams) SetNicmultiqueuenumber(v int) {
 	p.p["nicmultiqueuenumber"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetNicmultiqueuenumber() {
+	if p.p != nil && p.p["nicmultiqueuenumber"] != nil {
+		delete(p.p, "nicmultiqueuenumber")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetNicmultiqueuenumber() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1846,6 +2158,12 @@ func (p *DeployVirtualMachineParams) SetNicnetworklist(v []map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["nicnetworklist"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetNicnetworklist() {
+	if p.p != nil && p.p["nicnetworklist"] != nil {
+		delete(p.p, "nicnetworklist")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetNicnetworklist() ([]map[string]string, bool) {
@@ -1877,6 +2195,12 @@ func (p *DeployVirtualMachineParams) SetNicpackedvirtqueuesenabled(v bool) {
 	p.p["nicpackedvirtqueuesenabled"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetNicpackedvirtqueuesenabled() {
+	if p.p != nil && p.p["nicpackedvirtqueuesenabled"] != nil {
+		delete(p.p, "nicpackedvirtqueuesenabled")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetNicpackedvirtqueuesenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1890,6 +2214,12 @@ func (p *DeployVirtualMachineParams) SetOverridediskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["overridediskofferingid"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetOverridediskofferingid() {
+	if p.p != nil && p.p["overridediskofferingid"] != nil {
+		delete(p.p, "overridediskofferingid")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetOverridediskofferingid() (string, bool) {
@@ -1907,6 +2237,12 @@ func (p *DeployVirtualMachineParams) SetPassword(v string) {
 	p.p["password"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetPassword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1920,6 +2256,12 @@ func (p *DeployVirtualMachineParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetPodid() (string, bool) {
@@ -1937,6 +2279,12 @@ func (p *DeployVirtualMachineParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1950,6 +2298,12 @@ func (p *DeployVirtualMachineParams) SetProperties(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["properties"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetProperties() {
+	if p.p != nil && p.p["properties"] != nil {
+		delete(p.p, "properties")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetProperties() (map[string]string, bool) {
@@ -1967,6 +2321,12 @@ func (p *DeployVirtualMachineParams) SetRootdisksize(v int64) {
 	p.p["rootdisksize"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetRootdisksize() {
+	if p.p != nil && p.p["rootdisksize"] != nil {
+		delete(p.p, "rootdisksize")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetRootdisksize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1980,6 +2340,12 @@ func (p *DeployVirtualMachineParams) SetSecuritygroupids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupids"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetSecuritygroupids() {
+	if p.p != nil && p.p["securitygroupids"] != nil {
+		delete(p.p, "securitygroupids")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetSecuritygroupids() ([]string, bool) {
@@ -1997,6 +2363,12 @@ func (p *DeployVirtualMachineParams) SetSecuritygroupnames(v []string) {
 	p.p["securitygroupnames"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetSecuritygroupnames() {
+	if p.p != nil && p.p["securitygroupnames"] != nil {
+		delete(p.p, "securitygroupnames")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetSecuritygroupnames() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2010,6 +2382,12 @@ func (p *DeployVirtualMachineParams) SetServiceofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["serviceofferingid"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetServiceofferingid() (string, bool) {
@@ -2027,6 +2405,12 @@ func (p *DeployVirtualMachineParams) SetSize(v int64) {
 	p.p["size"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetSize() {
+	if p.p != nil && p.p["size"] != nil {
+		delete(p.p, "size")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetSize() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2040,6 +2424,12 @@ func (p *DeployVirtualMachineParams) SetStartvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startvm"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetStartvm() {
+	if p.p != nil && p.p["startvm"] != nil {
+		delete(p.p, "startvm")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetStartvm() (bool, bool) {
@@ -2057,6 +2447,12 @@ func (p *DeployVirtualMachineParams) SetTemplateid(v string) {
 	p.p["templateid"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetTemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2070,6 +2466,12 @@ func (p *DeployVirtualMachineParams) SetUserdata(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdata"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetUserdata() {
+	if p.p != nil && p.p["userdata"] != nil {
+		delete(p.p, "userdata")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetUserdata() (string, bool) {
@@ -2087,6 +2489,12 @@ func (p *DeployVirtualMachineParams) SetUserdatadetails(v map[string]string) {
 	p.p["userdatadetails"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetUserdatadetails() {
+	if p.p != nil && p.p["userdatadetails"] != nil {
+		delete(p.p, "userdatadetails")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetUserdatadetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2102,6 +2510,12 @@ func (p *DeployVirtualMachineParams) SetUserdataid(v string) {
 	p.p["userdataid"] = v
 }
 
+func (p *DeployVirtualMachineParams) ResetUserdataid() {
+	if p.p != nil && p.p["userdataid"] != nil {
+		delete(p.p, "userdataid")
+	}
+}
+
 func (p *DeployVirtualMachineParams) GetUserdataid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2115,6 +2529,12 @@ func (p *DeployVirtualMachineParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *DeployVirtualMachineParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *DeployVirtualMachineParams) GetZoneid() (string, bool) {
@@ -2361,6 +2781,12 @@ func (p *DestroyVirtualMachineParams) SetExpunge(v bool) {
 	p.p["expunge"] = v
 }
 
+func (p *DestroyVirtualMachineParams) ResetExpunge() {
+	if p.p != nil && p.p["expunge"] != nil {
+		delete(p.p, "expunge")
+	}
+}
+
 func (p *DestroyVirtualMachineParams) GetExpunge() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2376,6 +2802,12 @@ func (p *DestroyVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DestroyVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DestroyVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2389,6 +2821,12 @@ func (p *DestroyVirtualMachineParams) SetVolumeids(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeids"] = v
+}
+
+func (p *DestroyVirtualMachineParams) ResetVolumeids() {
+	if p.p != nil && p.p["volumeids"] != nil {
+		delete(p.p, "volumeids")
+	}
 }
 
 func (p *DestroyVirtualMachineParams) GetVolumeids() ([]string, bool) {
@@ -2625,6 +3063,12 @@ func (p *ExpungeVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ExpungeVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ExpungeVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2699,6 +3143,12 @@ func (p *GetVMPasswordParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *GetVMPasswordParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *GetVMPasswordParams) GetId() (string, bool) {
@@ -2896,6 +3346,12 @@ func (p *ListVirtualMachinesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2909,6 +3365,12 @@ func (p *ListVirtualMachinesParams) SetAccumulate(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accumulate"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetAccumulate() {
+	if p.p != nil && p.p["accumulate"] != nil {
+		delete(p.p, "accumulate")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetAccumulate() (bool, bool) {
@@ -2926,6 +3388,12 @@ func (p *ListVirtualMachinesParams) SetAffinitygroupid(v string) {
 	p.p["affinitygroupid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetAffinitygroupid() {
+	if p.p != nil && p.p["affinitygroupid"] != nil {
+		delete(p.p, "affinitygroupid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetAffinitygroupid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2939,6 +3407,12 @@ func (p *ListVirtualMachinesParams) SetAutoscalevmgroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["autoscalevmgroupid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetAutoscalevmgroupid() {
+	if p.p != nil && p.p["autoscalevmgroupid"] != nil {
+		delete(p.p, "autoscalevmgroupid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetAutoscalevmgroupid() (string, bool) {
@@ -2956,6 +3430,12 @@ func (p *ListVirtualMachinesParams) SetBackupofferingid(v string) {
 	p.p["backupofferingid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetBackupofferingid() {
+	if p.p != nil && p.p["backupofferingid"] != nil {
+		delete(p.p, "backupofferingid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetBackupofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2969,6 +3449,12 @@ func (p *ListVirtualMachinesParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetClusterid() (string, bool) {
@@ -2986,6 +3472,12 @@ func (p *ListVirtualMachinesParams) SetDetails(v []string) {
 	p.p["details"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetDetails() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2999,6 +3491,12 @@ func (p *ListVirtualMachinesParams) SetDisplayvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvm"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetDisplayvm() {
+	if p.p != nil && p.p["displayvm"] != nil {
+		delete(p.p, "displayvm")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetDisplayvm() (bool, bool) {
@@ -3016,6 +3514,12 @@ func (p *ListVirtualMachinesParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3029,6 +3533,12 @@ func (p *ListVirtualMachinesParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetForvirtualnetwork() {
+	if p.p != nil && p.p["forvirtualnetwork"] != nil {
+		delete(p.p, "forvirtualnetwork")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetForvirtualnetwork() (bool, bool) {
@@ -3046,6 +3556,12 @@ func (p *ListVirtualMachinesParams) SetGroupid(v string) {
 	p.p["groupid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetGroupid() {
+	if p.p != nil && p.p["groupid"] != nil {
+		delete(p.p, "groupid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetGroupid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3059,6 +3575,12 @@ func (p *ListVirtualMachinesParams) SetHaenable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["haenable"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetHaenable() {
+	if p.p != nil && p.p["haenable"] != nil {
+		delete(p.p, "haenable")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetHaenable() (bool, bool) {
@@ -3076,6 +3598,12 @@ func (p *ListVirtualMachinesParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3089,6 +3617,12 @@ func (p *ListVirtualMachinesParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetHypervisor() (string, bool) {
@@ -3106,6 +3640,12 @@ func (p *ListVirtualMachinesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3119,6 +3659,12 @@ func (p *ListVirtualMachinesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetIds() ([]string, bool) {
@@ -3136,6 +3682,12 @@ func (p *ListVirtualMachinesParams) SetIsoid(v string) {
 	p.p["isoid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetIsoid() {
+	if p.p != nil && p.p["isoid"] != nil {
+		delete(p.p, "isoid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetIsoid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3149,6 +3701,12 @@ func (p *ListVirtualMachinesParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetIsrecursive() (bool, bool) {
@@ -3166,6 +3724,12 @@ func (p *ListVirtualMachinesParams) SetIsvnf(v bool) {
 	p.p["isvnf"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetIsvnf() {
+	if p.p != nil && p.p["isvnf"] != nil {
+		delete(p.p, "isvnf")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetIsvnf() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3179,6 +3743,12 @@ func (p *ListVirtualMachinesParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetKeypair() {
+	if p.p != nil && p.p["keypair"] != nil {
+		delete(p.p, "keypair")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetKeypair() (string, bool) {
@@ -3196,6 +3766,12 @@ func (p *ListVirtualMachinesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3209,6 +3785,12 @@ func (p *ListVirtualMachinesParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetListall() (bool, bool) {
@@ -3226,6 +3808,12 @@ func (p *ListVirtualMachinesParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3239,6 +3827,12 @@ func (p *ListVirtualMachinesParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetNetworkid() (string, bool) {
@@ -3256,6 +3850,12 @@ func (p *ListVirtualMachinesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3269,6 +3869,12 @@ func (p *ListVirtualMachinesParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetPagesize() (int, bool) {
@@ -3286,6 +3892,12 @@ func (p *ListVirtualMachinesParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3299,6 +3911,12 @@ func (p *ListVirtualMachinesParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetProjectid() (string, bool) {
@@ -3316,6 +3934,12 @@ func (p *ListVirtualMachinesParams) SetRetrieveonlyresourcecount(v bool) {
 	p.p["retrieveonlyresourcecount"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetRetrieveonlyresourcecount() {
+	if p.p != nil && p.p["retrieveonlyresourcecount"] != nil {
+		delete(p.p, "retrieveonlyresourcecount")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetRetrieveonlyresourcecount() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3329,6 +3953,12 @@ func (p *ListVirtualMachinesParams) SetSecuritygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetSecuritygroupid() {
+	if p.p != nil && p.p["securitygroupid"] != nil {
+		delete(p.p, "securitygroupid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetSecuritygroupid() (string, bool) {
@@ -3346,6 +3976,12 @@ func (p *ListVirtualMachinesParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3359,6 +3995,12 @@ func (p *ListVirtualMachinesParams) SetShowicon(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showicon"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetShowicon() (bool, bool) {
@@ -3376,6 +4018,12 @@ func (p *ListVirtualMachinesParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3389,6 +4037,12 @@ func (p *ListVirtualMachinesParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetStorageid() (string, bool) {
@@ -3406,6 +4060,12 @@ func (p *ListVirtualMachinesParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3419,6 +4079,12 @@ func (p *ListVirtualMachinesParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetTemplateid() (string, bool) {
@@ -3436,6 +4102,12 @@ func (p *ListVirtualMachinesParams) SetUserdata(v bool) {
 	p.p["userdata"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetUserdata() {
+	if p.p != nil && p.p["userdata"] != nil {
+		delete(p.p, "userdata")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetUserdata() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3449,6 +4121,12 @@ func (p *ListVirtualMachinesParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetUserid() (string, bool) {
@@ -3466,6 +4144,12 @@ func (p *ListVirtualMachinesParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *ListVirtualMachinesParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *ListVirtualMachinesParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3479,6 +4163,12 @@ func (p *ListVirtualMachinesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVirtualMachinesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVirtualMachinesParams) GetZoneid() (string, bool) {
@@ -3917,6 +4607,12 @@ func (p *ListVirtualMachinesMetricsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3930,6 +4626,12 @@ func (p *ListVirtualMachinesMetricsParams) SetAccumulate(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["accumulate"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetAccumulate() {
+	if p.p != nil && p.p["accumulate"] != nil {
+		delete(p.p, "accumulate")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetAccumulate() (bool, bool) {
@@ -3947,6 +4649,12 @@ func (p *ListVirtualMachinesMetricsParams) SetAffinitygroupid(v string) {
 	p.p["affinitygroupid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetAffinitygroupid() {
+	if p.p != nil && p.p["affinitygroupid"] != nil {
+		delete(p.p, "affinitygroupid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetAffinitygroupid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3960,6 +4668,12 @@ func (p *ListVirtualMachinesMetricsParams) SetAutoscalevmgroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["autoscalevmgroupid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetAutoscalevmgroupid() {
+	if p.p != nil && p.p["autoscalevmgroupid"] != nil {
+		delete(p.p, "autoscalevmgroupid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetAutoscalevmgroupid() (string, bool) {
@@ -3977,6 +4691,12 @@ func (p *ListVirtualMachinesMetricsParams) SetBackupofferingid(v string) {
 	p.p["backupofferingid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetBackupofferingid() {
+	if p.p != nil && p.p["backupofferingid"] != nil {
+		delete(p.p, "backupofferingid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetBackupofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3990,6 +4710,12 @@ func (p *ListVirtualMachinesMetricsParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetClusterid() (string, bool) {
@@ -4007,6 +4733,12 @@ func (p *ListVirtualMachinesMetricsParams) SetDetails(v []string) {
 	p.p["details"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetDetails() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4020,6 +4752,12 @@ func (p *ListVirtualMachinesMetricsParams) SetDisplayvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvm"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetDisplayvm() {
+	if p.p != nil && p.p["displayvm"] != nil {
+		delete(p.p, "displayvm")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetDisplayvm() (bool, bool) {
@@ -4037,6 +4775,12 @@ func (p *ListVirtualMachinesMetricsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4050,6 +4794,12 @@ func (p *ListVirtualMachinesMetricsParams) SetForvirtualnetwork(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["forvirtualnetwork"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetForvirtualnetwork() {
+	if p.p != nil && p.p["forvirtualnetwork"] != nil {
+		delete(p.p, "forvirtualnetwork")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetForvirtualnetwork() (bool, bool) {
@@ -4067,6 +4817,12 @@ func (p *ListVirtualMachinesMetricsParams) SetGroupid(v string) {
 	p.p["groupid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetGroupid() {
+	if p.p != nil && p.p["groupid"] != nil {
+		delete(p.p, "groupid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetGroupid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4080,6 +4836,12 @@ func (p *ListVirtualMachinesMetricsParams) SetHaenable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["haenable"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetHaenable() {
+	if p.p != nil && p.p["haenable"] != nil {
+		delete(p.p, "haenable")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetHaenable() (bool, bool) {
@@ -4097,6 +4859,12 @@ func (p *ListVirtualMachinesMetricsParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4110,6 +4878,12 @@ func (p *ListVirtualMachinesMetricsParams) SetHypervisor(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hypervisor"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetHypervisor() {
+	if p.p != nil && p.p["hypervisor"] != nil {
+		delete(p.p, "hypervisor")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetHypervisor() (string, bool) {
@@ -4127,6 +4901,12 @@ func (p *ListVirtualMachinesMetricsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4140,6 +4920,12 @@ func (p *ListVirtualMachinesMetricsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetIds() ([]string, bool) {
@@ -4157,6 +4943,12 @@ func (p *ListVirtualMachinesMetricsParams) SetIsoid(v string) {
 	p.p["isoid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetIsoid() {
+	if p.p != nil && p.p["isoid"] != nil {
+		delete(p.p, "isoid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetIsoid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4170,6 +4962,12 @@ func (p *ListVirtualMachinesMetricsParams) SetIsrecursive(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isrecursive"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetIsrecursive() (bool, bool) {
@@ -4187,6 +4985,12 @@ func (p *ListVirtualMachinesMetricsParams) SetIsvnf(v bool) {
 	p.p["isvnf"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetIsvnf() {
+	if p.p != nil && p.p["isvnf"] != nil {
+		delete(p.p, "isvnf")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetIsvnf() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4200,6 +5004,12 @@ func (p *ListVirtualMachinesMetricsParams) SetKeypair(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keypair"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetKeypair() {
+	if p.p != nil && p.p["keypair"] != nil {
+		delete(p.p, "keypair")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetKeypair() (string, bool) {
@@ -4217,6 +5027,12 @@ func (p *ListVirtualMachinesMetricsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4230,6 +5046,12 @@ func (p *ListVirtualMachinesMetricsParams) SetListall(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listall"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetListall() (bool, bool) {
@@ -4247,6 +5069,12 @@ func (p *ListVirtualMachinesMetricsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4260,6 +5088,12 @@ func (p *ListVirtualMachinesMetricsParams) SetNetworkid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["networkid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetNetworkid() {
+	if p.p != nil && p.p["networkid"] != nil {
+		delete(p.p, "networkid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetNetworkid() (string, bool) {
@@ -4277,6 +5111,12 @@ func (p *ListVirtualMachinesMetricsParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4290,6 +5130,12 @@ func (p *ListVirtualMachinesMetricsParams) SetPagesize(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["pagesize"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetPagesize() (int, bool) {
@@ -4307,6 +5153,12 @@ func (p *ListVirtualMachinesMetricsParams) SetPodid(v string) {
 	p.p["podid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetPodid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4320,6 +5172,12 @@ func (p *ListVirtualMachinesMetricsParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetProjectid() (string, bool) {
@@ -4337,6 +5195,12 @@ func (p *ListVirtualMachinesMetricsParams) SetRetrieveonlyresourcecount(v bool) 
 	p.p["retrieveonlyresourcecount"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetRetrieveonlyresourcecount() {
+	if p.p != nil && p.p["retrieveonlyresourcecount"] != nil {
+		delete(p.p, "retrieveonlyresourcecount")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetRetrieveonlyresourcecount() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4350,6 +5214,12 @@ func (p *ListVirtualMachinesMetricsParams) SetSecuritygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetSecuritygroupid() {
+	if p.p != nil && p.p["securitygroupid"] != nil {
+		delete(p.p, "securitygroupid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetSecuritygroupid() (string, bool) {
@@ -4367,6 +5237,12 @@ func (p *ListVirtualMachinesMetricsParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4380,6 +5256,12 @@ func (p *ListVirtualMachinesMetricsParams) SetShowicon(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showicon"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetShowicon() (bool, bool) {
@@ -4397,6 +5279,12 @@ func (p *ListVirtualMachinesMetricsParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4410,6 +5298,12 @@ func (p *ListVirtualMachinesMetricsParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetStorageid() (string, bool) {
@@ -4427,6 +5321,12 @@ func (p *ListVirtualMachinesMetricsParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4440,6 +5340,12 @@ func (p *ListVirtualMachinesMetricsParams) SetTemplateid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["templateid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetTemplateid() (string, bool) {
@@ -4457,6 +5363,12 @@ func (p *ListVirtualMachinesMetricsParams) SetUserdata(v bool) {
 	p.p["userdata"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetUserdata() {
+	if p.p != nil && p.p["userdata"] != nil {
+		delete(p.p, "userdata")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetUserdata() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4470,6 +5382,12 @@ func (p *ListVirtualMachinesMetricsParams) SetUserid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetUserid() {
+	if p.p != nil && p.p["userid"] != nil {
+		delete(p.p, "userid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetUserid() (string, bool) {
@@ -4487,6 +5405,12 @@ func (p *ListVirtualMachinesMetricsParams) SetVpcid(v string) {
 	p.p["vpcid"] = v
 }
 
+func (p *ListVirtualMachinesMetricsParams) ResetVpcid() {
+	if p.p != nil && p.p["vpcid"] != nil {
+		delete(p.p, "vpcid")
+	}
+}
+
 func (p *ListVirtualMachinesMetricsParams) GetVpcid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4500,6 +5424,12 @@ func (p *ListVirtualMachinesMetricsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVirtualMachinesMetricsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVirtualMachinesMetricsParams) GetZoneid() (string, bool) {
@@ -4821,6 +5751,12 @@ func (p *MigrateVirtualMachineParams) SetAutoselect(v bool) {
 	p.p["autoselect"] = v
 }
 
+func (p *MigrateVirtualMachineParams) ResetAutoselect() {
+	if p.p != nil && p.p["autoselect"] != nil {
+		delete(p.p, "autoselect")
+	}
+}
+
 func (p *MigrateVirtualMachineParams) GetAutoselect() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4834,6 +5770,12 @@ func (p *MigrateVirtualMachineParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *MigrateVirtualMachineParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *MigrateVirtualMachineParams) GetHostid() (string, bool) {
@@ -4851,6 +5793,12 @@ func (p *MigrateVirtualMachineParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *MigrateVirtualMachineParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *MigrateVirtualMachineParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4864,6 +5812,12 @@ func (p *MigrateVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *MigrateVirtualMachineParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *MigrateVirtualMachineParams) GetVirtualmachineid() (string, bool) {
@@ -5115,6 +6069,12 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetAutoselect(v bool) {
 	p.p["autoselect"] = v
 }
 
+func (p *MigrateVirtualMachineWithVolumeParams) ResetAutoselect() {
+	if p.p != nil && p.p["autoselect"] != nil {
+		delete(p.p, "autoselect")
+	}
+}
+
 func (p *MigrateVirtualMachineWithVolumeParams) GetAutoselect() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5130,6 +6090,12 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *MigrateVirtualMachineWithVolumeParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *MigrateVirtualMachineWithVolumeParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5143,6 +6109,12 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetMigrateto(v []map[string]stri
 		p.p = make(map[string]interface{})
 	}
 	p.p["migrateto"] = v
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) ResetMigrateto() {
+	if p.p != nil && p.p["migrateto"] != nil {
+		delete(p.p, "migrateto")
+	}
 }
 
 func (p *MigrateVirtualMachineWithVolumeParams) GetMigrateto() ([]map[string]string, bool) {
@@ -5172,6 +6144,12 @@ func (p *MigrateVirtualMachineWithVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *MigrateVirtualMachineWithVolumeParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *MigrateVirtualMachineWithVolumeParams) GetVirtualmachineid() (string, bool) {
@@ -5416,6 +6394,12 @@ func (p *RebootVirtualMachineParams) SetBootintosetup(v bool) {
 	p.p["bootintosetup"] = v
 }
 
+func (p *RebootVirtualMachineParams) ResetBootintosetup() {
+	if p.p != nil && p.p["bootintosetup"] != nil {
+		delete(p.p, "bootintosetup")
+	}
+}
+
 func (p *RebootVirtualMachineParams) GetBootintosetup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5431,6 +6415,12 @@ func (p *RebootVirtualMachineParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *RebootVirtualMachineParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *RebootVirtualMachineParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5444,6 +6434,12 @@ func (p *RebootVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *RebootVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *RebootVirtualMachineParams) GetId() (string, bool) {
@@ -5680,6 +6676,12 @@ func (p *RecoverVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RecoverVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RecoverVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5897,6 +6899,12 @@ func (p *RemoveNicFromVirtualMachineParams) SetNicid(v string) {
 	p.p["nicid"] = v
 }
 
+func (p *RemoveNicFromVirtualMachineParams) ResetNicid() {
+	if p.p != nil && p.p["nicid"] != nil {
+		delete(p.p, "nicid")
+	}
+}
+
 func (p *RemoveNicFromVirtualMachineParams) GetNicid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -5910,6 +6918,12 @@ func (p *RemoveNicFromVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *RemoveNicFromVirtualMachineParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *RemoveNicFromVirtualMachineParams) GetVirtualmachineid() (string, bool) {
@@ -6150,6 +7164,12 @@ func (p *ResetPasswordForVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ResetPasswordForVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ResetPasswordForVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6163,6 +7183,12 @@ func (p *ResetPasswordForVirtualMachineParams) SetPassword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["password"] = v
+}
+
+func (p *ResetPasswordForVirtualMachineParams) ResetPassword() {
+	if p.p != nil && p.p["password"] != nil {
+		delete(p.p, "password")
+	}
 }
 
 func (p *ResetPasswordForVirtualMachineParams) GetPassword() (string, bool) {
@@ -6402,6 +7428,12 @@ func (p *RestoreVirtualMachineParams) SetTemplateid(v string) {
 	p.p["templateid"] = v
 }
 
+func (p *RestoreVirtualMachineParams) ResetTemplateid() {
+	if p.p != nil && p.p["templateid"] != nil {
+		delete(p.p, "templateid")
+	}
+}
+
 func (p *RestoreVirtualMachineParams) GetTemplateid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6415,6 +7447,12 @@ func (p *RestoreVirtualMachineParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *RestoreVirtualMachineParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *RestoreVirtualMachineParams) GetVirtualmachineid() (string, bool) {
@@ -6676,6 +7714,12 @@ func (p *ScaleVirtualMachineParams) SetAutomigrate(v bool) {
 	p.p["automigrate"] = v
 }
 
+func (p *ScaleVirtualMachineParams) ResetAutomigrate() {
+	if p.p != nil && p.p["automigrate"] != nil {
+		delete(p.p, "automigrate")
+	}
+}
+
 func (p *ScaleVirtualMachineParams) GetAutomigrate() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6689,6 +7733,12 @@ func (p *ScaleVirtualMachineParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *ScaleVirtualMachineParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *ScaleVirtualMachineParams) GetDetails() (map[string]string, bool) {
@@ -6706,6 +7756,12 @@ func (p *ScaleVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ScaleVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ScaleVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6719,6 +7775,12 @@ func (p *ScaleVirtualMachineParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
+}
+
+func (p *ScaleVirtualMachineParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
 }
 
 func (p *ScaleVirtualMachineParams) GetMaxiops() (int64, bool) {
@@ -6736,6 +7798,12 @@ func (p *ScaleVirtualMachineParams) SetMiniops(v int64) {
 	p.p["miniops"] = v
 }
 
+func (p *ScaleVirtualMachineParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
+}
+
 func (p *ScaleVirtualMachineParams) GetMiniops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6751,6 +7819,12 @@ func (p *ScaleVirtualMachineParams) SetServiceofferingid(v string) {
 	p.p["serviceofferingid"] = v
 }
 
+func (p *ScaleVirtualMachineParams) ResetServiceofferingid() {
+	if p.p != nil && p.p["serviceofferingid"] != nil {
+		delete(p.p, "serviceofferingid")
+	}
+}
+
 func (p *ScaleVirtualMachineParams) GetServiceofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6764,6 +7838,12 @@ func (p *ScaleVirtualMachineParams) SetShrinkok(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["shrinkok"] = v
+}
+
+func (p *ScaleVirtualMachineParams) ResetShrinkok() {
+	if p.p != nil && p.p["shrinkok"] != nil {
+		delete(p.p, "shrinkok")
+	}
 }
 
 func (p *ScaleVirtualMachineParams) GetShrinkok() (bool, bool) {
@@ -6863,6 +7943,12 @@ func (p *StartVirtualMachineParams) SetBootintosetup(v bool) {
 	p.p["bootintosetup"] = v
 }
 
+func (p *StartVirtualMachineParams) ResetBootintosetup() {
+	if p.p != nil && p.p["bootintosetup"] != nil {
+		delete(p.p, "bootintosetup")
+	}
+}
+
 func (p *StartVirtualMachineParams) GetBootintosetup() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6876,6 +7962,12 @@ func (p *StartVirtualMachineParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *StartVirtualMachineParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *StartVirtualMachineParams) GetClusterid() (string, bool) {
@@ -6893,6 +7985,12 @@ func (p *StartVirtualMachineParams) SetConsiderlasthost(v bool) {
 	p.p["considerlasthost"] = v
 }
 
+func (p *StartVirtualMachineParams) ResetConsiderlasthost() {
+	if p.p != nil && p.p["considerlasthost"] != nil {
+		delete(p.p, "considerlasthost")
+	}
+}
+
 func (p *StartVirtualMachineParams) GetConsiderlasthost() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6906,6 +8004,12 @@ func (p *StartVirtualMachineParams) SetDeploymentplanner(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["deploymentplanner"] = v
+}
+
+func (p *StartVirtualMachineParams) ResetDeploymentplanner() {
+	if p.p != nil && p.p["deploymentplanner"] != nil {
+		delete(p.p, "deploymentplanner")
+	}
 }
 
 func (p *StartVirtualMachineParams) GetDeploymentplanner() (string, bool) {
@@ -6923,6 +8027,12 @@ func (p *StartVirtualMachineParams) SetHostid(v string) {
 	p.p["hostid"] = v
 }
 
+func (p *StartVirtualMachineParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
+}
+
 func (p *StartVirtualMachineParams) GetHostid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6938,6 +8048,12 @@ func (p *StartVirtualMachineParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *StartVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *StartVirtualMachineParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -6951,6 +8067,12 @@ func (p *StartVirtualMachineParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *StartVirtualMachineParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *StartVirtualMachineParams) GetPodid() (string, bool) {
@@ -7191,6 +8313,12 @@ func (p *StopVirtualMachineParams) SetForced(v bool) {
 	p.p["forced"] = v
 }
 
+func (p *StopVirtualMachineParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
 func (p *StopVirtualMachineParams) GetForced() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7204,6 +8332,12 @@ func (p *StopVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *StopVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *StopVirtualMachineParams) GetId() (string, bool) {
@@ -7443,6 +8577,12 @@ func (p *UpdateDefaultNicForVirtualMachineParams) SetNicid(v string) {
 	p.p["nicid"] = v
 }
 
+func (p *UpdateDefaultNicForVirtualMachineParams) ResetNicid() {
+	if p.p != nil && p.p["nicid"] != nil {
+		delete(p.p, "nicid")
+	}
+}
+
 func (p *UpdateDefaultNicForVirtualMachineParams) GetNicid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7456,6 +8596,12 @@ func (p *UpdateDefaultNicForVirtualMachineParams) SetVirtualmachineid(v string) 
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *UpdateDefaultNicForVirtualMachineParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *UpdateDefaultNicForVirtualMachineParams) GetVirtualmachineid() (string, bool) {
@@ -7765,6 +8911,12 @@ func (p *UpdateVirtualMachineParams) SetCleanupdetails(v bool) {
 	p.p["cleanupdetails"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetCleanupdetails() {
+	if p.p != nil && p.p["cleanupdetails"] != nil {
+		delete(p.p, "cleanupdetails")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetCleanupdetails() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7778,6 +8930,12 @@ func (p *UpdateVirtualMachineParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetCustomid() (string, bool) {
@@ -7795,6 +8953,12 @@ func (p *UpdateVirtualMachineParams) SetDetails(v map[string]string) {
 	p.p["details"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetDetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7808,6 +8972,12 @@ func (p *UpdateVirtualMachineParams) SetDhcpoptionsnetworklist(v []map[string]st
 		p.p = make(map[string]interface{})
 	}
 	p.p["dhcpoptionsnetworklist"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetDhcpoptionsnetworklist() {
+	if p.p != nil && p.p["dhcpoptionsnetworklist"] != nil {
+		delete(p.p, "dhcpoptionsnetworklist")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetDhcpoptionsnetworklist() ([]map[string]string, bool) {
@@ -7839,6 +9009,12 @@ func (p *UpdateVirtualMachineParams) SetDisplayname(v string) {
 	p.p["displayname"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetDisplayname() {
+	if p.p != nil && p.p["displayname"] != nil {
+		delete(p.p, "displayname")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetDisplayname() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7852,6 +9028,12 @@ func (p *UpdateVirtualMachineParams) SetDisplayvm(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvm"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetDisplayvm() {
+	if p.p != nil && p.p["displayvm"] != nil {
+		delete(p.p, "displayvm")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetDisplayvm() (bool, bool) {
@@ -7869,6 +9051,12 @@ func (p *UpdateVirtualMachineParams) SetExtraconfig(v string) {
 	p.p["extraconfig"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetExtraconfig() {
+	if p.p != nil && p.p["extraconfig"] != nil {
+		delete(p.p, "extraconfig")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetExtraconfig() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7882,6 +9070,12 @@ func (p *UpdateVirtualMachineParams) SetGroup(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["group"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetGroup() {
+	if p.p != nil && p.p["group"] != nil {
+		delete(p.p, "group")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetGroup() (string, bool) {
@@ -7899,6 +9093,12 @@ func (p *UpdateVirtualMachineParams) SetHaenable(v bool) {
 	p.p["haenable"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetHaenable() {
+	if p.p != nil && p.p["haenable"] != nil {
+		delete(p.p, "haenable")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetHaenable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7912,6 +9112,12 @@ func (p *UpdateVirtualMachineParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetId() (string, bool) {
@@ -7929,6 +9135,12 @@ func (p *UpdateVirtualMachineParams) SetInstancename(v string) {
 	p.p["instancename"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetInstancename() {
+	if p.p != nil && p.p["instancename"] != nil {
+		delete(p.p, "instancename")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetInstancename() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7942,6 +9154,12 @@ func (p *UpdateVirtualMachineParams) SetIsdynamicallyscalable(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["isdynamicallyscalable"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetIsdynamicallyscalable() {
+	if p.p != nil && p.p["isdynamicallyscalable"] != nil {
+		delete(p.p, "isdynamicallyscalable")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetIsdynamicallyscalable() (bool, bool) {
@@ -7959,6 +9177,12 @@ func (p *UpdateVirtualMachineParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -7972,6 +9196,12 @@ func (p *UpdateVirtualMachineParams) SetOstypeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ostypeid"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetOstypeid() {
+	if p.p != nil && p.p["ostypeid"] != nil {
+		delete(p.p, "ostypeid")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetOstypeid() (string, bool) {
@@ -7989,6 +9219,12 @@ func (p *UpdateVirtualMachineParams) SetSecuritygroupids(v []string) {
 	p.p["securitygroupids"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetSecuritygroupids() {
+	if p.p != nil && p.p["securitygroupids"] != nil {
+		delete(p.p, "securitygroupids")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetSecuritygroupids() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8002,6 +9238,12 @@ func (p *UpdateVirtualMachineParams) SetSecuritygroupnames(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupnames"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetSecuritygroupnames() {
+	if p.p != nil && p.p["securitygroupnames"] != nil {
+		delete(p.p, "securitygroupnames")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetSecuritygroupnames() ([]string, bool) {
@@ -8019,6 +9261,12 @@ func (p *UpdateVirtualMachineParams) SetUserdata(v string) {
 	p.p["userdata"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetUserdata() {
+	if p.p != nil && p.p["userdata"] != nil {
+		delete(p.p, "userdata")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetUserdata() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8034,6 +9282,12 @@ func (p *UpdateVirtualMachineParams) SetUserdatadetails(v map[string]string) {
 	p.p["userdatadetails"] = v
 }
 
+func (p *UpdateVirtualMachineParams) ResetUserdatadetails() {
+	if p.p != nil && p.p["userdatadetails"] != nil {
+		delete(p.p, "userdatadetails")
+	}
+}
+
 func (p *UpdateVirtualMachineParams) GetUserdatadetails() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8047,6 +9301,12 @@ func (p *UpdateVirtualMachineParams) SetUserdataid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["userdataid"] = v
+}
+
+func (p *UpdateVirtualMachineParams) ResetUserdataid() {
+	if p.p != nil && p.p["userdataid"] != nil {
+		delete(p.p, "userdataid")
+	}
 }
 
 func (p *UpdateVirtualMachineParams) GetUserdataid() (string, bool) {
@@ -8287,6 +9547,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetEnddate(v string) {
 	p.p["enddate"] = v
 }
 
+func (p *ListVirtualMachinesUsageHistoryParams) ResetEnddate() {
+	if p.p != nil && p.p["enddate"] != nil {
+		delete(p.p, "enddate")
+	}
+}
+
 func (p *ListVirtualMachinesUsageHistoryParams) GetEnddate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8300,6 +9566,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ListVirtualMachinesUsageHistoryParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ListVirtualMachinesUsageHistoryParams) GetId() (string, bool) {
@@ -8317,6 +9589,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetIds(v []string) {
 	p.p["ids"] = v
 }
 
+func (p *ListVirtualMachinesUsageHistoryParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
+}
+
 func (p *ListVirtualMachinesUsageHistoryParams) GetIds() ([]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8330,6 +9608,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVirtualMachinesUsageHistoryParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVirtualMachinesUsageHistoryParams) GetKeyword() (string, bool) {
@@ -8347,6 +9631,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListVirtualMachinesUsageHistoryParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListVirtualMachinesUsageHistoryParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8360,6 +9650,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListVirtualMachinesUsageHistoryParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListVirtualMachinesUsageHistoryParams) GetPage() (int, bool) {
@@ -8377,6 +9673,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListVirtualMachinesUsageHistoryParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListVirtualMachinesUsageHistoryParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -8390,6 +9692,12 @@ func (p *ListVirtualMachinesUsageHistoryParams) SetStartdate(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["startdate"] = v
+}
+
+func (p *ListVirtualMachinesUsageHistoryParams) ResetStartdate() {
+	if p.p != nil && p.p["startdate"] != nil {
+		delete(p.p, "startdate")
+	}
 }
 
 func (p *ListVirtualMachinesUsageHistoryParams) GetStartdate() (string, bool) {

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -101,6 +101,12 @@ func (p *AttachVolumeParams) SetDeviceid(v int64) {
 	p.p["deviceid"] = v
 }
 
+func (p *AttachVolumeParams) ResetDeviceid() {
+	if p.p != nil && p.p["deviceid"] != nil {
+		delete(p.p, "deviceid")
+	}
+}
+
 func (p *AttachVolumeParams) GetDeviceid() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -116,6 +122,12 @@ func (p *AttachVolumeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *AttachVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *AttachVolumeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -129,6 +141,12 @@ func (p *AttachVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *AttachVolumeParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *AttachVolumeParams) GetVirtualmachineid() (string, bool) {
@@ -317,6 +335,12 @@ func (p *CreateVolumeParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *CreateVolumeParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *CreateVolumeParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -330,6 +354,12 @@ func (p *CreateVolumeParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
+}
+
+func (p *CreateVolumeParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
 }
 
 func (p *CreateVolumeParams) GetCustomid() (string, bool) {
@@ -347,6 +377,12 @@ func (p *CreateVolumeParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *CreateVolumeParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *CreateVolumeParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -360,6 +396,12 @@ func (p *CreateVolumeParams) SetDisplayvolume(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvolume"] = v
+}
+
+func (p *CreateVolumeParams) ResetDisplayvolume() {
+	if p.p != nil && p.p["displayvolume"] != nil {
+		delete(p.p, "displayvolume")
+	}
 }
 
 func (p *CreateVolumeParams) GetDisplayvolume() (bool, bool) {
@@ -377,6 +419,12 @@ func (p *CreateVolumeParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateVolumeParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateVolumeParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -390,6 +438,12 @@ func (p *CreateVolumeParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
+}
+
+func (p *CreateVolumeParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
 }
 
 func (p *CreateVolumeParams) GetMaxiops() (int64, bool) {
@@ -407,6 +461,12 @@ func (p *CreateVolumeParams) SetMiniops(v int64) {
 	p.p["miniops"] = v
 }
 
+func (p *CreateVolumeParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
+}
+
 func (p *CreateVolumeParams) GetMiniops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -420,6 +480,12 @@ func (p *CreateVolumeParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *CreateVolumeParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *CreateVolumeParams) GetName() (string, bool) {
@@ -437,6 +503,12 @@ func (p *CreateVolumeParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *CreateVolumeParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *CreateVolumeParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -450,6 +522,12 @@ func (p *CreateVolumeParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
+}
+
+func (p *CreateVolumeParams) ResetSize() {
+	if p.p != nil && p.p["size"] != nil {
+		delete(p.p, "size")
+	}
 }
 
 func (p *CreateVolumeParams) GetSize() (int64, bool) {
@@ -467,6 +545,12 @@ func (p *CreateVolumeParams) SetSnapshotid(v string) {
 	p.p["snapshotid"] = v
 }
 
+func (p *CreateVolumeParams) ResetSnapshotid() {
+	if p.p != nil && p.p["snapshotid"] != nil {
+		delete(p.p, "snapshotid")
+	}
+}
+
 func (p *CreateVolumeParams) GetSnapshotid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -482,6 +566,12 @@ func (p *CreateVolumeParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *CreateVolumeParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *CreateVolumeParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -495,6 +585,12 @@ func (p *CreateVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *CreateVolumeParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *CreateVolumeParams) GetZoneid() (string, bool) {
@@ -641,6 +737,12 @@ func (p *DeleteVolumeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteVolumeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -733,6 +835,12 @@ func (p *DestroyVolumeParams) SetExpunge(v bool) {
 	p.p["expunge"] = v
 }
 
+func (p *DestroyVolumeParams) ResetExpunge() {
+	if p.p != nil && p.p["expunge"] != nil {
+		delete(p.p, "expunge")
+	}
+}
+
 func (p *DestroyVolumeParams) GetExpunge() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -746,6 +854,12 @@ func (p *DestroyVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *DestroyVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *DestroyVolumeParams) GetId() (string, bool) {
@@ -900,6 +1014,12 @@ func (p *DetachVolumeParams) SetDeviceid(v int64) {
 	p.p["deviceid"] = v
 }
 
+func (p *DetachVolumeParams) ResetDeviceid() {
+	if p.p != nil && p.p["deviceid"] != nil {
+		delete(p.p, "deviceid")
+	}
+}
+
 func (p *DetachVolumeParams) GetDeviceid() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -915,6 +1035,12 @@ func (p *DetachVolumeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DetachVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DetachVolumeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -928,6 +1054,12 @@ func (p *DetachVolumeParams) SetVirtualmachineid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["virtualmachineid"] = v
+}
+
+func (p *DetachVolumeParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
 }
 
 func (p *DetachVolumeParams) GetVirtualmachineid() (string, bool) {
@@ -1083,6 +1215,12 @@ func (p *ExtractVolumeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ExtractVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ExtractVolumeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1096,6 +1234,12 @@ func (p *ExtractVolumeParams) SetMode(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["mode"] = v
+}
+
+func (p *ExtractVolumeParams) ResetMode() {
+	if p.p != nil && p.p["mode"] != nil {
+		delete(p.p, "mode")
+	}
 }
 
 func (p *ExtractVolumeParams) GetMode() (string, bool) {
@@ -1113,6 +1257,12 @@ func (p *ExtractVolumeParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *ExtractVolumeParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *ExtractVolumeParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1126,6 +1276,12 @@ func (p *ExtractVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ExtractVolumeParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ExtractVolumeParams) GetZoneid() (string, bool) {
@@ -1223,6 +1379,12 @@ func (p *GetPathForVolumeParams) SetVolumeid(v string) {
 	p.p["volumeid"] = v
 }
 
+func (p *GetPathForVolumeParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
+}
+
 func (p *GetPathForVolumeParams) GetVolumeid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1284,6 +1446,12 @@ func (p *GetSolidFireVolumeSizeParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
+}
+
+func (p *GetSolidFireVolumeSizeParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
 }
 
 func (p *GetSolidFireVolumeSizeParams) GetVolumeid() (string, bool) {
@@ -1370,6 +1538,12 @@ func (p *GetUploadParamsForVolumeParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *GetUploadParamsForVolumeParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *GetUploadParamsForVolumeParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1383,6 +1557,12 @@ func (p *GetUploadParamsForVolumeParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
+}
+
+func (p *GetUploadParamsForVolumeParams) ResetChecksum() {
+	if p.p != nil && p.p["checksum"] != nil {
+		delete(p.p, "checksum")
+	}
 }
 
 func (p *GetUploadParamsForVolumeParams) GetChecksum() (string, bool) {
@@ -1400,6 +1580,12 @@ func (p *GetUploadParamsForVolumeParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *GetUploadParamsForVolumeParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *GetUploadParamsForVolumeParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1413,6 +1599,12 @@ func (p *GetUploadParamsForVolumeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *GetUploadParamsForVolumeParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *GetUploadParamsForVolumeParams) GetDomainid() (string, bool) {
@@ -1430,6 +1622,12 @@ func (p *GetUploadParamsForVolumeParams) SetFormat(v string) {
 	p.p["format"] = v
 }
 
+func (p *GetUploadParamsForVolumeParams) ResetFormat() {
+	if p.p != nil && p.p["format"] != nil {
+		delete(p.p, "format")
+	}
+}
+
 func (p *GetUploadParamsForVolumeParams) GetFormat() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1443,6 +1641,12 @@ func (p *GetUploadParamsForVolumeParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
+}
+
+func (p *GetUploadParamsForVolumeParams) ResetImagestoreuuid() {
+	if p.p != nil && p.p["imagestoreuuid"] != nil {
+		delete(p.p, "imagestoreuuid")
+	}
 }
 
 func (p *GetUploadParamsForVolumeParams) GetImagestoreuuid() (string, bool) {
@@ -1460,6 +1664,12 @@ func (p *GetUploadParamsForVolumeParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *GetUploadParamsForVolumeParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *GetUploadParamsForVolumeParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1475,6 +1685,12 @@ func (p *GetUploadParamsForVolumeParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *GetUploadParamsForVolumeParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *GetUploadParamsForVolumeParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1488,6 +1704,12 @@ func (p *GetUploadParamsForVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *GetUploadParamsForVolumeParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *GetUploadParamsForVolumeParams) GetZoneid() (string, bool) {
@@ -1557,6 +1779,12 @@ func (p *GetVolumeiScsiNameParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
+}
+
+func (p *GetVolumeiScsiNameParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
 }
 
 func (p *GetVolumeiScsiNameParams) GetVolumeid() (string, bool) {
@@ -1700,6 +1928,12 @@ func (p *ListVolumesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVolumesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVolumesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1713,6 +1947,12 @@ func (p *ListVolumesParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ListVolumesParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ListVolumesParams) GetClusterid() (string, bool) {
@@ -1730,6 +1970,12 @@ func (p *ListVolumesParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *ListVolumesParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *ListVolumesParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1743,6 +1989,12 @@ func (p *ListVolumesParams) SetDisplayvolume(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvolume"] = v
+}
+
+func (p *ListVolumesParams) ResetDisplayvolume() {
+	if p.p != nil && p.p["displayvolume"] != nil {
+		delete(p.p, "displayvolume")
+	}
 }
 
 func (p *ListVolumesParams) GetDisplayvolume() (bool, bool) {
@@ -1760,6 +2012,12 @@ func (p *ListVolumesParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListVolumesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListVolumesParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1773,6 +2031,12 @@ func (p *ListVolumesParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *ListVolumesParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *ListVolumesParams) GetHostid() (string, bool) {
@@ -1790,6 +2054,12 @@ func (p *ListVolumesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVolumesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVolumesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1803,6 +2073,12 @@ func (p *ListVolumesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListVolumesParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListVolumesParams) GetIds() ([]string, bool) {
@@ -1820,6 +2096,12 @@ func (p *ListVolumesParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListVolumesParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListVolumesParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1833,6 +2115,12 @@ func (p *ListVolumesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVolumesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVolumesParams) GetKeyword() (string, bool) {
@@ -1850,6 +2138,12 @@ func (p *ListVolumesParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListVolumesParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListVolumesParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1863,6 +2157,12 @@ func (p *ListVolumesParams) SetListsystemvms(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listsystemvms"] = v
+}
+
+func (p *ListVolumesParams) ResetListsystemvms() {
+	if p.p != nil && p.p["listsystemvms"] != nil {
+		delete(p.p, "listsystemvms")
+	}
 }
 
 func (p *ListVolumesParams) GetListsystemvms() (bool, bool) {
@@ -1880,6 +2180,12 @@ func (p *ListVolumesParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListVolumesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListVolumesParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1893,6 +2199,12 @@ func (p *ListVolumesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListVolumesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListVolumesParams) GetPage() (int, bool) {
@@ -1910,6 +2222,12 @@ func (p *ListVolumesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListVolumesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListVolumesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1923,6 +2241,12 @@ func (p *ListVolumesParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListVolumesParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListVolumesParams) GetPodid() (string, bool) {
@@ -1940,6 +2264,12 @@ func (p *ListVolumesParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVolumesParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVolumesParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1953,6 +2283,12 @@ func (p *ListVolumesParams) SetRetrieveonlyresourcecount(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListVolumesParams) ResetRetrieveonlyresourcecount() {
+	if p.p != nil && p.p["retrieveonlyresourcecount"] != nil {
+		delete(p.p, "retrieveonlyresourcecount")
+	}
 }
 
 func (p *ListVolumesParams) GetRetrieveonlyresourcecount() (bool, bool) {
@@ -1970,6 +2306,12 @@ func (p *ListVolumesParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListVolumesParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListVolumesParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1983,6 +2325,12 @@ func (p *ListVolumesParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListVolumesParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListVolumesParams) GetStorageid() (string, bool) {
@@ -2000,6 +2348,12 @@ func (p *ListVolumesParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListVolumesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListVolumesParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2013,6 +2367,12 @@ func (p *ListVolumesParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListVolumesParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListVolumesParams) GetType() (string, bool) {
@@ -2030,6 +2390,12 @@ func (p *ListVolumesParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *ListVolumesParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *ListVolumesParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2043,6 +2409,12 @@ func (p *ListVolumesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVolumesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVolumesParams) GetZoneid() (string, bool) {
@@ -2338,6 +2710,12 @@ func (p *ListVolumesMetricsParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2351,6 +2729,12 @@ func (p *ListVolumesMetricsParams) SetClusterid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["clusterid"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetClusterid() {
+	if p.p != nil && p.p["clusterid"] != nil {
+		delete(p.p, "clusterid")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetClusterid() (string, bool) {
@@ -2368,6 +2752,12 @@ func (p *ListVolumesMetricsParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2381,6 +2771,12 @@ func (p *ListVolumesMetricsParams) SetDisplayvolume(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["displayvolume"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetDisplayvolume() {
+	if p.p != nil && p.p["displayvolume"] != nil {
+		delete(p.p, "displayvolume")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetDisplayvolume() (bool, bool) {
@@ -2398,6 +2794,12 @@ func (p *ListVolumesMetricsParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2411,6 +2813,12 @@ func (p *ListVolumesMetricsParams) SetHostid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["hostid"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetHostid() {
+	if p.p != nil && p.p["hostid"] != nil {
+		delete(p.p, "hostid")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetHostid() (string, bool) {
@@ -2428,6 +2836,12 @@ func (p *ListVolumesMetricsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2441,6 +2855,12 @@ func (p *ListVolumesMetricsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetIds() ([]string, bool) {
@@ -2458,6 +2878,12 @@ func (p *ListVolumesMetricsParams) SetIsrecursive(v bool) {
 	p.p["isrecursive"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetIsrecursive() {
+	if p.p != nil && p.p["isrecursive"] != nil {
+		delete(p.p, "isrecursive")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetIsrecursive() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2471,6 +2897,12 @@ func (p *ListVolumesMetricsParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetKeyword() (string, bool) {
@@ -2488,6 +2920,12 @@ func (p *ListVolumesMetricsParams) SetListall(v bool) {
 	p.p["listall"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetListall() {
+	if p.p != nil && p.p["listall"] != nil {
+		delete(p.p, "listall")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetListall() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2501,6 +2939,12 @@ func (p *ListVolumesMetricsParams) SetListsystemvms(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["listsystemvms"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetListsystemvms() {
+	if p.p != nil && p.p["listsystemvms"] != nil {
+		delete(p.p, "listsystemvms")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetListsystemvms() (bool, bool) {
@@ -2518,6 +2962,12 @@ func (p *ListVolumesMetricsParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2531,6 +2981,12 @@ func (p *ListVolumesMetricsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetPage() (int, bool) {
@@ -2548,6 +3004,12 @@ func (p *ListVolumesMetricsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2561,6 +3023,12 @@ func (p *ListVolumesMetricsParams) SetPodid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["podid"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetPodid() {
+	if p.p != nil && p.p["podid"] != nil {
+		delete(p.p, "podid")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetPodid() (string, bool) {
@@ -2578,6 +3046,12 @@ func (p *ListVolumesMetricsParams) SetProjectid(v string) {
 	p.p["projectid"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetProjectid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2591,6 +3065,12 @@ func (p *ListVolumesMetricsParams) SetRetrieveonlyresourcecount(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["retrieveonlyresourcecount"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetRetrieveonlyresourcecount() {
+	if p.p != nil && p.p["retrieveonlyresourcecount"] != nil {
+		delete(p.p, "retrieveonlyresourcecount")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetRetrieveonlyresourcecount() (bool, bool) {
@@ -2608,6 +3088,12 @@ func (p *ListVolumesMetricsParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2621,6 +3107,12 @@ func (p *ListVolumesMetricsParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetStorageid() (string, bool) {
@@ -2638,6 +3130,12 @@ func (p *ListVolumesMetricsParams) SetTags(v map[string]string) {
 	p.p["tags"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetTags() (map[string]string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2651,6 +3149,12 @@ func (p *ListVolumesMetricsParams) SetType(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["type"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetType() {
+	if p.p != nil && p.p["type"] != nil {
+		delete(p.p, "type")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetType() (string, bool) {
@@ -2668,6 +3172,12 @@ func (p *ListVolumesMetricsParams) SetVirtualmachineid(v string) {
 	p.p["virtualmachineid"] = v
 }
 
+func (p *ListVolumesMetricsParams) ResetVirtualmachineid() {
+	if p.p != nil && p.p["virtualmachineid"] != nil {
+		delete(p.p, "virtualmachineid")
+	}
+}
+
 func (p *ListVolumesMetricsParams) GetVirtualmachineid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2681,6 +3191,12 @@ func (p *ListVolumesMetricsParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListVolumesMetricsParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListVolumesMetricsParams) GetZoneid() (string, bool) {
@@ -2907,6 +3423,12 @@ func (p *MigrateVolumeParams) SetLivemigrate(v bool) {
 	p.p["livemigrate"] = v
 }
 
+func (p *MigrateVolumeParams) ResetLivemigrate() {
+	if p.p != nil && p.p["livemigrate"] != nil {
+		delete(p.p, "livemigrate")
+	}
+}
+
 func (p *MigrateVolumeParams) GetLivemigrate() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2920,6 +3442,12 @@ func (p *MigrateVolumeParams) SetNewdiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["newdiskofferingid"] = v
+}
+
+func (p *MigrateVolumeParams) ResetNewdiskofferingid() {
+	if p.p != nil && p.p["newdiskofferingid"] != nil {
+		delete(p.p, "newdiskofferingid")
+	}
 }
 
 func (p *MigrateVolumeParams) GetNewdiskofferingid() (string, bool) {
@@ -2937,6 +3465,12 @@ func (p *MigrateVolumeParams) SetStorageid(v string) {
 	p.p["storageid"] = v
 }
 
+func (p *MigrateVolumeParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
+}
+
 func (p *MigrateVolumeParams) GetStorageid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2950,6 +3484,12 @@ func (p *MigrateVolumeParams) SetVolumeid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["volumeid"] = v
+}
+
+func (p *MigrateVolumeParams) ResetVolumeid() {
+	if p.p != nil && p.p["volumeid"] != nil {
+		delete(p.p, "volumeid")
+	}
 }
 
 func (p *MigrateVolumeParams) GetVolumeid() (string, bool) {
@@ -3098,6 +3638,12 @@ func (p *RecoverVolumeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *RecoverVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *RecoverVolumeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3242,6 +3788,12 @@ func (p *ResizeVolumeParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *ResizeVolumeParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *ResizeVolumeParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3255,6 +3807,12 @@ func (p *ResizeVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *ResizeVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *ResizeVolumeParams) GetId() (string, bool) {
@@ -3272,6 +3830,12 @@ func (p *ResizeVolumeParams) SetMaxiops(v int64) {
 	p.p["maxiops"] = v
 }
 
+func (p *ResizeVolumeParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
+}
+
 func (p *ResizeVolumeParams) GetMaxiops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3285,6 +3849,12 @@ func (p *ResizeVolumeParams) SetMiniops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["miniops"] = v
+}
+
+func (p *ResizeVolumeParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
 }
 
 func (p *ResizeVolumeParams) GetMiniops() (int64, bool) {
@@ -3302,6 +3872,12 @@ func (p *ResizeVolumeParams) SetShrinkok(v bool) {
 	p.p["shrinkok"] = v
 }
 
+func (p *ResizeVolumeParams) ResetShrinkok() {
+	if p.p != nil && p.p["shrinkok"] != nil {
+		delete(p.p, "shrinkok")
+	}
+}
+
 func (p *ResizeVolumeParams) GetShrinkok() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3315,6 +3891,12 @@ func (p *ResizeVolumeParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
+}
+
+func (p *ResizeVolumeParams) ResetSize() {
+	if p.p != nil && p.p["size"] != nil {
+		delete(p.p, "size")
+	}
 }
 
 func (p *ResizeVolumeParams) GetSize() (int64, bool) {
@@ -3484,6 +4066,12 @@ func (p *UpdateVolumeParams) SetChaininfo(v string) {
 	p.p["chaininfo"] = v
 }
 
+func (p *UpdateVolumeParams) ResetChaininfo() {
+	if p.p != nil && p.p["chaininfo"] != nil {
+		delete(p.p, "chaininfo")
+	}
+}
+
 func (p *UpdateVolumeParams) GetChaininfo() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3497,6 +4085,12 @@ func (p *UpdateVolumeParams) SetCustomid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["customid"] = v
+}
+
+func (p *UpdateVolumeParams) ResetCustomid() {
+	if p.p != nil && p.p["customid"] != nil {
+		delete(p.p, "customid")
+	}
 }
 
 func (p *UpdateVolumeParams) GetCustomid() (string, bool) {
@@ -3514,6 +4108,12 @@ func (p *UpdateVolumeParams) SetDisplayvolume(v bool) {
 	p.p["displayvolume"] = v
 }
 
+func (p *UpdateVolumeParams) ResetDisplayvolume() {
+	if p.p != nil && p.p["displayvolume"] != nil {
+		delete(p.p, "displayvolume")
+	}
+}
+
 func (p *UpdateVolumeParams) GetDisplayvolume() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3527,6 +4127,12 @@ func (p *UpdateVolumeParams) SetId(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["id"] = v
+}
+
+func (p *UpdateVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
 }
 
 func (p *UpdateVolumeParams) GetId() (string, bool) {
@@ -3544,6 +4150,12 @@ func (p *UpdateVolumeParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateVolumeParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateVolumeParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3557,6 +4169,12 @@ func (p *UpdateVolumeParams) SetPath(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["path"] = v
+}
+
+func (p *UpdateVolumeParams) ResetPath() {
+	if p.p != nil && p.p["path"] != nil {
+		delete(p.p, "path")
+	}
 }
 
 func (p *UpdateVolumeParams) GetPath() (string, bool) {
@@ -3574,6 +4192,12 @@ func (p *UpdateVolumeParams) SetState(v string) {
 	p.p["state"] = v
 }
 
+func (p *UpdateVolumeParams) ResetState() {
+	if p.p != nil && p.p["state"] != nil {
+		delete(p.p, "state")
+	}
+}
+
 func (p *UpdateVolumeParams) GetState() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3587,6 +4211,12 @@ func (p *UpdateVolumeParams) SetStorageid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["storageid"] = v
+}
+
+func (p *UpdateVolumeParams) ResetStorageid() {
+	if p.p != nil && p.p["storageid"] != nil {
+		delete(p.p, "storageid")
+	}
 }
 
 func (p *UpdateVolumeParams) GetStorageid() (string, bool) {
@@ -3760,6 +4390,12 @@ func (p *UploadVolumeParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *UploadVolumeParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *UploadVolumeParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3773,6 +4409,12 @@ func (p *UploadVolumeParams) SetChecksum(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["checksum"] = v
+}
+
+func (p *UploadVolumeParams) ResetChecksum() {
+	if p.p != nil && p.p["checksum"] != nil {
+		delete(p.p, "checksum")
+	}
 }
 
 func (p *UploadVolumeParams) GetChecksum() (string, bool) {
@@ -3790,6 +4432,12 @@ func (p *UploadVolumeParams) SetDiskofferingid(v string) {
 	p.p["diskofferingid"] = v
 }
 
+func (p *UploadVolumeParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
+}
+
 func (p *UploadVolumeParams) GetDiskofferingid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3803,6 +4451,12 @@ func (p *UploadVolumeParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *UploadVolumeParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *UploadVolumeParams) GetDomainid() (string, bool) {
@@ -3820,6 +4474,12 @@ func (p *UploadVolumeParams) SetFormat(v string) {
 	p.p["format"] = v
 }
 
+func (p *UploadVolumeParams) ResetFormat() {
+	if p.p != nil && p.p["format"] != nil {
+		delete(p.p, "format")
+	}
+}
+
 func (p *UploadVolumeParams) GetFormat() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3833,6 +4493,12 @@ func (p *UploadVolumeParams) SetImagestoreuuid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["imagestoreuuid"] = v
+}
+
+func (p *UploadVolumeParams) ResetImagestoreuuid() {
+	if p.p != nil && p.p["imagestoreuuid"] != nil {
+		delete(p.p, "imagestoreuuid")
+	}
 }
 
 func (p *UploadVolumeParams) GetImagestoreuuid() (string, bool) {
@@ -3850,6 +4516,12 @@ func (p *UploadVolumeParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UploadVolumeParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UploadVolumeParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3863,6 +4535,12 @@ func (p *UploadVolumeParams) SetProjectid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["projectid"] = v
+}
+
+func (p *UploadVolumeParams) ResetProjectid() {
+	if p.p != nil && p.p["projectid"] != nil {
+		delete(p.p, "projectid")
+	}
 }
 
 func (p *UploadVolumeParams) GetProjectid() (string, bool) {
@@ -3880,6 +4558,12 @@ func (p *UploadVolumeParams) SetUrl(v string) {
 	p.p["url"] = v
 }
 
+func (p *UploadVolumeParams) ResetUrl() {
+	if p.p != nil && p.p["url"] != nil {
+		delete(p.p, "url")
+	}
+}
+
 func (p *UploadVolumeParams) GetUrl() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -3893,6 +4577,12 @@ func (p *UploadVolumeParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *UploadVolumeParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *UploadVolumeParams) GetZoneid() (string, bool) {
@@ -4066,6 +4756,12 @@ func (p *ChangeOfferingForVolumeParams) SetAutomigrate(v bool) {
 	p.p["automigrate"] = v
 }
 
+func (p *ChangeOfferingForVolumeParams) ResetAutomigrate() {
+	if p.p != nil && p.p["automigrate"] != nil {
+		delete(p.p, "automigrate")
+	}
+}
+
 func (p *ChangeOfferingForVolumeParams) GetAutomigrate() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4079,6 +4775,12 @@ func (p *ChangeOfferingForVolumeParams) SetDiskofferingid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["diskofferingid"] = v
+}
+
+func (p *ChangeOfferingForVolumeParams) ResetDiskofferingid() {
+	if p.p != nil && p.p["diskofferingid"] != nil {
+		delete(p.p, "diskofferingid")
+	}
 }
 
 func (p *ChangeOfferingForVolumeParams) GetDiskofferingid() (string, bool) {
@@ -4096,6 +4798,12 @@ func (p *ChangeOfferingForVolumeParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ChangeOfferingForVolumeParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ChangeOfferingForVolumeParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4109,6 +4817,12 @@ func (p *ChangeOfferingForVolumeParams) SetMaxiops(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["maxiops"] = v
+}
+
+func (p *ChangeOfferingForVolumeParams) ResetMaxiops() {
+	if p.p != nil && p.p["maxiops"] != nil {
+		delete(p.p, "maxiops")
+	}
 }
 
 func (p *ChangeOfferingForVolumeParams) GetMaxiops() (int64, bool) {
@@ -4126,6 +4840,12 @@ func (p *ChangeOfferingForVolumeParams) SetMiniops(v int64) {
 	p.p["miniops"] = v
 }
 
+func (p *ChangeOfferingForVolumeParams) ResetMiniops() {
+	if p.p != nil && p.p["miniops"] != nil {
+		delete(p.p, "miniops")
+	}
+}
+
 func (p *ChangeOfferingForVolumeParams) GetMiniops() (int64, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4141,6 +4861,12 @@ func (p *ChangeOfferingForVolumeParams) SetShrinkok(v bool) {
 	p.p["shrinkok"] = v
 }
 
+func (p *ChangeOfferingForVolumeParams) ResetShrinkok() {
+	if p.p != nil && p.p["shrinkok"] != nil {
+		delete(p.p, "shrinkok")
+	}
+}
+
 func (p *ChangeOfferingForVolumeParams) GetShrinkok() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -4154,6 +4880,12 @@ func (p *ChangeOfferingForVolumeParams) SetSize(v int64) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["size"] = v
+}
+
+func (p *ChangeOfferingForVolumeParams) ResetSize() {
+	if p.p != nil && p.p["size"] != nil {
+		delete(p.p, "size")
+	}
 }
 
 func (p *ChangeOfferingForVolumeParams) GetSize() (int64, bool) {

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -127,6 +127,12 @@ func (p *CreateZoneParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *CreateZoneParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *CreateZoneParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -140,6 +146,12 @@ func (p *CreateZoneParams) SetDns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns1"] = v
+}
+
+func (p *CreateZoneParams) ResetDns1() {
+	if p.p != nil && p.p["dns1"] != nil {
+		delete(p.p, "dns1")
+	}
 }
 
 func (p *CreateZoneParams) GetDns1() (string, bool) {
@@ -157,6 +169,12 @@ func (p *CreateZoneParams) SetDns2(v string) {
 	p.p["dns2"] = v
 }
 
+func (p *CreateZoneParams) ResetDns2() {
+	if p.p != nil && p.p["dns2"] != nil {
+		delete(p.p, "dns2")
+	}
+}
+
 func (p *CreateZoneParams) GetDns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -170,6 +188,12 @@ func (p *CreateZoneParams) SetDomain(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domain"] = v
+}
+
+func (p *CreateZoneParams) ResetDomain() {
+	if p.p != nil && p.p["domain"] != nil {
+		delete(p.p, "domain")
+	}
 }
 
 func (p *CreateZoneParams) GetDomain() (string, bool) {
@@ -187,6 +211,12 @@ func (p *CreateZoneParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *CreateZoneParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *CreateZoneParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -200,6 +230,12 @@ func (p *CreateZoneParams) SetGuestcidraddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestcidraddress"] = v
+}
+
+func (p *CreateZoneParams) ResetGuestcidraddress() {
+	if p.p != nil && p.p["guestcidraddress"] != nil {
+		delete(p.p, "guestcidraddress")
+	}
 }
 
 func (p *CreateZoneParams) GetGuestcidraddress() (string, bool) {
@@ -217,6 +253,12 @@ func (p *CreateZoneParams) SetInternaldns1(v string) {
 	p.p["internaldns1"] = v
 }
 
+func (p *CreateZoneParams) ResetInternaldns1() {
+	if p.p != nil && p.p["internaldns1"] != nil {
+		delete(p.p, "internaldns1")
+	}
+}
+
 func (p *CreateZoneParams) GetInternaldns1() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -230,6 +272,12 @@ func (p *CreateZoneParams) SetInternaldns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internaldns2"] = v
+}
+
+func (p *CreateZoneParams) ResetInternaldns2() {
+	if p.p != nil && p.p["internaldns2"] != nil {
+		delete(p.p, "internaldns2")
+	}
 }
 
 func (p *CreateZoneParams) GetInternaldns2() (string, bool) {
@@ -247,6 +295,12 @@ func (p *CreateZoneParams) SetIp6dns1(v string) {
 	p.p["ip6dns1"] = v
 }
 
+func (p *CreateZoneParams) ResetIp6dns1() {
+	if p.p != nil && p.p["ip6dns1"] != nil {
+		delete(p.p, "ip6dns1")
+	}
+}
+
 func (p *CreateZoneParams) GetIp6dns1() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -260,6 +314,12 @@ func (p *CreateZoneParams) SetIp6dns2(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns2"] = v
+}
+
+func (p *CreateZoneParams) ResetIp6dns2() {
+	if p.p != nil && p.p["ip6dns2"] != nil {
+		delete(p.p, "ip6dns2")
+	}
 }
 
 func (p *CreateZoneParams) GetIp6dns2() (string, bool) {
@@ -277,6 +337,12 @@ func (p *CreateZoneParams) SetIsedge(v bool) {
 	p.p["isedge"] = v
 }
 
+func (p *CreateZoneParams) ResetIsedge() {
+	if p.p != nil && p.p["isedge"] != nil {
+		delete(p.p, "isedge")
+	}
+}
+
 func (p *CreateZoneParams) GetIsedge() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -290,6 +356,12 @@ func (p *CreateZoneParams) SetLocalstorageenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["localstorageenabled"] = v
+}
+
+func (p *CreateZoneParams) ResetLocalstorageenabled() {
+	if p.p != nil && p.p["localstorageenabled"] != nil {
+		delete(p.p, "localstorageenabled")
+	}
 }
 
 func (p *CreateZoneParams) GetLocalstorageenabled() (bool, bool) {
@@ -307,6 +379,12 @@ func (p *CreateZoneParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *CreateZoneParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *CreateZoneParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -322,6 +400,12 @@ func (p *CreateZoneParams) SetNetworktype(v string) {
 	p.p["networktype"] = v
 }
 
+func (p *CreateZoneParams) ResetNetworktype() {
+	if p.p != nil && p.p["networktype"] != nil {
+		delete(p.p, "networktype")
+	}
+}
+
 func (p *CreateZoneParams) GetNetworktype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -335,6 +419,12 @@ func (p *CreateZoneParams) SetSecuritygroupenabled(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["securitygroupenabled"] = v
+}
+
+func (p *CreateZoneParams) ResetSecuritygroupenabled() {
+	if p.p != nil && p.p["securitygroupenabled"] != nil {
+		delete(p.p, "securitygroupenabled")
+	}
 }
 
 func (p *CreateZoneParams) GetSecuritygroupenabled() (bool, bool) {
@@ -453,6 +543,12 @@ func (p *DedicateZoneParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *DedicateZoneParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *DedicateZoneParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -468,6 +564,12 @@ func (p *DedicateZoneParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *DedicateZoneParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *DedicateZoneParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -481,6 +583,12 @@ func (p *DedicateZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *DedicateZoneParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *DedicateZoneParams) GetZoneid() (string, bool) {
@@ -569,6 +677,12 @@ func (p *DeleteZoneParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *DeleteZoneParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *DeleteZoneParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -655,6 +769,12 @@ func (p *DisableOutOfBandManagementForZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *DisableOutOfBandManagementForZoneParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *DisableOutOfBandManagementForZoneParams) GetZoneid() (string, bool) {
@@ -747,6 +867,12 @@ func (p *EnableOutOfBandManagementForZoneParams) SetZoneid(v string) {
 	p.p["zoneid"] = v
 }
 
+func (p *EnableOutOfBandManagementForZoneParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
+}
+
 func (p *EnableOutOfBandManagementForZoneParams) GetZoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -837,6 +963,12 @@ func (p *DisableHAForZoneParams) SetZoneid(v string) {
 	p.p["zoneid"] = v
 }
 
+func (p *DisableHAForZoneParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
+}
+
 func (p *DisableHAForZoneParams) GetZoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -911,6 +1043,12 @@ func (p *EnableHAForZoneParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *EnableHAForZoneParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *EnableHAForZoneParams) GetZoneid() (string, bool) {
@@ -1009,6 +1147,12 @@ func (p *ListDedicatedZonesParams) SetAccount(v string) {
 	p.p["account"] = v
 }
 
+func (p *ListDedicatedZonesParams) ResetAccount() {
+	if p.p != nil && p.p["account"] != nil {
+		delete(p.p, "account")
+	}
+}
+
 func (p *ListDedicatedZonesParams) GetAccount() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1022,6 +1166,12 @@ func (p *ListDedicatedZonesParams) SetAffinitygroupid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["affinitygroupid"] = v
+}
+
+func (p *ListDedicatedZonesParams) ResetAffinitygroupid() {
+	if p.p != nil && p.p["affinitygroupid"] != nil {
+		delete(p.p, "affinitygroupid")
+	}
 }
 
 func (p *ListDedicatedZonesParams) GetAffinitygroupid() (string, bool) {
@@ -1039,6 +1189,12 @@ func (p *ListDedicatedZonesParams) SetDomainid(v string) {
 	p.p["domainid"] = v
 }
 
+func (p *ListDedicatedZonesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
+}
+
 func (p *ListDedicatedZonesParams) GetDomainid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1052,6 +1208,12 @@ func (p *ListDedicatedZonesParams) SetKeyword(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["keyword"] = v
+}
+
+func (p *ListDedicatedZonesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
 }
 
 func (p *ListDedicatedZonesParams) GetKeyword() (string, bool) {
@@ -1069,6 +1231,12 @@ func (p *ListDedicatedZonesParams) SetPage(v int) {
 	p.p["page"] = v
 }
 
+func (p *ListDedicatedZonesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
+}
+
 func (p *ListDedicatedZonesParams) GetPage() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1084,6 +1252,12 @@ func (p *ListDedicatedZonesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListDedicatedZonesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListDedicatedZonesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1097,6 +1271,12 @@ func (p *ListDedicatedZonesParams) SetZoneid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["zoneid"] = v
+}
+
+func (p *ListDedicatedZonesParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
 }
 
 func (p *ListDedicatedZonesParams) GetZoneid() (string, bool) {
@@ -1211,6 +1391,12 @@ func (p *ListZonesParams) SetAvailable(v bool) {
 	p.p["available"] = v
 }
 
+func (p *ListZonesParams) ResetAvailable() {
+	if p.p != nil && p.p["available"] != nil {
+		delete(p.p, "available")
+	}
+}
+
 func (p *ListZonesParams) GetAvailable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1224,6 +1410,12 @@ func (p *ListZonesParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListZonesParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListZonesParams) GetDomainid() (string, bool) {
@@ -1241,6 +1433,12 @@ func (p *ListZonesParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListZonesParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListZonesParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1254,6 +1452,12 @@ func (p *ListZonesParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListZonesParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListZonesParams) GetIds() ([]string, bool) {
@@ -1271,6 +1475,12 @@ func (p *ListZonesParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListZonesParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListZonesParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1284,6 +1494,12 @@ func (p *ListZonesParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListZonesParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListZonesParams) GetName() (string, bool) {
@@ -1301,6 +1517,12 @@ func (p *ListZonesParams) SetNetworktype(v string) {
 	p.p["networktype"] = v
 }
 
+func (p *ListZonesParams) ResetNetworktype() {
+	if p.p != nil && p.p["networktype"] != nil {
+		delete(p.p, "networktype")
+	}
+}
+
 func (p *ListZonesParams) GetNetworktype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1314,6 +1536,12 @@ func (p *ListZonesParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListZonesParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListZonesParams) GetPage() (int, bool) {
@@ -1331,6 +1559,12 @@ func (p *ListZonesParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListZonesParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListZonesParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1344,6 +1578,12 @@ func (p *ListZonesParams) SetShowcapacities(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showcapacities"] = v
+}
+
+func (p *ListZonesParams) ResetShowcapacities() {
+	if p.p != nil && p.p["showcapacities"] != nil {
+		delete(p.p, "showcapacities")
+	}
 }
 
 func (p *ListZonesParams) GetShowcapacities() (bool, bool) {
@@ -1361,6 +1601,12 @@ func (p *ListZonesParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListZonesParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListZonesParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1374,6 +1620,12 @@ func (p *ListZonesParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListZonesParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListZonesParams) GetTags() (map[string]string, bool) {
@@ -1609,6 +1861,12 @@ func (p *ListZonesMetricsParams) SetAvailable(v bool) {
 	p.p["available"] = v
 }
 
+func (p *ListZonesMetricsParams) ResetAvailable() {
+	if p.p != nil && p.p["available"] != nil {
+		delete(p.p, "available")
+	}
+}
+
 func (p *ListZonesMetricsParams) GetAvailable() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1622,6 +1880,12 @@ func (p *ListZonesMetricsParams) SetDomainid(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["domainid"] = v
+}
+
+func (p *ListZonesMetricsParams) ResetDomainid() {
+	if p.p != nil && p.p["domainid"] != nil {
+		delete(p.p, "domainid")
+	}
 }
 
 func (p *ListZonesMetricsParams) GetDomainid() (string, bool) {
@@ -1639,6 +1903,12 @@ func (p *ListZonesMetricsParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *ListZonesMetricsParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *ListZonesMetricsParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1652,6 +1922,12 @@ func (p *ListZonesMetricsParams) SetIds(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ids"] = v
+}
+
+func (p *ListZonesMetricsParams) ResetIds() {
+	if p.p != nil && p.p["ids"] != nil {
+		delete(p.p, "ids")
+	}
 }
 
 func (p *ListZonesMetricsParams) GetIds() ([]string, bool) {
@@ -1669,6 +1945,12 @@ func (p *ListZonesMetricsParams) SetKeyword(v string) {
 	p.p["keyword"] = v
 }
 
+func (p *ListZonesMetricsParams) ResetKeyword() {
+	if p.p != nil && p.p["keyword"] != nil {
+		delete(p.p, "keyword")
+	}
+}
+
 func (p *ListZonesMetricsParams) GetKeyword() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1682,6 +1964,12 @@ func (p *ListZonesMetricsParams) SetName(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["name"] = v
+}
+
+func (p *ListZonesMetricsParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
 }
 
 func (p *ListZonesMetricsParams) GetName() (string, bool) {
@@ -1699,6 +1987,12 @@ func (p *ListZonesMetricsParams) SetNetworktype(v string) {
 	p.p["networktype"] = v
 }
 
+func (p *ListZonesMetricsParams) ResetNetworktype() {
+	if p.p != nil && p.p["networktype"] != nil {
+		delete(p.p, "networktype")
+	}
+}
+
 func (p *ListZonesMetricsParams) GetNetworktype() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1712,6 +2006,12 @@ func (p *ListZonesMetricsParams) SetPage(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["page"] = v
+}
+
+func (p *ListZonesMetricsParams) ResetPage() {
+	if p.p != nil && p.p["page"] != nil {
+		delete(p.p, "page")
+	}
 }
 
 func (p *ListZonesMetricsParams) GetPage() (int, bool) {
@@ -1729,6 +2029,12 @@ func (p *ListZonesMetricsParams) SetPagesize(v int) {
 	p.p["pagesize"] = v
 }
 
+func (p *ListZonesMetricsParams) ResetPagesize() {
+	if p.p != nil && p.p["pagesize"] != nil {
+		delete(p.p, "pagesize")
+	}
+}
+
 func (p *ListZonesMetricsParams) GetPagesize() (int, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1742,6 +2048,12 @@ func (p *ListZonesMetricsParams) SetShowcapacities(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["showcapacities"] = v
+}
+
+func (p *ListZonesMetricsParams) ResetShowcapacities() {
+	if p.p != nil && p.p["showcapacities"] != nil {
+		delete(p.p, "showcapacities")
+	}
 }
 
 func (p *ListZonesMetricsParams) GetShowcapacities() (bool, bool) {
@@ -1759,6 +2071,12 @@ func (p *ListZonesMetricsParams) SetShowicon(v bool) {
 	p.p["showicon"] = v
 }
 
+func (p *ListZonesMetricsParams) ResetShowicon() {
+	if p.p != nil && p.p["showicon"] != nil {
+		delete(p.p, "showicon")
+	}
+}
+
 func (p *ListZonesMetricsParams) GetShowicon() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -1772,6 +2090,12 @@ func (p *ListZonesMetricsParams) SetTags(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["tags"] = v
+}
+
+func (p *ListZonesMetricsParams) ResetTags() {
+	if p.p != nil && p.p["tags"] != nil {
+		delete(p.p, "tags")
+	}
 }
 
 func (p *ListZonesMetricsParams) GetTags() (map[string]string, bool) {
@@ -1982,6 +2306,12 @@ func (p *ReleaseDedicatedZoneParams) SetZoneid(v string) {
 	p.p["zoneid"] = v
 }
 
+func (p *ReleaseDedicatedZoneParams) ResetZoneid() {
+	if p.p != nil && p.p["zoneid"] != nil {
+		delete(p.p, "zoneid")
+	}
+}
+
 func (p *ReleaseDedicatedZoneParams) GetZoneid() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2114,6 +2444,12 @@ func (p *UpdateZoneParams) SetAllocationstate(v string) {
 	p.p["allocationstate"] = v
 }
 
+func (p *UpdateZoneParams) ResetAllocationstate() {
+	if p.p != nil && p.p["allocationstate"] != nil {
+		delete(p.p, "allocationstate")
+	}
+}
+
 func (p *UpdateZoneParams) GetAllocationstate() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2127,6 +2463,12 @@ func (p *UpdateZoneParams) SetDetails(v map[string]string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["details"] = v
+}
+
+func (p *UpdateZoneParams) ResetDetails() {
+	if p.p != nil && p.p["details"] != nil {
+		delete(p.p, "details")
+	}
 }
 
 func (p *UpdateZoneParams) GetDetails() (map[string]string, bool) {
@@ -2144,6 +2486,12 @@ func (p *UpdateZoneParams) SetDhcpprovider(v string) {
 	p.p["dhcpprovider"] = v
 }
 
+func (p *UpdateZoneParams) ResetDhcpprovider() {
+	if p.p != nil && p.p["dhcpprovider"] != nil {
+		delete(p.p, "dhcpprovider")
+	}
+}
+
 func (p *UpdateZoneParams) GetDhcpprovider() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2157,6 +2505,12 @@ func (p *UpdateZoneParams) SetDns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dns1"] = v
+}
+
+func (p *UpdateZoneParams) ResetDns1() {
+	if p.p != nil && p.p["dns1"] != nil {
+		delete(p.p, "dns1")
+	}
 }
 
 func (p *UpdateZoneParams) GetDns1() (string, bool) {
@@ -2174,6 +2528,12 @@ func (p *UpdateZoneParams) SetDns2(v string) {
 	p.p["dns2"] = v
 }
 
+func (p *UpdateZoneParams) ResetDns2() {
+	if p.p != nil && p.p["dns2"] != nil {
+		delete(p.p, "dns2")
+	}
+}
+
 func (p *UpdateZoneParams) GetDns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2187,6 +2547,12 @@ func (p *UpdateZoneParams) SetDnssearchorder(v []string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["dnssearchorder"] = v
+}
+
+func (p *UpdateZoneParams) ResetDnssearchorder() {
+	if p.p != nil && p.p["dnssearchorder"] != nil {
+		delete(p.p, "dnssearchorder")
+	}
 }
 
 func (p *UpdateZoneParams) GetDnssearchorder() ([]string, bool) {
@@ -2204,6 +2570,12 @@ func (p *UpdateZoneParams) SetDomain(v string) {
 	p.p["domain"] = v
 }
 
+func (p *UpdateZoneParams) ResetDomain() {
+	if p.p != nil && p.p["domain"] != nil {
+		delete(p.p, "domain")
+	}
+}
+
 func (p *UpdateZoneParams) GetDomain() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2217,6 +2589,12 @@ func (p *UpdateZoneParams) SetGuestcidraddress(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["guestcidraddress"] = v
+}
+
+func (p *UpdateZoneParams) ResetGuestcidraddress() {
+	if p.p != nil && p.p["guestcidraddress"] != nil {
+		delete(p.p, "guestcidraddress")
+	}
 }
 
 func (p *UpdateZoneParams) GetGuestcidraddress() (string, bool) {
@@ -2234,6 +2612,12 @@ func (p *UpdateZoneParams) SetId(v string) {
 	p.p["id"] = v
 }
 
+func (p *UpdateZoneParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
 func (p *UpdateZoneParams) GetId() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2247,6 +2631,12 @@ func (p *UpdateZoneParams) SetInternaldns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["internaldns1"] = v
+}
+
+func (p *UpdateZoneParams) ResetInternaldns1() {
+	if p.p != nil && p.p["internaldns1"] != nil {
+		delete(p.p, "internaldns1")
+	}
 }
 
 func (p *UpdateZoneParams) GetInternaldns1() (string, bool) {
@@ -2264,6 +2654,12 @@ func (p *UpdateZoneParams) SetInternaldns2(v string) {
 	p.p["internaldns2"] = v
 }
 
+func (p *UpdateZoneParams) ResetInternaldns2() {
+	if p.p != nil && p.p["internaldns2"] != nil {
+		delete(p.p, "internaldns2")
+	}
+}
+
 func (p *UpdateZoneParams) GetInternaldns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2277,6 +2673,12 @@ func (p *UpdateZoneParams) SetIp6dns1(v string) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ip6dns1"] = v
+}
+
+func (p *UpdateZoneParams) ResetIp6dns1() {
+	if p.p != nil && p.p["ip6dns1"] != nil {
+		delete(p.p, "ip6dns1")
+	}
 }
 
 func (p *UpdateZoneParams) GetIp6dns1() (string, bool) {
@@ -2294,6 +2696,12 @@ func (p *UpdateZoneParams) SetIp6dns2(v string) {
 	p.p["ip6dns2"] = v
 }
 
+func (p *UpdateZoneParams) ResetIp6dns2() {
+	if p.p != nil && p.p["ip6dns2"] != nil {
+		delete(p.p, "ip6dns2")
+	}
+}
+
 func (p *UpdateZoneParams) GetIp6dns2() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2307,6 +2715,12 @@ func (p *UpdateZoneParams) SetIspublic(v bool) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["ispublic"] = v
+}
+
+func (p *UpdateZoneParams) ResetIspublic() {
+	if p.p != nil && p.p["ispublic"] != nil {
+		delete(p.p, "ispublic")
+	}
 }
 
 func (p *UpdateZoneParams) GetIspublic() (bool, bool) {
@@ -2324,6 +2738,12 @@ func (p *UpdateZoneParams) SetLocalstorageenabled(v bool) {
 	p.p["localstorageenabled"] = v
 }
 
+func (p *UpdateZoneParams) ResetLocalstorageenabled() {
+	if p.p != nil && p.p["localstorageenabled"] != nil {
+		delete(p.p, "localstorageenabled")
+	}
+}
+
 func (p *UpdateZoneParams) GetLocalstorageenabled() (bool, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2339,6 +2759,12 @@ func (p *UpdateZoneParams) SetName(v string) {
 	p.p["name"] = v
 }
 
+func (p *UpdateZoneParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
 func (p *UpdateZoneParams) GetName() (string, bool) {
 	if p.p == nil {
 		p.p = make(map[string]interface{})
@@ -2352,6 +2778,12 @@ func (p *UpdateZoneParams) SetSortkey(v int) {
 		p.p = make(map[string]interface{})
 	}
 	p.p["sortkey"] = v
+}
+
+func (p *UpdateZoneParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
 }
 
 func (p *UpdateZoneParams) GetSortkey() (int, bool) {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1380,6 +1380,13 @@ func (s *service) generateParamGettersAndSettersFunc(a *API) {
 			pn("}")
 			pn("")
 
+			pn("func (p *%s) Reset%s() {", capitalize(a.Name+"Params"), capitalize(ap.Name))
+			pn("	if p.p != nil && p.p[\"%s\"] != nil {", ap.Name)
+			pn("		delete(p.p, \"%s\")", ap.Name)
+			pn("	}")
+			pn("}")
+			pn("")
+
 			pn("func (p *%s) Get%s() (%s, bool) {", capitalize(a.Name+"Params"), capitalize(ap.Name), mapType(a.Name, ap.Name, ap.Type))
 			pn("	if p.p == nil {")
 			pn("		p.p = make(map[string]interface{})")


### PR DESCRIPTION
After merging PR https://github.com/apache/cloudstack-go/pull/80 , optional params always needs to be set.
In case of the optional parameter of type UUID, the only option is to set the value to an empty string. This results in a request to ACS with the optional parameter in the request with an empty string. ACS throws an error because it can't find the associated id in the database.

Actual change is only in `generate.go`. Rest of the changes are in generated code.