### PR TITLE
Use POST for user sensitive calls

### DIFF
--- a/cloudstack/UserService.go
+++ b/cloudstack/UserService.go
@@ -243,7 +243,7 @@ func (s *UserService) NewCreateUserParams(account string, email string, firstnam
 
 // Creates a user for an account that already exists
 func (s *UserService) CreateUser(p *CreateUserParams) (*CreateUserResponse, error) {
-	resp, err := s.cs.newRequest("createUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1478,7 +1478,7 @@ func (s *UserService) NewUpdateUserParams(id string) *UpdateUserParams {
 
 // Updates a user account
 func (s *UserService) UpdateUser(p *UpdateUserParams) (*UpdateUserResponse, error) {
-	resp, err := s.cs.newRequest("updateUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VPNService.go
+++ b/cloudstack/VPNService.go
@@ -191,7 +191,7 @@ func (s *VPNService) NewAddVpnUserParams(password string, username string) *AddV
 
 // Adds vpn users
 func (s *VPNService) AddVpnUser(p *AddVpnUserParams) (*AddVpnUserResponse, error) {
-	resp, err := s.cs.newRequest("addVpnUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addVpnUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -58,6 +58,20 @@ var detailsRequireZeroIndex = map[string]bool{
 	"updateAccount":    true,
 }
 
+// requiresPost is a prefilled set of API names that require POST
+// for security or size purposes
+var requiresPostMethod = map[string]bool{
+	"login":                            true,
+	"deployVirtualMachine":             true,
+	"updateVirtualMachine":             true,
+	"createUser":                       true,
+	"updateUser":                       true,
+	"addVpnUser":                       true,
+	"registerUserData":                 true,
+	"setupUserTwoFactorAuthentication": true,
+	"validateUserTwoFactorAuthenticationCode": true,
+}
+
 var mapRequireList = map[string]map[string]bool{
 	"deployVirtualMachine": map[string]bool{
 		"dhcpoptionsnetworklist": true,
@@ -1698,7 +1712,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 		pn("		time.Sleep(500 * time.Millisecond)")
 		pn("	}")
 	} else {
-		if a.Name == "deployVirtualMachine" || a.Name == "login" || a.Name == "updateVirtualMachine" {
+		if requiresPostMethod[a.Name] {
 			pn("	resp, err := s.cs.newPostRequest(\"%s\", p.toURLValues())", a.Name)
 		} else {
 			pn("	resp, err := s.cs.newRequest(\"%s\", p.toURLValues())", a.Name)


### PR DESCRIPTION
Add a set to contain the API names that should use POST. Not all defined API names here are actually generated by this client yet (namely the 2FA and registerUserData APIs), but would want to be POST when they're introduced.

Note this also fixes a typo in the listApis.json which actually resides [upstream core cloudstack](https://github.com/apache/cloudstack/tree/main/plugins/network-elements/opendaylight/src/main/java/org/apache/cloudstack/network/opendaylight/api/commands), in the "OpenDaylight" API descriptions.

It seems `listApis.json` was recently updated without calling generate, because without fixing the typo here it wants to introduce the typo into the generated code. So I am stuck with a choice between committing a change to listApis or committing a typo to the generated bindings.