### PR TITLE
fix(userdatadetails): Fix userdatatails to create all files

### DIFF
--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -9801,8 +9801,7 @@ func (p *UpdateVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {


### PR DESCRIPTION
Hi, i have a problem to create metadata files with userdatadetails, with the current configuration it is creating only one key file and one value file, this way:
![Image](https://github.com/user-attachments/assets/e1c371ee-3da6-4447-a8d5-d6df77614096)

current code:
https://github.com/apache/cloudstack-go/blob/bfc6c0cc51d3cb3846af4b94239944c76c2264bf/cloudstack/VirtualMachineService.go#L1443
```go
if v, found := p.p["userdatadetails"]; found {
	m := v.(map[string]string)
	for i, k := range getSortedKeysFromMap(m) {
		u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
		u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
	}
}
```

the cloudstack api use with this form:

![Image](https://github.com/user-attachments/assets/6b595d0d-90e7-4814-a5cf-bda6ec584199)

to fix this problem is necessary change the code for this mode:


```go
if v, found := p.p["userdatadetails"]; found {
	m := v.(map[string]string)
	for i, k := range getSortedKeysFromMap(m) {
		u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
	}
}
```

The error have a big impact in my current work, if possible, correct it as soon as possible.
Thanks by attention, Lucas Batista - Wevy Cloud (Brazil)