### PR TITLE
Modify State Changing Requests to Utilize POST Request

### DIFF
--- a/cloudstack/ASNumberRangeService.go
+++ b/cloudstack/ASNumberRangeService.go
@@ -133,7 +133,7 @@ func (s *ASNumberRangeService) NewCreateASNRangeParams(endasn int64, startasn in
 
 // Creates a range of Autonomous Systems for BGP Dynamic Routing
 func (s *ASNumberRangeService) CreateASNRange(p *CreateASNRangeParams) (*CreateASNRangeResponse, error) {
-	resp, err := s.cs.newRequest("createASNRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createASNRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (s *ASNumberRangeService) NewDeleteASNRangeParams(id string) *DeleteASNRang
 
 // deletes a range of Autonomous Systems for BGP Dynamic Routing
 func (s *ASNumberRangeService) DeleteASNRange(p *DeleteASNRangeParams) (*DeleteASNRangeResponse, error) {
-	resp, err := s.cs.newRequest("deleteASNRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteASNRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ASNumberService.go
+++ b/cloudstack/ASNumberService.go
@@ -435,7 +435,7 @@ func (s *ASNumberService) NewReleaseASNumberParams(asnumber int64, zoneid string
 
 // Releases an AS Number back to the pool
 func (s *ASNumberService) ReleaseASNumber(p *ReleaseASNumberParams) (*ReleaseASNumberResponse, error) {
-	resp, err := s.cs.newRequest("releaseASNumber", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseASNumber", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -423,7 +423,7 @@ func (s *AccountService) NewCreateAccountParams(email string, firstname string, 
 
 // Creates an account
 func (s *AccountService) CreateAccount(p *CreateAccountParams) (*CreateAccountResponse, error) {
-	resp, err := s.cs.newRequest("createAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -579,7 +579,7 @@ func (s *AccountService) NewDeleteAccountParams(id string) *DeleteAccountParams 
 
 // Deletes a account, and all users associated with this account
 func (s *AccountService) DeleteAccount(p *DeleteAccountParams) (*DeleteAccountResponse, error) {
-	resp, err := s.cs.newRequest("deleteAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +734,7 @@ func (s *AccountService) NewDisableAccountParams(lock bool) *DisableAccountParam
 
 // Disables an account
 func (s *AccountService) DisableAccount(p *DisableAccountParams) (*DisableAccountResponse, error) {
-	resp, err := s.cs.newRequest("disableAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +953,7 @@ func (s *AccountService) NewEnableAccountParams() *EnableAccountParams {
 
 // Enables an account
 func (s *AccountService) EnableAccount(p *EnableAccountParams) (*EnableAccountResponse, error) {
-	resp, err := s.cs.newRequest("enableAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1104,7 +1104,7 @@ func (s *AccountService) NewIsAccountAllowedToCreateOfferingsWithTagsParams() *I
 
 // Return true if the specified account is allowed to create offerings with tags.
 func (s *AccountService) IsAccountAllowedToCreateOfferingsWithTags(p *IsAccountAllowedToCreateOfferingsWithTagsParams) (*IsAccountAllowedToCreateOfferingsWithTagsResponse, error) {
-	resp, err := s.cs.newRequest("isAccountAllowedToCreateOfferingsWithTags", p.toURLValues())
+	resp, err := s.cs.newPostRequest("isAccountAllowedToCreateOfferingsWithTags", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1317,7 +1317,7 @@ func (s *AccountService) NewLinkAccountToLdapParams(account string, domainid str
 
 // link a cloudstack account to a group or OU in ldap
 func (s *AccountService) LinkAccountToLdap(p *LinkAccountToLdapParams) (*LinkAccountToLdapResponse, error) {
-	resp, err := s.cs.newRequest("linkAccountToLdap", p.toURLValues())
+	resp, err := s.cs.newPostRequest("linkAccountToLdap", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2310,7 +2310,7 @@ func (s *AccountService) NewLockAccountParams(account string, domainid string) *
 
 // This deprecated function used to locks an account. Look for the API DisableAccount instead
 func (s *AccountService) LockAccount(p *LockAccountParams) (*LockAccountResponse, error) {
-	resp, err := s.cs.newRequest("lockAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("lockAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2512,7 +2512,7 @@ func (s *AccountService) NewMarkDefaultZoneForAccountParams(account string, doma
 
 // Marks a default zone for this account
 func (s *AccountService) MarkDefaultZoneForAccount(p *MarkDefaultZoneForAccountParams) (*MarkDefaultZoneForAccountResponse, error) {
-	resp, err := s.cs.newRequest("markDefaultZoneForAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("markDefaultZoneForAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2830,7 +2830,7 @@ func (s *AccountService) NewUpdateAccountParams() *UpdateAccountParams {
 
 // Updates account information for the authenticated user
 func (s *AccountService) UpdateAccount(p *UpdateAccountParams) (*UpdateAccountResponse, error) {
-	resp, err := s.cs.newRequest("updateAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AccountService.go
+++ b/cloudstack/AccountService.go
@@ -1104,7 +1104,7 @@ func (s *AccountService) NewIsAccountAllowedToCreateOfferingsWithTagsParams() *I
 
 // Return true if the specified account is allowed to create offerings with tags.
 func (s *AccountService) IsAccountAllowedToCreateOfferingsWithTags(p *IsAccountAllowedToCreateOfferingsWithTagsParams) (*IsAccountAllowedToCreateOfferingsWithTagsResponse, error) {
-	resp, err := s.cs.newPostRequest("isAccountAllowedToCreateOfferingsWithTags", p.toURLValues())
+	resp, err := s.cs.newRequest("isAccountAllowedToCreateOfferingsWithTags", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AddressService.go
+++ b/cloudstack/AddressService.go
@@ -118,7 +118,7 @@ func (s *AddressService) NewAcquirePodIpAddressParams(zoneid string) *AcquirePod
 
 // Allocates IP addresses in respective Pod of a Zone
 func (s *AddressService) AcquirePodIpAddress(p *AcquirePodIpAddressParams) (*AcquirePodIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("acquirePodIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("acquirePodIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (s *AddressService) NewAssociateIpAddressParams() *AssociateIpAddressParams
 
 // Acquires and associates a public IP to an account.
 func (s *AddressService) AssociateIpAddress(p *AssociateIpAddressParams) (*AssociateIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("associateIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("associateIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +554,7 @@ func (s *AddressService) NewDisassociateIpAddressParams(id string) *Disassociate
 
 // Disassociates an IP address from the account.
 func (s *AddressService) DisassociateIpAddress(p *DisassociateIpAddressParams) (*DisassociateIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("disassociateIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disassociateIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1440,7 +1440,7 @@ func (s *AddressService) NewUpdateIpAddressParams(id string) *UpdateIpAddressPar
 
 // Updates an IP address
 func (s *AddressService) UpdateIpAddress(p *UpdateIpAddressParams) (*UpdateIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("updateIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1562,7 +1562,7 @@ func (s *AddressService) NewReleaseIpAddressParams(id string) *ReleaseIpAddressP
 
 // Releases an IP address from the account.
 func (s *AddressService) ReleaseIpAddress(p *ReleaseIpAddressParams) (*ReleaseIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("releaseIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1657,7 +1657,7 @@ func (s *AddressService) NewReleasePodIpAddressParams(id int64) *ReleasePodIpAdd
 
 // Releases a Pod IP back to the Pod
 func (s *AddressService) ReleasePodIpAddress(p *ReleasePodIpAddressParams) (*ReleasePodIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("releasePodIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releasePodIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1848,7 +1848,7 @@ func (s *AddressService) NewReserveIpAddressParams(id string) *ReserveIpAddressP
 
 // Reserve a public IP to an account.
 func (s *AddressService) ReserveIpAddress(p *ReserveIpAddressParams) (*ReserveIpAddressResponse, error) {
-	resp, err := s.cs.newRequest("reserveIpAddress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("reserveIpAddress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AffinityGroupService.go
+++ b/cloudstack/AffinityGroupService.go
@@ -211,7 +211,7 @@ func (s *AffinityGroupService) NewCreateAffinityGroupParams(name string, affinit
 
 // Creates an affinity/anti-affinity group
 func (s *AffinityGroupService) CreateAffinityGroup(p *CreateAffinityGroupParams) (*CreateAffinityGroupResponse, error) {
-	resp, err := s.cs.newRequest("createAffinityGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createAffinityGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +403,7 @@ func (s *AffinityGroupService) NewDeleteAffinityGroupParams() *DeleteAffinityGro
 
 // Deletes affinity group
 func (s *AffinityGroupService) DeleteAffinityGroup(p *DeleteAffinityGroupParams) (*DeleteAffinityGroupResponse, error) {
-	resp, err := s.cs.newRequest("deleteAffinityGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAffinityGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1095,7 +1095,7 @@ func (s *AffinityGroupService) NewUpdateVMAffinityGroupParams(id string) *Update
 
 // Updates the affinity/anti-affinity group associations of a virtual machine. The VM has to be stopped and restarted for the new properties to take effect.
 func (s *AffinityGroupService) UpdateVMAffinityGroup(p *UpdateVMAffinityGroupParams) (*UpdateVMAffinityGroupResponse, error) {
-	resp, err := s.cs.newRequest("updateVMAffinityGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVMAffinityGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AlertService.go
+++ b/cloudstack/AlertService.go
@@ -162,7 +162,7 @@ func (s *AlertService) NewArchiveAlertsParams() *ArchiveAlertsParams {
 
 // Archive one or more alerts.
 func (s *AlertService) ArchiveAlerts(p *ArchiveAlertsParams) (*ArchiveAlertsResponse, error) {
-	resp, err := s.cs.newRequest("archiveAlerts", p.toURLValues())
+	resp, err := s.cs.newPostRequest("archiveAlerts", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (s *AlertService) NewDeleteAlertsParams() *DeleteAlertsParams {
 
 // Delete one or more alerts.
 func (s *AlertService) DeleteAlerts(p *DeleteAlertsParams) (*DeleteAlertsResponse, error) {
-	resp, err := s.cs.newRequest("deleteAlerts", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAlerts", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +521,7 @@ func (s *AlertService) NewGenerateAlertParams(description string, name string, a
 
 // Generates an alert
 func (s *AlertService) GenerateAlert(p *GenerateAlertParams) (*GenerateAlertResponse, error) {
-	resp, err := s.cs.newRequest("generateAlert", p.toURLValues())
+	resp, err := s.cs.newPostRequest("generateAlert", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AnnotationService.go
+++ b/cloudstack/AnnotationService.go
@@ -158,7 +158,7 @@ func (s *AnnotationService) NewAddAnnotationParams() *AddAnnotationParams {
 
 // add an annotation.
 func (s *AnnotationService) AddAnnotation(p *AddAnnotationParams) (*AddAnnotationResponse, error) {
-	resp, err := s.cs.newRequest("addAnnotation", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addAnnotation", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -519,7 +519,7 @@ func (s *AnnotationService) NewRemoveAnnotationParams(id string) *RemoveAnnotati
 
 // remove an annotation.
 func (s *AnnotationService) RemoveAnnotation(p *RemoveAnnotationParams) (*RemoveAnnotationResponse, error) {
-	resp, err := s.cs.newRequest("removeAnnotation", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeAnnotation", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +624,7 @@ func (s *AnnotationService) NewUpdateAnnotationVisibilityParams(adminsonly bool,
 
 // update an annotation visibility.
 func (s *AnnotationService) UpdateAnnotationVisibility(p *UpdateAnnotationVisibilityParams) (*UpdateAnnotationVisibilityResponse, error) {
-	resp, err := s.cs.newRequest("updateAnnotationVisibility", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateAnnotationVisibility", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AuthenticationService.go
+++ b/cloudstack/AuthenticationService.go
@@ -211,7 +211,7 @@ func (s *AuthenticationService) NewLogoutParams() *LogoutParams {
 
 // Logs out the user
 func (s *AuthenticationService) Logout(p *LogoutParams) (*LogoutResponse, error) {
-	resp, err := s.cs.newRequest("logout", p.toURLValues())
+	resp, err := s.cs.newPostRequest("logout", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (s *AuthenticationService) NewOauthloginParams(email string, provider strin
 
 // Logs a user into the CloudStack after successful verification of OAuth secret code from the particular provider.A successful login attempt will generate a JSESSIONID cookie value that can be passed in subsequent Query command calls until the "logout" command has been issued or the session has expired.
 func (s *AuthenticationService) Oauthlogin(p *OauthloginParams) (*OauthloginResponse, error) {
-	resp, err := s.cs.newRequest("oauthlogin", p.toURLValues())
+	resp, err := s.cs.newPostRequest("oauthlogin", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -231,7 +231,7 @@ func (s *AutoScaleService) NewCreateAutoScalePolicyParams(action string, conditi
 
 // Creates an autoscale policy for a provision or deprovision action, the action is taken when the all the conditions evaluates to true for the specified duration. The policy is in effect once it is attached to a autscale vm group.
 func (s *AutoScaleService) CreateAutoScalePolicy(p *CreateAutoScalePolicyParams) (*CreateAutoScalePolicyResponse, error) {
-	resp, err := s.cs.newRequest("createAutoScalePolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createAutoScalePolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +531,7 @@ func (s *AutoScaleService) NewCreateAutoScaleVmGroupParams(lbruleid string, maxm
 
 // Creates and automatically starts a virtual machine based on a service offering, disk offering, and template.
 func (s *AutoScaleService) CreateAutoScaleVmGroup(p *CreateAutoScaleVmGroupParams) (*CreateAutoScaleVmGroupResponse, error) {
-	resp, err := s.cs.newRequest("createAutoScaleVmGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createAutoScaleVmGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -971,7 +971,7 @@ func (s *AutoScaleService) NewCreateAutoScaleVmProfileParams(serviceofferingid s
 
 // Creates a profile that contains information about the virtual machine which will be provisioned automatically by autoscale feature.
 func (s *AutoScaleService) CreateAutoScaleVmProfile(p *CreateAutoScaleVmProfileParams) (*CreateAutoScaleVmProfileResponse, error) {
-	resp, err := s.cs.newRequest("createAutoScaleVmProfile", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createAutoScaleVmProfile", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1198,7 +1198,7 @@ func (s *AutoScaleService) NewCreateConditionParams(counterid string, relational
 
 // Creates a condition for VM auto scaling
 func (s *AutoScaleService) CreateCondition(p *CreateConditionParams) (*CreateConditionResponse, error) {
-	resp, err := s.cs.newRequest("createCondition", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createCondition", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1371,7 +1371,7 @@ func (s *AutoScaleService) NewCreateCounterParams(name string, provider string, 
 
 // Adds metric counter for VM auto scaling
 func (s *AutoScaleService) CreateCounter(p *CreateCounterParams) (*CreateCounterResponse, error) {
-	resp, err := s.cs.newRequest("createCounter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createCounter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1462,7 +1462,7 @@ func (s *AutoScaleService) NewDeleteAutoScalePolicyParams(id string) *DeleteAuto
 
 // Deletes a autoscale policy.
 func (s *AutoScaleService) DeleteAutoScalePolicy(p *DeleteAutoScalePolicyParams) (*DeleteAutoScalePolicyResponse, error) {
-	resp, err := s.cs.newRequest("deleteAutoScalePolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAutoScalePolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1569,7 +1569,7 @@ func (s *AutoScaleService) NewDeleteAutoScaleVmGroupParams(id string) *DeleteAut
 
 // Deletes a autoscale vm group.
 func (s *AutoScaleService) DeleteAutoScaleVmGroup(p *DeleteAutoScaleVmGroupParams) (*DeleteAutoScaleVmGroupResponse, error) {
-	resp, err := s.cs.newRequest("deleteAutoScaleVmGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAutoScaleVmGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1651,7 +1651,7 @@ func (s *AutoScaleService) NewDeleteAutoScaleVmProfileParams(id string) *DeleteA
 
 // Deletes a autoscale vm profile.
 func (s *AutoScaleService) DeleteAutoScaleVmProfile(p *DeleteAutoScaleVmProfileParams) (*DeleteAutoScaleVmProfileResponse, error) {
-	resp, err := s.cs.newRequest("deleteAutoScaleVmProfile", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAutoScaleVmProfile", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1733,7 +1733,7 @@ func (s *AutoScaleService) NewDeleteConditionParams(id string) *DeleteConditionP
 
 // Removes a condition for VM auto scaling
 func (s *AutoScaleService) DeleteCondition(p *DeleteConditionParams) (*DeleteConditionResponse, error) {
-	resp, err := s.cs.newRequest("deleteCondition", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteCondition", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1815,7 +1815,7 @@ func (s *AutoScaleService) NewDeleteCounterParams(id string) *DeleteCounterParam
 
 // Deletes a counter for VM auto scaling
 func (s *AutoScaleService) DeleteCounter(p *DeleteCounterParams) (*DeleteCounterResponse, error) {
-	resp, err := s.cs.newRequest("deleteCounter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteCounter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1897,7 +1897,7 @@ func (s *AutoScaleService) NewDisableAutoScaleVmGroupParams(id string) *DisableA
 
 // Disables an AutoScale Vm Group
 func (s *AutoScaleService) DisableAutoScaleVmGroup(p *DisableAutoScaleVmGroupParams) (*DisableAutoScaleVmGroupResponse, error) {
-	resp, err := s.cs.newRequest("disableAutoScaleVmGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableAutoScaleVmGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2009,7 +2009,7 @@ func (s *AutoScaleService) NewEnableAutoScaleVmGroupParams(id string) *EnableAut
 
 // Enables an AutoScale Vm Group
 func (s *AutoScaleService) EnableAutoScaleVmGroup(p *EnableAutoScaleVmGroupParams) (*EnableAutoScaleVmGroupResponse, error) {
-	resp, err := s.cs.newRequest("enableAutoScaleVmGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableAutoScaleVmGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4297,7 +4297,7 @@ func (s *AutoScaleService) NewUpdateAutoScalePolicyParams(id string) *UpdateAuto
 
 // Updates an existing autoscale policy.
 func (s *AutoScaleService) UpdateAutoScalePolicy(p *UpdateAutoScalePolicyParams) (*UpdateAutoScalePolicyResponse, error) {
-	resp, err := s.cs.newRequest("updateAutoScalePolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateAutoScalePolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4592,7 +4592,7 @@ func (s *AutoScaleService) NewUpdateAutoScaleVmGroupParams(id string) *UpdateAut
 
 // Updates an existing autoscale vm group.
 func (s *AutoScaleService) UpdateAutoScaleVmGroup(p *UpdateAutoScaleVmGroupParams) (*UpdateAutoScaleVmGroupResponse, error) {
-	resp, err := s.cs.newRequest("updateAutoScaleVmGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateAutoScaleVmGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4982,7 +4982,7 @@ func (s *AutoScaleService) NewUpdateAutoScaleVmProfileParams(id string) *UpdateA
 
 // Updates an existing autoscale vm profile.
 func (s *AutoScaleService) UpdateAutoScaleVmProfile(p *UpdateAutoScaleVmProfileParams) (*UpdateAutoScaleVmProfileResponse, error) {
-	resp, err := s.cs.newRequest("updateAutoScaleVmProfile", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateAutoScaleVmProfile", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5137,7 +5137,7 @@ func (s *AutoScaleService) NewUpdateConditionParams(id string, relationaloperato
 
 // Updates a condition for VM auto scaling
 func (s *AutoScaleService) UpdateCondition(p *UpdateConditionParams) (*UpdateConditionResponse, error) {
-	resp, err := s.cs.newRequest("updateCondition", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateCondition", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/BGPPeerService.go
+++ b/cloudstack/BGPPeerService.go
@@ -117,7 +117,7 @@ func (s *BGPPeerService) NewChangeBgpPeersForVpcParams(vpcid string) *ChangeBgpP
 
 // Change the BGP peers for a VPC.
 func (s *BGPPeerService) ChangeBgpPeersForVpc(p *ChangeBgpPeersForVpcParams) (*ChangeBgpPeersForVpcResponse, error) {
-	resp, err := s.cs.newRequest("changeBgpPeersForVpc", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeBgpPeersForVpc", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,7 @@ func (s *BGPPeerService) NewCreateBgpPeerParams(asnumber int64, zoneid string) *
 
 // Creates a Bgp Peer for a zone.
 func (s *BGPPeerService) CreateBgpPeer(p *CreateBgpPeerParams) (*CreateBgpPeerResponse, error) {
-	resp, err := s.cs.newRequest("createBgpPeer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createBgpPeer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (s *BGPPeerService) NewDedicateBgpPeerParams(id string) *DedicateBgpPeerPar
 
 // Dedicates an existing Bgp Peer to an account or a domain.
 func (s *BGPPeerService) DedicateBgpPeer(p *DedicateBgpPeerParams) (*DedicateBgpPeerResponse, error) {
-	resp, err := s.cs.newRequest("dedicateBgpPeer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicateBgpPeer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -683,7 +683,7 @@ func (s *BGPPeerService) NewDeleteBgpPeerParams(id string) *DeleteBgpPeerParams 
 
 // Deletes an existing Bgp Peer.
 func (s *BGPPeerService) DeleteBgpPeer(p *DeleteBgpPeerParams) (*DeleteBgpPeerResponse, error) {
-	resp, err := s.cs.newRequest("deleteBgpPeer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteBgpPeer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1101,7 +1101,7 @@ func (s *BGPPeerService) NewReleaseBgpPeerParams(id string) *ReleaseBgpPeerParam
 
 // Releases an existing dedicated Bgp Peer.
 func (s *BGPPeerService) ReleaseBgpPeer(p *ReleaseBgpPeerParams) (*ReleaseBgpPeerResponse, error) {
-	resp, err := s.cs.newRequest("releaseBgpPeer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseBgpPeer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1349,7 +1349,7 @@ func (s *BGPPeerService) NewUpdateBgpPeerParams(id string) *UpdateBgpPeerParams 
 
 // Updates an existing Bgp Peer.
 func (s *BGPPeerService) UpdateBgpPeer(p *UpdateBgpPeerParams) (*UpdateBgpPeerResponse, error) {
-	resp, err := s.cs.newRequest("updateBgpPeer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateBgpPeer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/BaremetalService.go
+++ b/cloudstack/BaremetalService.go
@@ -193,7 +193,7 @@ func (s *BaremetalService) NewAddBaremetalDhcpParams(dhcpservertype string, pass
 
 // adds a baremetal dhcp server
 func (s *BaremetalService) AddBaremetalDhcp(p *AddBaremetalDhcpParams) (*AddBaremetalDhcpResponse, error) {
-	resp, err := s.cs.newRequest("addBaremetalDhcp", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBaremetalDhcp", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (s *BaremetalService) NewAddBaremetalPxeKickStartServerParams(password stri
 
 // add a baremetal pxe server
 func (s *BaremetalService) AddBaremetalPxeKickStartServer(p *AddBaremetalPxeKickStartServerParams) (*AddBaremetalPxeKickStartServerResponse, error) {
-	resp, err := s.cs.newRequest("addBaremetalPxeKickStartServer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBaremetalPxeKickStartServer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +769,7 @@ func (s *BaremetalService) NewAddBaremetalPxePingServerParams(password string, p
 
 // add a baremetal ping pxe server
 func (s *BaremetalService) AddBaremetalPxePingServer(p *AddBaremetalPxePingServerParams) (*AddBaremetalPxePingServerResponse, error) {
-	resp, err := s.cs.newRequest("addBaremetalPxePingServer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBaremetalPxePingServer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -861,7 +861,7 @@ func (s *BaremetalService) NewAddBaremetalRctParams(baremetalrcturl string) *Add
 
 // adds baremetal rack configuration text
 func (s *BaremetalService) AddBaremetalRct(p *AddBaremetalRctParams) (*AddBaremetalRctResponse, error) {
-	resp, err := s.cs.newRequest("addBaremetalRct", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBaremetalRct", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -948,7 +948,7 @@ func (s *BaremetalService) NewDeleteBaremetalRctParams(id string) *DeleteBaremet
 
 // deletes baremetal rack configuration text
 func (s *BaremetalService) DeleteBaremetalRct(p *DeleteBaremetalRctParams) (*DeleteBaremetalRctResponse, error) {
-	resp, err := s.cs.newRequest("deleteBaremetalRct", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteBaremetalRct", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1522,7 +1522,7 @@ func (s *BaremetalService) NewNotifyBaremetalProvisionDoneParams(mac string) *No
 
 // Notify provision has been done on a host. This api is for baremetal virtual router service, not for end user
 func (s *BaremetalService) NotifyBaremetalProvisionDone(p *NotifyBaremetalProvisionDoneParams) (*NotifyBaremetalProvisionDoneResponse, error) {
-	resp, err := s.cs.newRequest("notifyBaremetalProvisionDone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("notifyBaremetalProvisionDone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/BigSwitchBCFService.go
+++ b/cloudstack/BigSwitchBCFService.go
@@ -182,7 +182,7 @@ func (s *BigSwitchBCFService) NewAddBigSwitchBcfDeviceParams(hostname string, na
 
 // Adds a BigSwitch BCF Controller device
 func (s *BigSwitchBCFService) AddBigSwitchBcfDevice(p *AddBigSwitchBcfDeviceParams) (*AddBigSwitchBcfDeviceResponse, error) {
-	resp, err := s.cs.newRequest("addBigSwitchBcfDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBigSwitchBcfDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (s *BigSwitchBCFService) NewDeleteBigSwitchBcfDeviceParams(bcfdeviceid stri
 
 // delete a BigSwitch BCF Controller device
 func (s *BigSwitchBCFService) DeleteBigSwitchBcfDevice(p *DeleteBigSwitchBcfDeviceParams) (*DeleteBigSwitchBcfDeviceResponse, error) {
-	resp, err := s.cs.newRequest("deleteBigSwitchBcfDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteBigSwitchBcfDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/BrocadeVCSService.go
+++ b/cloudstack/BrocadeVCSService.go
@@ -160,7 +160,7 @@ func (s *BrocadeVCSService) NewAddBrocadeVcsDeviceParams(hostname string, passwo
 
 // Adds a Brocade VCS Switch
 func (s *BrocadeVCSService) AddBrocadeVcsDevice(p *AddBrocadeVcsDeviceParams) (*AddBrocadeVcsDeviceResponse, error) {
-	resp, err := s.cs.newRequest("addBrocadeVcsDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBrocadeVcsDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (s *BrocadeVCSService) NewDeleteBrocadeVcsDeviceParams(vcsdeviceid string) 
 
 // delete a Brocade VCS Switch
 func (s *BrocadeVCSService) DeleteBrocadeVcsDevice(p *DeleteBrocadeVcsDeviceParams) (*DeleteBrocadeVcsDeviceResponse, error) {
-	resp, err := s.cs.newRequest("deleteBrocadeVcsDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteBrocadeVcsDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/CertificateService.go
+++ b/cloudstack/CertificateService.go
@@ -194,7 +194,7 @@ func (s *CertificateService) NewIssueCertificateParams() *IssueCertificateParams
 
 // Issues a client certificate using configured or provided CA plugin
 func (s *CertificateService) IssueCertificate(p *IssueCertificateParams) (*IssueCertificateResponse, error) {
-	resp, err := s.cs.newRequest("issueCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("issueCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -710,7 +710,7 @@ func (s *CertificateService) NewProvisionCertificateParams(hostid string) *Provi
 
 // Issues and propagates client certificate on a connected host/agent using configured CA plugin
 func (s *CertificateService) ProvisionCertificate(p *ProvisionCertificateParams) (*ProvisionCertificateResponse, error) {
-	resp, err := s.cs.newRequest("provisionCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("provisionCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -817,7 +817,7 @@ func (s *CertificateService) NewProvisionTemplateDirectDownloadCertificateParams
 
 // Provisions a host with a direct download certificate
 func (s *CertificateService) ProvisionTemplateDirectDownloadCertificate(p *ProvisionTemplateDirectDownloadCertificateParams) (*ProvisionTemplateDirectDownloadCertificateResponse, error) {
-	resp, err := s.cs.newRequest("provisionTemplateDirectDownloadCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("provisionTemplateDirectDownloadCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -934,7 +934,7 @@ func (s *CertificateService) NewRevokeCertificateParams(serial string) *RevokeCe
 
 // Revokes certificate using configured CA plugin
 func (s *CertificateService) RevokeCertificate(p *RevokeCertificateParams) (*RevokeCertificateResponse, error) {
-	resp, err := s.cs.newRequest("revokeCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("revokeCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1112,7 +1112,7 @@ func (s *CertificateService) NewRevokeTemplateDirectDownloadCertificateParams(zo
 
 // Revoke a direct download certificate from hosts in a zone
 func (s *CertificateService) RevokeTemplateDirectDownloadCertificate(p *RevokeTemplateDirectDownloadCertificateParams) (*RevokeTemplateDirectDownloadCertificateResponse, error) {
-	resp, err := s.cs.newRequest("revokeTemplateDirectDownloadCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("revokeTemplateDirectDownloadCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1279,7 +1279,7 @@ func (s *CertificateService) NewUploadCustomCertificateParams(certificate string
 
 // Uploads a custom certificate for the console proxy VMs to use for SSL. Can be used to upload a single certificate signed by a known CA. Can also be used, through multiple calls, to upload a chain of certificates from CA to the custom certificate itself.
 func (s *CertificateService) UploadCustomCertificate(p *UploadCustomCertificateParams) (*UploadCustomCertificateResponse, error) {
-	resp, err := s.cs.newRequest("uploadCustomCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("uploadCustomCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1464,7 +1464,7 @@ func (s *CertificateService) NewUploadTemplateDirectDownloadCertificateParams(ce
 
 // Upload a certificate for HTTPS direct template download on KVM hosts
 func (s *CertificateService) UploadTemplateDirectDownloadCertificate(p *UploadTemplateDirectDownloadCertificateParams) (*UploadTemplateDirectDownloadCertificateResponse, error) {
-	resp, err := s.cs.newRequest("uploadTemplateDirectDownloadCertificate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("uploadTemplateDirectDownloadCertificate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/CloudianService.go
+++ b/cloudstack/CloudianService.go
@@ -51,7 +51,7 @@ func (s *CloudianService) NewCloudianIsEnabledParams() *CloudianIsEnabledParams 
 
 // Checks if the Cloudian Connector is enabled
 func (s *CloudianService) CloudianIsEnabled(p *CloudianIsEnabledParams) (*CloudianIsEnabledResponse, error) {
-	resp, err := s.cs.newRequest("cloudianIsEnabled", p.toURLValues())
+	resp, err := s.cs.newPostRequest("cloudianIsEnabled", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/CloudianService.go
+++ b/cloudstack/CloudianService.go
@@ -51,7 +51,7 @@ func (s *CloudianService) NewCloudianIsEnabledParams() *CloudianIsEnabledParams 
 
 // Checks if the Cloudian Connector is enabled
 func (s *CloudianService) CloudianIsEnabled(p *CloudianIsEnabledParams) (*CloudianIsEnabledResponse, error) {
-	resp, err := s.cs.newPostRequest("cloudianIsEnabled", p.toURLValues())
+	resp, err := s.cs.newRequest("cloudianIsEnabled", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -574,7 +574,7 @@ func (s *ClusterService) NewAddClusterParams(clustername string, clustertype str
 
 // Adds a new cluster
 func (s *ClusterService) AddCluster(p *AddClusterParams) (*AddClusterResponse, error) {
-	resp, err := s.cs.newRequest("addCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +725,7 @@ func (s *ClusterService) NewDedicateClusterParams(clusterid string, domainid str
 
 // Dedicate an existing cluster
 func (s *ClusterService) DedicateCluster(p *DedicateClusterParams) (*DedicateClusterResponse, error) {
-	resp, err := s.cs.newRequest("dedicateCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicateCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (s *ClusterService) NewDeleteClusterParams(id string) *DeleteClusterParams 
 
 // Deletes a cluster.
 func (s *ClusterService) DeleteCluster(p *DeleteClusterParams) (*DeleteClusterResponse, error) {
-	resp, err := s.cs.newRequest("deleteCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -910,7 +910,7 @@ func (s *ClusterService) NewDisableOutOfBandManagementForClusterParams(clusterid
 
 // Disables out-of-band management for a cluster
 func (s *ClusterService) DisableOutOfBandManagementForCluster(p *DisableOutOfBandManagementForClusterParams) (*DisableOutOfBandManagementForClusterResponse, error) {
-	resp, err := s.cs.newRequest("disableOutOfBandManagementForCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableOutOfBandManagementForCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1006,7 +1006,7 @@ func (s *ClusterService) NewEnableOutOfBandManagementForClusterParams(clusterid 
 
 // Enables out-of-band management for a cluster
 func (s *ClusterService) EnableOutOfBandManagementForCluster(p *EnableOutOfBandManagementForClusterParams) (*EnableOutOfBandManagementForClusterResponse, error) {
-	resp, err := s.cs.newRequest("enableOutOfBandManagementForCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableOutOfBandManagementForCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1102,7 +1102,7 @@ func (s *ClusterService) NewEnableHAForClusterParams(clusterid string) *EnableHA
 
 // Enables HA cluster-wide
 func (s *ClusterService) EnableHAForCluster(p *EnableHAForClusterParams) (*EnableHAForClusterResponse, error) {
-	resp, err := s.cs.newRequest("enableHAForCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableHAForCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1212,7 +1212,7 @@ func (s *ClusterService) NewExecuteClusterDrsPlanParams(id string) *ExecuteClust
 
 // Execute DRS for a cluster. If there is another plan in progress for the same cluster, this command will fail.
 func (s *ClusterService) ExecuteClusterDrsPlan(p *ExecuteClusterDrsPlanParams) (*ExecuteClusterDrsPlanResponse, error) {
-	resp, err := s.cs.newRequest("executeClusterDrsPlan", p.toURLValues())
+	resp, err := s.cs.newPostRequest("executeClusterDrsPlan", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1328,7 +1328,7 @@ func (s *ClusterService) NewGenerateClusterDrsPlanParams(id string) *GenerateClu
 
 // Generate DRS plan for a cluster
 func (s *ClusterService) GenerateClusterDrsPlan(p *GenerateClusterDrsPlanParams) (*GenerateClusterDrsPlanResponse, error) {
-	resp, err := s.cs.newRequest("generateClusterDrsPlan", p.toURLValues())
+	resp, err := s.cs.newPostRequest("generateClusterDrsPlan", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1399,7 +1399,7 @@ func (s *ClusterService) NewDisableHAForClusterParams(clusterid string) *Disable
 
 // Disables HA cluster-wide
 func (s *ClusterService) DisableHAForCluster(p *DisableHAForClusterParams) (*DisableHAForClusterResponse, error) {
-	resp, err := s.cs.newRequest("disableHAForCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableHAForCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2831,7 +2831,7 @@ func (s *ClusterService) NewReleaseDedicatedClusterParams(clusterid string) *Rel
 
 // Release the dedication for cluster
 func (s *ClusterService) ReleaseDedicatedCluster(p *ReleaseDedicatedClusterParams) (*ReleaseDedicatedClusterResponse, error) {
-	resp, err := s.cs.newRequest("releaseDedicatedCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseDedicatedCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3057,7 +3057,7 @@ func (s *ClusterService) NewUpdateClusterParams(id string) *UpdateClusterParams 
 
 // Updates an existing cluster
 func (s *ClusterService) UpdateCluster(p *UpdateClusterParams) (*UpdateClusterResponse, error) {
-	resp, err := s.cs.newRequest("updateCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ConfigurationService.go
+++ b/cloudstack/ConfigurationService.go
@@ -999,7 +999,7 @@ func (s *ConfigurationService) NewUpdateConfigurationParams(name string) *Update
 
 // Updates a configuration.
 func (s *ConfigurationService) UpdateConfiguration(p *UpdateConfigurationParams) (*UpdateConfigurationResponse, error) {
-	resp, err := s.cs.newRequest("updateConfiguration", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateConfiguration", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1227,7 +1227,7 @@ func (s *ConfigurationService) NewResetConfigurationParams(name string) *ResetCo
 
 // Resets a configuration. The configuration will be set to default value for global setting, and removed from account_details or domain_details for Account/Domain settings
 func (s *ConfigurationService) ResetConfiguration(p *ResetConfigurationParams) (*ResetConfigurationResponse, error) {
-	resp, err := s.cs.newRequest("resetConfiguration", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetConfiguration", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1307,7 +1307,7 @@ func (s *ConfigurationService) NewUpdateStorageCapabilitiesParams(id string) *Up
 
 // Syncs capabilities of storage pools
 func (s *ConfigurationService) UpdateStorageCapabilities(p *UpdateStorageCapabilitiesParams) (*UpdateStorageCapabilitiesResponse, error) {
-	resp, err := s.cs.newRequest("updateStorageCapabilities", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateStorageCapabilities", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ConsoleEndpointService.go
+++ b/cloudstack/ConsoleEndpointService.go
@@ -101,7 +101,7 @@ func (s *ConsoleEndpointService) NewCreateConsoleEndpointParams(virtualmachineid
 
 // Create a console endpoint to connect to a VM console
 func (s *ConsoleEndpointService) CreateConsoleEndpoint(p *CreateConsoleEndpointParams) (*CreateConsoleEndpointResponse, error) {
-	resp, err := s.cs.newRequest("createConsoleEndpoint", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createConsoleEndpoint", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/CustomService.go
+++ b/cloudstack/CustomService.go
@@ -77,7 +77,7 @@ func (p *CustomServiceParams) GetParam(param string) (interface{}, bool) {
 }
 
 func (s *CustomService) CustomRequest(api string, p *CustomServiceParams, result interface{}) error {
-	resp, err := s.cs.newRequest(api, p.toURLValues())
+	resp, err := s.cs.newPostRequest(api, p.toURLValues())
 	if err != nil {
 		return err
 	}

--- a/cloudstack/DiagnosticsService.go
+++ b/cloudstack/DiagnosticsService.go
@@ -264,7 +264,7 @@ func (s *DiagnosticsService) NewRunDiagnosticsParams(ipaddress string, targetid 
 
 // Execute network-utility command (ping/arping/tracert) on system VMs remotely
 func (s *DiagnosticsService) RunDiagnostics(p *RunDiagnosticsParams) (*RunDiagnosticsResponse, error) {
-	resp, err := s.cs.newRequest("runDiagnostics", p.toURLValues())
+	resp, err := s.cs.newPostRequest("runDiagnostics", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/DiskOfferingService.go
+++ b/cloudstack/DiskOfferingService.go
@@ -835,7 +835,7 @@ func (s *DiskOfferingService) NewCreateDiskOfferingParams(displaytext string, na
 
 // Creates a disk offering.
 func (s *DiskOfferingService) CreateDiskOffering(p *CreateDiskOfferingParams) (*CreateDiskOfferingResponse, error) {
-	resp, err := s.cs.newRequest("createDiskOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createDiskOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -942,7 +942,7 @@ func (s *DiskOfferingService) NewDeleteDiskOfferingParams(id string) *DeleteDisk
 
 // Updates a disk offering.
 func (s *DiskOfferingService) DeleteDiskOffering(p *DeleteDiskOfferingParams) (*DeleteDiskOfferingResponse, error) {
-	resp, err := s.cs.newRequest("deleteDiskOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteDiskOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2133,7 +2133,7 @@ func (s *DiskOfferingService) NewUpdateDiskOfferingParams(id string) *UpdateDisk
 
 // Updates a disk offering.
 func (s *DiskOfferingService) UpdateDiskOffering(p *UpdateDiskOfferingParams) (*UpdateDiskOfferingResponse, error) {
-	resp, err := s.cs.newRequest("updateDiskOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateDiskOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/DomainService.go
+++ b/cloudstack/DomainService.go
@@ -167,7 +167,7 @@ func (s *DomainService) NewCreateDomainParams(name string) *CreateDomainParams {
 
 // Creates a domain
 func (s *DomainService) CreateDomain(p *CreateDomainParams) (*CreateDomainResponse, error) {
-	resp, err := s.cs.newRequest("createDomain", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createDomain", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (s *DomainService) NewDeleteDomainParams(id string) *DeleteDomainParams {
 
 // Deletes a specified domain
 func (s *DomainService) DeleteDomain(p *DeleteDomainParams) (*DeleteDomainResponse, error) {
-	resp, err := s.cs.newRequest("deleteDomain", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteDomain", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1217,7 +1217,7 @@ func (s *DomainService) NewMoveDomainParams(domainid string, parentdomainid stri
 
 // Moves a domain and its children to a new parent domain.
 func (s *DomainService) MoveDomain(p *MoveDomainParams) (*MoveDomainResponse, error) {
-	resp, err := s.cs.newRequest("moveDomain", p.toURLValues())
+	resp, err := s.cs.newPostRequest("moveDomain", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1380,7 +1380,7 @@ func (s *DomainService) NewUpdateDomainParams(id string) *UpdateDomainParams {
 
 // Updates a domain with a new name
 func (s *DomainService) UpdateDomain(p *UpdateDomainParams) (*UpdateDomainResponse, error) {
-	resp, err := s.cs.newRequest("updateDomain", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateDomain", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/EventService.go
+++ b/cloudstack/EventService.go
@@ -158,7 +158,7 @@ func (s *EventService) NewArchiveEventsParams() *ArchiveEventsParams {
 
 // Archive one or more events.
 func (s *EventService) ArchiveEvents(p *ArchiveEventsParams) (*ArchiveEventsResponse, error) {
-	resp, err := s.cs.newRequest("archiveEvents", p.toURLValues())
+	resp, err := s.cs.newPostRequest("archiveEvents", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (s *EventService) NewDeleteEventsParams() *DeleteEventsParams {
 
 // Delete one or more events.
 func (s *EventService) DeleteEvents(p *DeleteEventsParams) (*DeleteEventsResponse, error) {
-	resp, err := s.cs.newRequest("deleteEvents", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteEvents", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -280,7 +280,7 @@ func (s *FirewallService) NewAddPaloAltoFirewallParams(networkdevicetype string,
 
 // Adds a Palo Alto firewall device
 func (s *FirewallService) AddPaloAltoFirewall(p *AddPaloAltoFirewallParams) (*AddPaloAltoFirewallResponse, error) {
-	resp, err := s.cs.newRequest("addPaloAltoFirewall", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addPaloAltoFirewall", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +411,7 @@ func (s *FirewallService) NewConfigurePaloAltoFirewallParams(fwdeviceid string) 
 
 // Configures a Palo Alto firewall device
 func (s *FirewallService) ConfigurePaloAltoFirewall(p *ConfigurePaloAltoFirewallParams) (*PaloAltoFirewallResponse, error) {
-	resp, err := s.cs.newRequest("configurePaloAltoFirewall", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configurePaloAltoFirewall", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func (s *FirewallService) NewCreateEgressFirewallRuleParams(networkid string, pr
 
 // Creates a egress firewall rule for a given network
 func (s *FirewallService) CreateEgressFirewallRule(p *CreateEgressFirewallRuleParams) (*CreateEgressFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("createEgressFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createEgressFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1045,7 +1045,7 @@ func (s *FirewallService) NewCreateFirewallRuleParams(ipaddressid string, protoc
 
 // Creates a firewall rule for a given IP address
 func (s *FirewallService) CreateFirewallRule(p *CreateFirewallRuleParams) (*CreateFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("createFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1425,7 +1425,7 @@ func (s *FirewallService) NewCreatePortForwardingRuleParams(ipaddressid string, 
 
 // Creates a port forwarding rule
 func (s *FirewallService) CreatePortForwardingRule(p *CreatePortForwardingRuleParams) (*CreatePortForwardingRuleResponse, error) {
-	resp, err := s.cs.newRequest("createPortForwardingRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createPortForwardingRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1756,7 +1756,7 @@ func (s *FirewallService) NewCreateRoutingFirewallRuleParams(networkid string, p
 
 // Creates a routing firewall rule in the given network in ROUTED mode
 func (s *FirewallService) CreateRoutingFirewallRule(p *CreateRoutingFirewallRuleParams) (*CreateRoutingFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("createRoutingFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createRoutingFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1863,7 +1863,7 @@ func (s *FirewallService) NewDeleteEgressFirewallRuleParams(id string) *DeleteEg
 
 // Deletes an egress firewall rule
 func (s *FirewallService) DeleteEgressFirewallRule(p *DeleteEgressFirewallRuleParams) (*DeleteEgressFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteEgressFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteEgressFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1950,7 +1950,7 @@ func (s *FirewallService) NewDeleteFirewallRuleParams(id string) *DeleteFirewall
 
 // Deletes a firewall rule
 func (s *FirewallService) DeleteFirewallRule(p *DeleteFirewallRuleParams) (*DeleteFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2037,7 +2037,7 @@ func (s *FirewallService) NewDeletePaloAltoFirewallParams(fwdeviceid string) *De
 
 // delete a Palo Alto firewall device
 func (s *FirewallService) DeletePaloAltoFirewall(p *DeletePaloAltoFirewallParams) (*DeletePaloAltoFirewallResponse, error) {
-	resp, err := s.cs.newRequest("deletePaloAltoFirewall", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deletePaloAltoFirewall", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2124,7 +2124,7 @@ func (s *FirewallService) NewDeletePortForwardingRuleParams(id string) *DeletePo
 
 // Deletes a port forwarding rule
 func (s *FirewallService) DeletePortForwardingRule(p *DeletePortForwardingRuleParams) (*DeletePortForwardingRuleResponse, error) {
-	resp, err := s.cs.newRequest("deletePortForwardingRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deletePortForwardingRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2211,7 +2211,7 @@ func (s *FirewallService) NewDeleteRoutingFirewallRuleParams(id string) *DeleteR
 
 // Deletes a routing firewall rule
 func (s *FirewallService) DeleteRoutingFirewallRule(p *DeleteRoutingFirewallRuleParams) (*DeleteRoutingFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteRoutingFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteRoutingFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4215,7 +4215,7 @@ func (s *FirewallService) NewUpdateEgressFirewallRuleParams(id string) *UpdateEg
 
 // Updates egress firewall rule
 func (s *FirewallService) UpdateEgressFirewallRule(p *UpdateEgressFirewallRuleParams) (*UpdateEgressFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("updateEgressFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateEgressFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4369,7 +4369,7 @@ func (s *FirewallService) NewUpdateFirewallRuleParams(id string) *UpdateFirewall
 
 // Updates firewall rule
 func (s *FirewallService) UpdateFirewallRule(p *UpdateFirewallRuleParams) (*UpdateFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("updateFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4621,7 +4621,7 @@ func (s *FirewallService) NewUpdatePortForwardingRuleParams(id string) *UpdatePo
 
 // Updates a port forwarding rule. Only the private port and the virtual machine can be updated.
 func (s *FirewallService) UpdatePortForwardingRule(p *UpdatePortForwardingRuleParams) (*UpdatePortForwardingRuleResponse, error) {
-	resp, err := s.cs.newRequest("updatePortForwardingRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updatePortForwardingRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5373,7 +5373,7 @@ func (s *FirewallService) NewCreateIpv6FirewallRuleParams(networkid string, prot
 
 // Creates an Ipv6 firewall rule in the given network (the network must not belong to VPC)
 func (s *FirewallService) CreateIpv6FirewallRule(p *CreateIpv6FirewallRuleParams) (*CreateIpv6FirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("createIpv6FirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createIpv6FirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5702,7 +5702,7 @@ func (s *FirewallService) NewUpdateIpv6FirewallRuleParams(id string) *UpdateIpv6
 
 // Updates Ipv6 firewall rule with specified ID
 func (s *FirewallService) UpdateIpv6FirewallRule(p *UpdateIpv6FirewallRuleParams) (*UpdateIpv6FirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("updateIpv6FirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateIpv6FirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5809,7 +5809,7 @@ func (s *FirewallService) NewDeleteIpv6FirewallRuleParams(id string) *DeleteIpv6
 
 // Deletes a IPv6 firewall rule
 func (s *FirewallService) DeleteIpv6FirewallRule(p *DeleteIpv6FirewallRuleParams) (*DeleteIpv6FirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteIpv6FirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteIpv6FirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5945,7 +5945,7 @@ func (s *FirewallService) NewUpdateRoutingFirewallRuleParams(id string) *UpdateR
 
 // Updates Routing firewall rule with specified ID
 func (s *FirewallService) UpdateRoutingFirewallRule(p *UpdateRoutingFirewallRuleParams) (*UpdateRoutingFirewallRuleResponse, error) {
-	resp, err := s.cs.newRequest("updateRoutingFirewallRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateRoutingFirewallRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -206,7 +206,7 @@ func (s *GuestOSService) NewAddGuestOsParams(oscategoryid string, osdisplayname 
 
 // Add a new guest OS type
 func (s *GuestOSService) AddGuestOs(p *AddGuestOsParams) (*AddGuestOsResponse, error) {
-	resp, err := s.cs.newRequest("addGuestOs", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addGuestOs", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +446,7 @@ func (s *GuestOSService) NewAddGuestOsMappingParams(hypervisor string, hyperviso
 
 // Adds a guest OS name to hypervisor OS name mapping
 func (s *GuestOSService) AddGuestOsMapping(p *AddGuestOsMappingParams) (*AddGuestOsMappingResponse, error) {
-	resp, err := s.cs.newRequest("addGuestOsMapping", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addGuestOsMapping", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1453,7 +1453,7 @@ func (s *GuestOSService) NewRemoveGuestOsParams(id string) *RemoveGuestOsParams 
 
 // Removes a Guest OS from listing.
 func (s *GuestOSService) RemoveGuestOs(p *RemoveGuestOsParams) (*RemoveGuestOsResponse, error) {
-	resp, err := s.cs.newRequest("removeGuestOs", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeGuestOs", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1535,7 +1535,7 @@ func (s *GuestOSService) NewRemoveGuestOsMappingParams(id string) *RemoveGuestOs
 
 // Removes a Guest OS Mapping.
 func (s *GuestOSService) RemoveGuestOsMapping(p *RemoveGuestOsMappingParams) (*RemoveGuestOsMappingResponse, error) {
-	resp, err := s.cs.newRequest("removeGuestOsMapping", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeGuestOsMapping", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1695,7 +1695,7 @@ func (s *GuestOSService) NewUpdateGuestOsParams(id string, osdisplayname string)
 
 // Updates the information about Guest OS
 func (s *GuestOSService) UpdateGuestOs(p *UpdateGuestOsParams) (*UpdateGuestOsResponse, error) {
-	resp, err := s.cs.newRequest("updateGuestOs", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateGuestOs", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1837,7 +1837,7 @@ func (s *GuestOSService) NewUpdateGuestOsMappingParams(id string, osnameforhyper
 
 // Updates the information about Guest OS to Hypervisor specific name mapping
 func (s *GuestOSService) UpdateGuestOsMapping(p *UpdateGuestOsMappingParams) (*UpdateGuestOsMappingResponse, error) {
-	resp, err := s.cs.newRequest("updateGuestOsMapping", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateGuestOsMapping", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -393,7 +393,7 @@ func (s *HostService) NewAddBaremetalHostParams(hypervisor string, podid string,
 
 // add a baremetal host
 func (s *HostService) AddBaremetalHost(p *AddBaremetalHostParams) (*AddBaremetalHostResponse, error) {
-	resp, err := s.cs.newRequest("addBaremetalHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addBaremetalHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +614,7 @@ func (s *HostService) NewAddGloboDnsHostParams(password string, physicalnetworki
 
 // Adds the GloboDNS external host
 func (s *HostService) AddGloboDnsHost(p *AddGloboDnsHostParams) (*AddGloboDnsHostResponse, error) {
-	resp, err := s.cs.newRequest("addGloboDnsHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addGloboDnsHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +916,7 @@ func (s *HostService) NewAddHostParams(hypervisor string, podid string, url stri
 
 // Adds a new host.
 func (s *HostService) AddHost(p *AddHostParams) (*AddHostResponse, error) {
-	resp, err := s.cs.newRequest("addHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1090,7 +1090,7 @@ func (s *HostService) NewAddSecondaryStorageParams(url string) *AddSecondaryStor
 
 // Adds secondary storage.
 func (s *HostService) AddSecondaryStorage(p *AddSecondaryStorageParams) (*AddSecondaryStorageResponse, error) {
-	resp, err := s.cs.newRequest("addSecondaryStorage", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addSecondaryStorage", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1167,7 +1167,7 @@ func (s *HostService) NewCancelHostMaintenanceParams(id string) *CancelHostMaint
 
 // Cancels host maintenance.
 func (s *HostService) CancelHostMaintenance(p *CancelHostMaintenanceParams) (*CancelHostMaintenanceResponse, error) {
-	resp, err := s.cs.newRequest("cancelHostMaintenance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("cancelHostMaintenance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1358,7 +1358,7 @@ func (s *HostService) NewConfigureHAForHostParams(hostid string, provider string
 
 // Configures HA for a host
 func (s *HostService) ConfigureHAForHost(p *ConfigureHAForHostParams) (*HAForHostResponse, error) {
-	resp, err := s.cs.newRequest("configureHAForHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configureHAForHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1448,7 +1448,7 @@ func (s *HostService) NewEnableHAForHostParams(hostid string) *EnableHAForHostPa
 
 // Enables HA for a host
 func (s *HostService) EnableHAForHost(p *EnableHAForHostParams) (*EnableHAForHostResponse, error) {
-	resp, err := s.cs.newRequest("enableHAForHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableHAForHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1587,7 +1587,7 @@ func (s *HostService) NewDedicateHostParams(domainid string, hostid string) *Ded
 
 // Dedicates a host.
 func (s *HostService) DedicateHost(p *DedicateHostParams) (*DedicateHostResponse, error) {
-	resp, err := s.cs.newRequest("dedicateHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicateHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1728,7 +1728,7 @@ func (s *HostService) NewDeleteHostParams(id string) *DeleteHostParams {
 
 // Deletes a host.
 func (s *HostService) DeleteHost(p *DeleteHostParams) (*DeleteHostResponse, error) {
-	resp, err := s.cs.newRequest("deleteHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1822,7 +1822,7 @@ func (s *HostService) NewDisableHAForHostParams(hostid string) *DisableHAForHost
 
 // Disables HA for a host
 func (s *HostService) DisableHAForHost(p *DisableHAForHostParams) (*DisableHAForHostResponse, error) {
-	resp, err := s.cs.newRequest("disableHAForHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableHAForHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1912,7 +1912,7 @@ func (s *HostService) NewDisableOutOfBandManagementForHostParams(hostid string) 
 
 // Disables out-of-band management for a host
 func (s *HostService) DisableOutOfBandManagementForHost(p *DisableOutOfBandManagementForHostParams) (*DisableOutOfBandManagementForHostResponse, error) {
-	resp, err := s.cs.newRequest("disableOutOfBandManagementForHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableOutOfBandManagementForHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2008,7 +2008,7 @@ func (s *HostService) NewEnableOutOfBandManagementForHostParams(hostid string) *
 
 // Enables out-of-band management for a host
 func (s *HostService) EnableOutOfBandManagementForHost(p *EnableOutOfBandManagementForHostParams) (*EnableOutOfBandManagementForHostResponse, error) {
-	resp, err := s.cs.newRequest("enableOutOfBandManagementForHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableOutOfBandManagementForHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3943,7 +3943,7 @@ func (s *HostService) NewPrepareHostForMaintenanceParams(id string) *PrepareHost
 
 // Prepares a host for maintenance.
 func (s *HostService) PrepareHostForMaintenance(p *PrepareHostForMaintenanceParams) (*PrepareHostForMaintenanceResponse, error) {
-	resp, err := s.cs.newRequest("prepareHostForMaintenance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("prepareHostForMaintenance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4109,7 +4109,7 @@ func (s *HostService) NewReconnectHostParams(id string) *ReconnectHostParams {
 
 // Reconnects a host.
 func (s *HostService) ReconnectHost(p *ReconnectHostParams) (*ReconnectHostResponse, error) {
-	resp, err := s.cs.newRequest("reconnectHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("reconnectHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4275,7 +4275,7 @@ func (s *HostService) NewReleaseDedicatedHostParams(hostid string) *ReleaseDedic
 
 // Release the dedication for host
 func (s *HostService) ReleaseDedicatedHost(p *ReleaseDedicatedHostParams) (*ReleaseDedicatedHostResponse, error) {
-	resp, err := s.cs.newRequest("releaseDedicatedHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseDedicatedHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4357,7 +4357,7 @@ func (s *HostService) NewReleaseHostReservationParams(id string) *ReleaseHostRes
 
 // Releases host reservation.
 func (s *HostService) ReleaseHostReservation(p *ReleaseHostReservationParams) (*ReleaseHostReservationResponse, error) {
-	resp, err := s.cs.newRequest("releaseHostReservation", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseHostReservation", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4609,7 +4609,7 @@ func (s *HostService) NewUpdateHostParams(id string) *UpdateHostParams {
 
 // Updates a host.
 func (s *HostService) UpdateHost(p *UpdateHostParams) (*UpdateHostResponse, error) {
-	resp, err := s.cs.newRequest("updateHost", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateHost", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4853,7 +4853,7 @@ func (s *HostService) NewUpdateHostPasswordParams(password string, username stri
 
 // Update password of a host/pool on management server.
 func (s *HostService) UpdateHostPassword(p *UpdateHostPasswordParams) (*UpdateHostPasswordResponse, error) {
-	resp, err := s.cs.newRequest("updateHostPassword", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateHostPassword", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4997,7 +4997,7 @@ func (s *HostService) NewMigrateSecondaryStorageDataParams(destpools []string, s
 
 // migrates data objects from one secondary storage to destination image store(s)
 func (s *HostService) MigrateSecondaryStorageData(p *MigrateSecondaryStorageDataParams) (*MigrateSecondaryStorageDataResponse, error) {
-	resp, err := s.cs.newRequest("migrateSecondaryStorageData", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateSecondaryStorageData", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5085,7 +5085,7 @@ func (s *HostService) NewCancelHostAsDegradedParams(id string) *CancelHostAsDegr
 
 // Cancel host status from 'Degraded'. Host will transit back to status 'Enabled'.
 func (s *HostService) CancelHostAsDegraded(p *CancelHostAsDegradedParams) (*CancelHostAsDegradedResponse, error) {
-	resp, err := s.cs.newRequest("cancelHostAsDegraded", p.toURLValues())
+	resp, err := s.cs.newPostRequest("cancelHostAsDegraded", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5664,7 +5664,7 @@ func (s *HostService) NewCreateSecondaryStorageSelectorParams(description string
 
 // Creates a secondary storage selector, described by the heuristic rule.
 func (s *HostService) CreateSecondaryStorageSelector(p *CreateSecondaryStorageSelectorParams) (*CreateSecondaryStorageSelectorResponse, error) {
-	resp, err := s.cs.newRequest("createSecondaryStorageSelector", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSecondaryStorageSelector", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5740,7 +5740,7 @@ func (s *HostService) NewRemoveSecondaryStorageSelectorParams(id string) *Remove
 
 // Removes an existing secondary storage selector.
 func (s *HostService) RemoveSecondaryStorageSelector(p *RemoveSecondaryStorageSelectorParams) (*RemoveSecondaryStorageSelectorResponse, error) {
-	resp, err := s.cs.newRequest("removeSecondaryStorageSelector", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeSecondaryStorageSelector", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5908,7 +5908,7 @@ func (s *HostService) NewDeclareHostAsDegradedParams(id string) *DeclareHostAsDe
 
 // Declare host as 'Degraded'. Host must be on 'Disconnected' or 'Alert' state. The ADMIN must be sure that there are no VMs running on the respective host otherwise this command might corrupted VMs that were running on the 'Degraded' host.
 func (s *HostService) DeclareHostAsDegraded(p *DeclareHostAsDegradedParams) (*DeclareHostAsDegradedResponse, error) {
-	resp, err := s.cs.newRequest("declareHostAsDegraded", p.toURLValues())
+	resp, err := s.cs.newPostRequest("declareHostAsDegraded", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6099,7 +6099,7 @@ func (s *HostService) NewUpdateSecondaryStorageSelectorParams(heuristicrule stri
 
 // Updates an existing secondary storage selector.
 func (s *HostService) UpdateSecondaryStorageSelector(p *UpdateSecondaryStorageSelectorParams) (*UpdateSecondaryStorageSelectorResponse, error) {
-	resp, err := s.cs.newRequest("updateSecondaryStorageSelector", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateSecondaryStorageSelector", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/HypervisorService.go
+++ b/cloudstack/HypervisorService.go
@@ -560,7 +560,7 @@ func (s *HypervisorService) NewUpdateHypervisorCapabilitiesParams() *UpdateHyper
 
 // Updates a hypervisor capabilities.
 func (s *HypervisorService) UpdateHypervisorCapabilities(p *UpdateHypervisorCapabilitiesParams) (*UpdateHypervisorCapabilitiesResponse, error) {
-	resp, err := s.cs.newRequest("updateHypervisorCapabilities", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateHypervisorCapabilities", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/IPQuarantineService.go
+++ b/cloudstack/IPQuarantineService.go
@@ -307,7 +307,7 @@ func (s *IPQuarantineService) NewRemoveQuarantinedIpParams(removalreason string)
 
 // Removes a public IP address from quarantine. Only IPs in active quarantine can be removed.
 func (s *IPQuarantineService) RemoveQuarantinedIp(p *RemoveQuarantinedIpParams) (*RemoveQuarantinedIpResponse, error) {
-	resp, err := s.cs.newRequest("removeQuarantinedIp", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeQuarantinedIp", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func (s *IPQuarantineService) NewUpdateQuarantinedIpParams(enddate string) *Upda
 
 // Updates the quarantine end date for the given public IP address.
 func (s *IPQuarantineService) UpdateQuarantinedIp(p *UpdateQuarantinedIpParams) (*UpdateQuarantinedIpResponse, error) {
-	resp, err := s.cs.newRequest("updateQuarantinedIp", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateQuarantinedIp", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ISOService.go
+++ b/cloudstack/ISOService.go
@@ -153,7 +153,7 @@ func (s *ISOService) NewAttachIsoParams(id string, virtualmachineid string) *Att
 
 // Attaches an ISO to a virtual machine.
 func (s *ISOService) AttachIso(p *AttachIsoParams) (*AttachIsoResponse, error) {
-	resp, err := s.cs.newRequest("attachIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("attachIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +474,7 @@ func (s *ISOService) NewCopyIsoParams(id string) *CopyIsoParams {
 
 // Copies an iso from one zone to another.
 func (s *ISOService) CopyIso(p *CopyIsoParams) (*CopyIsoResponse, error) {
-	resp, err := s.cs.newRequest("copyIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("copyIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -664,7 +664,7 @@ func (s *ISOService) NewDeleteIsoParams(id string) *DeleteIsoParams {
 
 // Deletes an ISO file.
 func (s *ISOService) DeleteIso(p *DeleteIsoParams) (*DeleteIsoResponse, error) {
-	resp, err := s.cs.newRequest("deleteIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -771,7 +771,7 @@ func (s *ISOService) NewDetachIsoParams(virtualmachineid string) *DetachIsoParam
 
 // Detaches any ISO file (if any) currently attached to a virtual machine.
 func (s *ISOService) DetachIso(p *DetachIsoParams) (*DetachIsoResponse, error) {
-	resp, err := s.cs.newRequest("detachIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("detachIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1092,7 +1092,7 @@ func (s *ISOService) NewExtractIsoParams(id string, mode string) *ExtractIsoPara
 
 // Extracts an ISO
 func (s *ISOService) ExtractIso(p *ExtractIsoParams) (*ExtractIsoResponse, error) {
-	resp, err := s.cs.newRequest("extractIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("extractIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2858,7 +2858,7 @@ func (s *ISOService) NewRegisterIsoParams(displaytext string, name string, url s
 
 // Registers an existing ISO into the CloudStack Cloud.
 func (s *ISOService) RegisterIso(p *RegisterIsoParams) (*RegisterIsoResponse, error) {
-	resp, err := s.cs.newRequest("registerIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3355,7 +3355,7 @@ func (s *ISOService) NewUpdateIsoParams(id string) *UpdateIsoParams {
 
 // Updates an ISO file.
 func (s *ISOService) UpdateIso(p *UpdateIsoParams) (*UpdateIsoResponse, error) {
-	resp, err := s.cs.newRequest("updateIso", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateIso", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3650,7 +3650,7 @@ func (s *ISOService) NewUpdateIsoPermissionsParams(id string) *UpdateIsoPermissi
 
 // Updates ISO permissions
 func (s *ISOService) UpdateIsoPermissions(p *UpdateIsoPermissionsParams) (*UpdateIsoPermissionsResponse, error) {
-	resp, err := s.cs.newRequest("updateIsoPermissions", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateIsoPermissions", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ImageStoreService.go
+++ b/cloudstack/ImageStoreService.go
@@ -208,7 +208,7 @@ func (s *ImageStoreService) NewAddImageStoreParams(provider string) *AddImageSto
 
 // Adds backup image store.
 func (s *ImageStoreService) AddImageStore(p *AddImageStoreParams) (*AddImageStoreResponse, error) {
-	resp, err := s.cs.newRequest("addImageStore", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addImageStore", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (s *ImageStoreService) NewAddImageStoreS3Params(accesskey string, bucket st
 
 // Adds S3 Image Store
 func (s *ImageStoreService) AddImageStoreS3(p *AddImageStoreS3Params) (*AddImageStoreS3Response, error) {
-	resp, err := s.cs.newRequest("addImageStoreS3", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addImageStoreS3", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +715,7 @@ func (s *ImageStoreService) NewCreateSecondaryStagingStoreParams(url string) *Cr
 
 // create secondary staging store.
 func (s *ImageStoreService) CreateSecondaryStagingStore(p *CreateSecondaryStagingStoreParams) (*CreateSecondaryStagingStoreResponse, error) {
-	resp, err := s.cs.newRequest("createSecondaryStagingStore", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSecondaryStagingStore", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -792,7 +792,7 @@ func (s *ImageStoreService) NewDeleteImageStoreParams(id string) *DeleteImageSto
 
 // Deletes an image store or Secondary Storage.
 func (s *ImageStoreService) DeleteImageStore(p *DeleteImageStoreParams) (*DeleteImageStoreResponse, error) {
-	resp, err := s.cs.newRequest("deleteImageStore", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteImageStore", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +886,7 @@ func (s *ImageStoreService) NewDeleteSecondaryStagingStoreParams(id string) *Del
 
 // Deletes a secondary staging store .
 func (s *ImageStoreService) DeleteSecondaryStagingStore(p *DeleteSecondaryStagingStoreParams) (*DeleteSecondaryStagingStoreResponse, error) {
-	resp, err := s.cs.newRequest("deleteSecondaryStagingStore", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteSecondaryStagingStore", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1748,7 +1748,7 @@ func (s *ImageStoreService) NewMigrateResourceToAnotherSecondaryStorageParams(de
 
 // migrates resources from one secondary storage to destination image store
 func (s *ImageStoreService) MigrateResourceToAnotherSecondaryStorage(p *MigrateResourceToAnotherSecondaryStorageParams) (*MigrateResourceToAnotherSecondaryStorageResponse, error) {
-	resp, err := s.cs.newRequest("migrateResourceToAnotherSecondaryStorage", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateResourceToAnotherSecondaryStorage", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1912,7 +1912,7 @@ func (s *ImageStoreService) NewUpdateCloudToUseObjectStoreParams(provider string
 
 // Migrate current NFS secondary storages to use object store.
 func (s *ImageStoreService) UpdateCloudToUseObjectStore(p *UpdateCloudToUseObjectStoreParams) (*UpdateCloudToUseObjectStoreResponse, error) {
-	resp, err := s.cs.newRequest("updateCloudToUseObjectStore", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateCloudToUseObjectStore", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2275,7 +2275,7 @@ func (s *ImageStoreService) NewUpdateImageStoreParams(id string) *UpdateImageSto
 
 // Updates image store read-only status
 func (s *ImageStoreService) UpdateImageStore(p *UpdateImageStoreParams) (*UpdateImageStoreResponse, error) {
-	resp, err := s.cs.newRequest("updateImageStore", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateImageStore", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2379,7 +2379,7 @@ func (s *ImageStoreService) NewDownloadImageStoreObjectParams(id string) *Downlo
 
 // Download object at a specified path on an image store.
 func (s *ImageStoreService) DownloadImageStoreObject(p *DownloadImageStoreObjectParams) (*DownloadImageStoreObjectResponse, error) {
-	resp, err := s.cs.newRequest("downloadImageStoreObject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("downloadImageStoreObject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/InternalLBService.go
+++ b/cloudstack/InternalLBService.go
@@ -119,7 +119,7 @@ func (s *InternalLBService) NewConfigureInternalLoadBalancerElementParams(enable
 
 // Configures an Internal Load Balancer element.
 func (s *InternalLBService) ConfigureInternalLoadBalancerElement(p *ConfigureInternalLoadBalancerElementParams) (*InternalLoadBalancerElementResponse, error) {
-	resp, err := s.cs.newRequest("configureInternalLoadBalancerElement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configureInternalLoadBalancerElement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (s *InternalLBService) NewCreateInternalLoadBalancerElementParams(nspid str
 
 // Create an Internal Load Balancer element.
 func (s *InternalLBService) CreateInternalLoadBalancerElement(p *CreateInternalLoadBalancerElementParams) (*CreateInternalLoadBalancerElementResponse, error) {
-	resp, err := s.cs.newRequest("createInternalLoadBalancerElement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createInternalLoadBalancerElement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1151,7 +1151,7 @@ func (s *InternalLBService) NewStartInternalLoadBalancerVMParams(id string) *Sta
 
 // Starts an existing internal lb vm.
 func (s *InternalLBService) StartInternalLoadBalancerVM(p *StartInternalLoadBalancerVMParams) (*StartInternalLoadBalancerVMResponse, error) {
-	resp, err := s.cs.newRequest("startInternalLoadBalancerVM", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startInternalLoadBalancerVM", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1323,7 +1323,7 @@ func (s *InternalLBService) NewStopInternalLoadBalancerVMParams(id string) *Stop
 
 // Stops an Internal LB vm.
 func (s *InternalLBService) StopInternalLoadBalancerVM(p *StopInternalLoadBalancerVMParams) (*StopInternalLoadBalancerVMResponse, error) {
-	resp, err := s.cs.newRequest("stopInternalLoadBalancerVM", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopInternalLoadBalancerVM", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/KubernetesService.go
+++ b/cloudstack/KubernetesService.go
@@ -308,7 +308,7 @@ func (s *KubernetesService) NewAddKubernetesSupportedVersionParams(mincpunumber 
 
 // Add a supported Kubernetes version
 func (s *KubernetesService) AddKubernetesSupportedVersion(p *AddKubernetesSupportedVersionParams) (*AddKubernetesSupportedVersionResponse, error) {
-	resp, err := s.cs.newRequest("addKubernetesSupportedVersion", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addKubernetesSupportedVersion", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -833,7 +833,7 @@ func (s *KubernetesService) NewCreateKubernetesClusterParams(description string,
 
 // Creates a Kubernetes cluster
 func (s *KubernetesService) CreateKubernetesCluster(p *CreateKubernetesClusterParams) (*CreateKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("createKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1004,7 +1004,7 @@ func (s *KubernetesService) NewDeleteKubernetesClusterParams(id string) *DeleteK
 
 // Deletes a Kubernetes cluster
 func (s *KubernetesService) DeleteKubernetesCluster(p *DeleteKubernetesClusterParams) (*DeleteKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("deleteKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1086,7 +1086,7 @@ func (s *KubernetesService) NewDeleteKubernetesSupportedVersionParams(id string)
 
 // Deletes a Kubernetes cluster
 func (s *KubernetesService) DeleteKubernetesSupportedVersion(p *DeleteKubernetesSupportedVersionParams) (*DeleteKubernetesSupportedVersionResponse, error) {
-	resp, err := s.cs.newRequest("deleteKubernetesSupportedVersion", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteKubernetesSupportedVersion", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2156,7 +2156,7 @@ func (s *KubernetesService) NewScaleKubernetesClusterParams(id string) *ScaleKub
 
 // Scales a created, running or stopped CloudManaged Kubernetes cluster
 func (s *KubernetesService) ScaleKubernetesCluster(p *ScaleKubernetesClusterParams) (*ScaleKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("scaleKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("scaleKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2277,7 +2277,7 @@ func (s *KubernetesService) NewStartKubernetesClusterParams(id string) *StartKub
 
 // Starts a stopped CloudManaged Kubernetes cluster
 func (s *KubernetesService) StartKubernetesCluster(p *StartKubernetesClusterParams) (*StartKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("startKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2398,7 +2398,7 @@ func (s *KubernetesService) NewStopKubernetesClusterParams(id string) *StopKuber
 
 // Stops a running CloudManaged Kubernetes cluster
 func (s *KubernetesService) StopKubernetesCluster(p *StopKubernetesClusterParams) (*StopKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("stopKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2505,7 +2505,7 @@ func (s *KubernetesService) NewUpdateKubernetesSupportedVersionParams(id string,
 
 // Update a supported Kubernetes version
 func (s *KubernetesService) UpdateKubernetesSupportedVersion(p *UpdateKubernetesSupportedVersionParams) (*UpdateKubernetesSupportedVersionResponse, error) {
-	resp, err := s.cs.newRequest("updateKubernetesSupportedVersion", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateKubernetesSupportedVersion", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2610,7 +2610,7 @@ func (s *KubernetesService) NewUpgradeKubernetesClusterParams(id string, kuberne
 
 // Upgrades a running CloudManaged Kubernetes cluster
 func (s *KubernetesService) UpgradeKubernetesCluster(p *UpgradeKubernetesClusterParams) (*UpgradeKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("upgradeKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("upgradeKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2782,7 +2782,7 @@ func (s *KubernetesService) NewAddVirtualMachinesToKubernetesClusterParams(id st
 
 // Add VMs to an ExternalManaged kubernetes cluster. Not applicable for CloudManaged kubernetes clusters.
 func (s *KubernetesService) AddVirtualMachinesToKubernetesCluster(p *AddVirtualMachinesToKubernetesClusterParams) (*AddVirtualMachinesToKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("addVirtualMachinesToKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addVirtualMachinesToKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2976,7 +2976,7 @@ func (s *KubernetesService) NewRemoveVirtualMachinesFromKubernetesClusterParams(
 
 // Remove VMs from an ExternalManaged kubernetes cluster. Not applicable for CloudManaged kubernetes clusters.
 func (s *KubernetesService) RemoveVirtualMachinesFromKubernetesCluster(p *RemoveVirtualMachinesFromKubernetesClusterParams) (*RemoveVirtualMachinesFromKubernetesClusterResponse, error) {
-	resp, err := s.cs.newRequest("removeVirtualMachinesFromKubernetesCluster", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeVirtualMachinesFromKubernetesCluster", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/LDAPService.go
+++ b/cloudstack/LDAPService.go
@@ -146,7 +146,7 @@ func (s *LDAPService) NewAddLdapConfigurationParams(hostname string, port int) *
 
 // Add a new Ldap Configuration
 func (s *LDAPService) AddLdapConfiguration(p *AddLdapConfigurationParams) (*AddLdapConfigurationResponse, error) {
-	resp, err := s.cs.newRequest("addLdapConfiguration", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addLdapConfiguration", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (s *LDAPService) NewDeleteLdapConfigurationParams(hostname string) *DeleteL
 
 // Remove an Ldap Configuration
 func (s *LDAPService) DeleteLdapConfiguration(p *DeleteLdapConfigurationParams) (*DeleteLdapConfigurationResponse, error) {
-	resp, err := s.cs.newRequest("deleteLdapConfiguration", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteLdapConfiguration", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +553,7 @@ func (s *LDAPService) NewImportLdapUsersParams() *ImportLdapUsersParams {
 
 // Import LDAP users
 func (s *LDAPService) ImportLdapUsers(p *ImportLdapUsersParams) (*ImportLdapUsersResponse, error) {
-	resp, err := s.cs.newRequest("importLdapUsers", p.toURLValues())
+	resp, err := s.cs.newPostRequest("importLdapUsers", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -843,7 +843,7 @@ func (s *LDAPService) NewLdapConfigParams() *LdapConfigParams {
 
 // (Deprecated, use addLdapConfiguration) Configure the LDAP context for this site.
 func (s *LDAPService) LdapConfig(p *LdapConfigParams) (*LdapConfigResponse, error) {
-	resp, err := s.cs.newRequest("ldapConfig", p.toURLValues())
+	resp, err := s.cs.newPostRequest("ldapConfig", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1136,7 +1136,7 @@ func (s *LDAPService) NewLdapCreateAccountParams(username string) *LdapCreateAcc
 
 // Creates an account from an LDAP user
 func (s *LDAPService) LdapCreateAccount(p *LdapCreateAccountParams) (*LdapCreateAccountResponse, error) {
-	resp, err := s.cs.newRequest("ldapCreateAccount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("ldapCreateAccount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1263,7 +1263,7 @@ func (s *LDAPService) NewLdapRemoveParams() *LdapRemoveParams {
 
 // (Deprecated , use deleteLdapConfiguration) Remove the LDAP context for this site.
 func (s *LDAPService) LdapRemove(p *LdapRemoveParams) (*LdapRemoveResponse, error) {
-	resp, err := s.cs.newRequest("ldapRemove", p.toURLValues())
+	resp, err := s.cs.newPostRequest("ldapRemove", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1458,7 +1458,7 @@ func (s *LDAPService) NewLinkDomainToLdapParams(accounttype int, domainid string
 
 // link an existing cloudstack domain to group or OU in ldap
 func (s *LDAPService) LinkDomainToLdap(p *LinkDomainToLdapParams) (*LinkDomainToLdapResponse, error) {
-	resp, err := s.cs.newRequest("linkDomainToLdap", p.toURLValues())
+	resp, err := s.cs.newPostRequest("linkDomainToLdap", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2021,7 +2021,7 @@ func (s *LDAPService) NewSearchLdapParams(query string) *SearchLdapParams {
 
 // Searches LDAP based on the username attribute
 func (s *LDAPService) SearchLdap(p *SearchLdapParams) (*SearchLdapResponse, error) {
-	resp, err := s.cs.newRequest("searchLdap", p.toURLValues())
+	resp, err := s.cs.newPostRequest("searchLdap", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/LimitService.go
+++ b/cloudstack/LimitService.go
@@ -478,7 +478,7 @@ func (s *LimitService) NewResetApiLimitParams() *ResetApiLimitParams {
 
 // Reset api count
 func (s *LimitService) ResetApiLimit(p *ResetApiLimitParams) (*ResetApiLimitResponse, error) {
-	resp, err := s.cs.newRequest("resetApiLimit", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetApiLimit", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +669,7 @@ func (s *LimitService) NewUpdateResourceCountParams(domainid string) *UpdateReso
 
 // Recalculate and update resource count for an account or domain. This also executes some cleanup tasks before calculating resource counts.
 func (s *LimitService) UpdateResourceCount(p *UpdateResourceCountParams) (*UpdateResourceCountResponse, error) {
-	resp, err := s.cs.newRequest("updateResourceCount", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateResourceCount", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -866,7 +866,7 @@ func (s *LimitService) NewUpdateResourceLimitParams(resourcetype int) *UpdateRes
 
 // Updates resource limits for an account or domain.
 func (s *LimitService) UpdateResourceLimit(p *UpdateResourceLimitParams) (*UpdateResourceLimitResponse, error) {
-	resp, err := s.cs.newRequest("updateResourceLimit", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateResourceLimit", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/LoadBalancerService.go
+++ b/cloudstack/LoadBalancerService.go
@@ -183,7 +183,7 @@ func (s *LoadBalancerService) NewAssignCertToLoadBalancerParams(certid string, l
 
 // Assigns a certificate to a load balancer rule
 func (s *LoadBalancerService) AssignCertToLoadBalancer(p *AssignCertToLoadBalancerParams) (*AssignCertToLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("assignCertToLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("assignCertToLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +319,7 @@ func (s *LoadBalancerService) NewAssignToGlobalLoadBalancerRuleParams(id string,
 
 // Assign load balancer rule or list of load balancer rules to a global load balancer rules.
 func (s *LoadBalancerService) AssignToGlobalLoadBalancerRule(p *AssignToGlobalLoadBalancerRuleParams) (*AssignToGlobalLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("assignToGlobalLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("assignToGlobalLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func (s *LoadBalancerService) NewAssignToLoadBalancerRuleParams(id string) *Assi
 
 // Assigns virtual machine or a list of virtual machines to a load balancer rule.
 func (s *LoadBalancerService) AssignToLoadBalancerRule(p *AssignToLoadBalancerRuleParams) (*AssignToLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("assignToLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("assignToLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -732,7 +732,7 @@ func (s *LoadBalancerService) NewCreateGlobalLoadBalancerRuleParams(gslbdomainna
 
 // Creates a global load balancer rule
 func (s *LoadBalancerService) CreateGlobalLoadBalancerRule(p *CreateGlobalLoadBalancerRuleParams) (*CreateGlobalLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("createGlobalLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createGlobalLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1030,7 +1030,7 @@ func (s *LoadBalancerService) NewCreateLBHealthCheckPolicyParams(lbruleid string
 
 // Creates a load balancer health check policy
 func (s *LoadBalancerService) CreateLBHealthCheckPolicy(p *CreateLBHealthCheckPolicyParams) (*CreateLBHealthCheckPolicyResponse, error) {
-	resp, err := s.cs.newRequest("createLBHealthCheckPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createLBHealthCheckPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1260,7 +1260,7 @@ func (s *LoadBalancerService) NewCreateLBStickinessPolicyParams(lbruleid string,
 
 // Creates a load balancer stickiness policy
 func (s *LoadBalancerService) CreateLBStickinessPolicy(p *CreateLBStickinessPolicyParams) (*CreateLBStickinessPolicyResponse, error) {
-	resp, err := s.cs.newRequest("createLBStickinessPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createLBStickinessPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1589,7 +1589,7 @@ func (s *LoadBalancerService) NewCreateLoadBalancerParams(algorithm string, inst
 
 // Creates an internal load balancer
 func (s *LoadBalancerService) CreateLoadBalancer(p *CreateLoadBalancerParams) (*CreateLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("createLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2024,7 +2024,7 @@ func (s *LoadBalancerService) NewCreateLoadBalancerRuleParams(algorithm string, 
 
 // Creates a load balancer rule
 func (s *LoadBalancerService) CreateLoadBalancerRule(p *CreateLoadBalancerRuleParams) (*CreateLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("createLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2131,7 +2131,7 @@ func (s *LoadBalancerService) NewDeleteGlobalLoadBalancerRuleParams(id string) *
 
 // Deletes a global load balancer rule.
 func (s *LoadBalancerService) DeleteGlobalLoadBalancerRule(p *DeleteGlobalLoadBalancerRuleParams) (*DeleteGlobalLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteGlobalLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteGlobalLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2213,7 +2213,7 @@ func (s *LoadBalancerService) NewDeleteLBHealthCheckPolicyParams(id string) *Del
 
 // Deletes a load balancer health check policy.
 func (s *LoadBalancerService) DeleteLBHealthCheckPolicy(p *DeleteLBHealthCheckPolicyParams) (*DeleteLBHealthCheckPolicyResponse, error) {
-	resp, err := s.cs.newRequest("deleteLBHealthCheckPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteLBHealthCheckPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2295,7 +2295,7 @@ func (s *LoadBalancerService) NewDeleteLBStickinessPolicyParams(id string) *Dele
 
 // Deletes a load balancer stickiness policy.
 func (s *LoadBalancerService) DeleteLBStickinessPolicy(p *DeleteLBStickinessPolicyParams) (*DeleteLBStickinessPolicyResponse, error) {
-	resp, err := s.cs.newRequest("deleteLBStickinessPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteLBStickinessPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2377,7 +2377,7 @@ func (s *LoadBalancerService) NewDeleteLoadBalancerParams(id string) *DeleteLoad
 
 // Deletes an internal load balancer
 func (s *LoadBalancerService) DeleteLoadBalancer(p *DeleteLoadBalancerParams) (*DeleteLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("deleteLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2459,7 +2459,7 @@ func (s *LoadBalancerService) NewDeleteLoadBalancerRuleParams(id string) *Delete
 
 // Deletes a load balancer rule.
 func (s *LoadBalancerService) DeleteLoadBalancerRule(p *DeleteLoadBalancerRuleParams) (*DeleteLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2541,7 +2541,7 @@ func (s *LoadBalancerService) NewDeleteServicePackageOfferingParams(id string) *
 
 // Delete Service Package
 func (s *LoadBalancerService) DeleteServicePackageOffering(p *DeleteServicePackageOfferingParams) (*DeleteServicePackageOfferingResponse, error) {
-	resp, err := s.cs.newRequest("deleteServicePackageOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteServicePackageOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2635,7 +2635,7 @@ func (s *LoadBalancerService) NewDeleteSslCertParams(id string) *DeleteSslCertPa
 
 // Delete a certificate to CloudStack
 func (s *LoadBalancerService) DeleteSslCert(p *DeleteSslCertParams) (*DeleteSslCertResponse, error) {
-	resp, err := s.cs.newRequest("deleteSslCert", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteSslCert", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2803,7 +2803,7 @@ func (s *LoadBalancerService) NewDeployNetscalerVpxParams(serviceofferingid stri
 
 // Creates new NS Vpx
 func (s *LoadBalancerService) DeployNetscalerVpx(p *DeployNetscalerVpxParams) (*DeployNetscalerVpxResponse, error) {
-	resp, err := s.cs.newRequest("deployNetscalerVpx", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deployNetscalerVpx", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5465,7 +5465,7 @@ func (s *LoadBalancerService) NewRemoveCertFromLoadBalancerParams(lbruleid strin
 
 // Removes a certificate from a load balancer rule
 func (s *LoadBalancerService) RemoveCertFromLoadBalancer(p *RemoveCertFromLoadBalancerParams) (*RemoveCertFromLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("removeCertFromLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeCertFromLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5573,7 +5573,7 @@ func (s *LoadBalancerService) NewRemoveFromGlobalLoadBalancerRuleParams(id strin
 
 // Removes a load balancer rule association with global load balancer rule
 func (s *LoadBalancerService) RemoveFromGlobalLoadBalancerRule(p *RemoveFromGlobalLoadBalancerRuleParams) (*RemoveFromGlobalLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("removeFromGlobalLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeFromGlobalLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5708,7 +5708,7 @@ func (s *LoadBalancerService) NewRemoveFromLoadBalancerRuleParams(id string) *Re
 
 // Removes a virtual machine or a list of virtual machines from a load balancer rule.
 func (s *LoadBalancerService) RemoveFromLoadBalancerRule(p *RemoveFromLoadBalancerRuleParams) (*RemoveFromLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("removeFromLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeFromLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5815,7 +5815,7 @@ func (s *LoadBalancerService) NewStopNetScalerVpxParams(id string) *StopNetScale
 
 // Stops a NetScalervm.
 func (s *LoadBalancerService) StopNetScalerVpx(p *StopNetScalerVpxParams) (*StopNetScalerVpxResponse, error) {
-	resp, err := s.cs.newRequest("stopNetScalerVpx", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopNetScalerVpx", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6034,7 +6034,7 @@ func (s *LoadBalancerService) NewUpdateGlobalLoadBalancerRuleParams(id string) *
 
 // update global load balancer rules.
 func (s *LoadBalancerService) UpdateGlobalLoadBalancerRule(p *UpdateGlobalLoadBalancerRuleParams) (*UpdateGlobalLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("updateGlobalLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateGlobalLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6208,7 +6208,7 @@ func (s *LoadBalancerService) NewUpdateLBHealthCheckPolicyParams(id string) *Upd
 
 // Updates load balancer health check policy
 func (s *LoadBalancerService) UpdateLBHealthCheckPolicy(p *UpdateLBHealthCheckPolicyParams) (*UpdateLBHealthCheckPolicyResponse, error) {
-	resp, err := s.cs.newRequest("updateLBHealthCheckPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateLBHealthCheckPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6360,7 +6360,7 @@ func (s *LoadBalancerService) NewUpdateLBStickinessPolicyParams(id string) *Upda
 
 // Updates load balancer stickiness policy
 func (s *LoadBalancerService) UpdateLBStickinessPolicy(p *UpdateLBStickinessPolicyParams) (*UpdateLBStickinessPolicyResponse, error) {
-	resp, err := s.cs.newRequest("updateLBStickinessPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateLBStickinessPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6513,7 +6513,7 @@ func (s *LoadBalancerService) NewUpdateLoadBalancerParams(id string) *UpdateLoad
 
 // Updates an internal load balancer
 func (s *LoadBalancerService) UpdateLoadBalancer(p *UpdateLoadBalancerParams) (*UpdateLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("updateLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6773,7 +6773,7 @@ func (s *LoadBalancerService) NewUpdateLoadBalancerRuleParams(id string) *Update
 
 // Updates load balancer
 func (s *LoadBalancerService) UpdateLoadBalancerRule(p *UpdateLoadBalancerRuleParams) (*UpdateLoadBalancerRuleResponse, error) {
-	resp, err := s.cs.newRequest("updateLoadBalancerRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateLoadBalancerRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7075,7 +7075,7 @@ func (s *LoadBalancerService) NewUploadSslCertParams(certificate string, name st
 
 // Upload a certificate to CloudStack
 func (s *LoadBalancerService) UploadSslCert(p *UploadSslCertParams) (*UploadSslCertResponse, error) {
-	resp, err := s.cs.newRequest("uploadSslCert", p.toURLValues())
+	resp, err := s.cs.newPostRequest("uploadSslCert", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ManagementService.go
+++ b/cloudstack/ManagementService.go
@@ -804,7 +804,7 @@ func (s *ManagementService) NewReadyForShutdownParams() *ReadyForShutdownParams 
 
 // Returns the status of CloudStack, whether a shutdown has been triggered and if ready to shutdown
 func (s *ManagementService) ReadyForShutdown(p *ReadyForShutdownParams) (*ReadyForShutdownResponse, error) {
-	resp, err := s.cs.newPostRequest("readyForShutdown", p.toURLValues())
+	resp, err := s.cs.newRequest("readyForShutdown", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ManagementService.go
+++ b/cloudstack/ManagementService.go
@@ -95,7 +95,7 @@ func (s *ManagementService) NewCancelShutdownParams(managementserverid UUID) *Ca
 
 // Cancels a triggered shutdown
 func (s *ManagementService) CancelShutdown(p *CancelShutdownParams) (*CancelShutdownResponse, error) {
-	resp, err := s.cs.newRequest("cancelShutdown", p.toURLValues())
+	resp, err := s.cs.newPostRequest("cancelShutdown", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -736,7 +736,7 @@ func (s *ManagementService) NewPrepareForShutdownParams(managementserverid UUID)
 
 // Prepares CloudStack for a safe manual shutdown by preventing new jobs from being accepted
 func (s *ManagementService) PrepareForShutdown(p *PrepareForShutdownParams) (*PrepareForShutdownResponse, error) {
-	resp, err := s.cs.newRequest("prepareForShutdown", p.toURLValues())
+	resp, err := s.cs.newPostRequest("prepareForShutdown", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -804,7 +804,7 @@ func (s *ManagementService) NewReadyForShutdownParams() *ReadyForShutdownParams 
 
 // Returns the status of CloudStack, whether a shutdown has been triggered and if ready to shutdown
 func (s *ManagementService) ReadyForShutdown(p *ReadyForShutdownParams) (*ReadyForShutdownResponse, error) {
-	resp, err := s.cs.newRequest("readyForShutdown", p.toURLValues())
+	resp, err := s.cs.newPostRequest("readyForShutdown", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -876,7 +876,7 @@ func (s *ManagementService) NewTriggerShutdownParams(managementserverid UUID) *T
 
 // Triggers an automatic safe shutdown of CloudStack by not accepting new jobs and shutting down when all pending jobbs have been completed. Triggers an immediate shutdown if forced
 func (s *ManagementService) TriggerShutdown(p *TriggerShutdownParams) (*TriggerShutdownResponse, error) {
-	resp, err := s.cs.newRequest("triggerShutdown", p.toURLValues())
+	resp, err := s.cs.newPostRequest("triggerShutdown", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NATService.go
+++ b/cloudstack/NATService.go
@@ -214,7 +214,7 @@ func (s *NATService) NewCreateIpForwardingRuleParams(ipaddressid string, protoco
 
 // Creates an IP forwarding rule
 func (s *NATService) CreateIpForwardingRule(p *CreateIpForwardingRuleParams) (*CreateIpForwardingRuleResponse, error) {
-	resp, err := s.cs.newRequest("createIpForwardingRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createIpForwardingRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (s *NATService) NewDeleteIpForwardingRuleParams(id string) *DeleteIpForward
 
 // Deletes an IP forwarding rule
 func (s *NATService) DeleteIpForwardingRule(p *DeleteIpForwardingRuleParams) (*DeleteIpForwardingRuleResponse, error) {
-	resp, err := s.cs.newRequest("deleteIpForwardingRule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteIpForwardingRule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (s *NATService) NewDisableStaticNatParams(ipaddressid string) *DisableStati
 
 // Disables static rule for given IP address
 func (s *NATService) DisableStaticNat(p *DisableStaticNatParams) (*DisableStaticNatResponse, error) {
-	resp, err := s.cs.newRequest("disableStaticNat", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableStaticNat", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +553,7 @@ func (s *NATService) NewEnableStaticNatParams(ipaddressid string, virtualmachine
 
 // Enables static NAT for given IP address
 func (s *NATService) EnableStaticNat(p *EnableStaticNatParams) (*EnableStaticNatResponse, error) {
-	resp, err := s.cs.newRequest("enableStaticNat", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableStaticNat", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NetscalerService.go
+++ b/cloudstack/NetscalerService.go
@@ -294,7 +294,7 @@ func (s *NetscalerService) NewAddNetscalerLoadBalancerParams(networkdevicetype s
 
 // Adds a netscaler load balancer device
 func (s *NetscalerService) AddNetscalerLoadBalancer(p *AddNetscalerLoadBalancerParams) (*AddNetscalerLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("addNetscalerLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addNetscalerLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +494,7 @@ func (s *NetscalerService) NewConfigureNetscalerLoadBalancerParams(lbdeviceid st
 
 // configures a netscaler load balancer device
 func (s *NetscalerService) ConfigureNetscalerLoadBalancer(p *ConfigureNetscalerLoadBalancerParams) (*NetscalerLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("configureNetscalerLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configureNetscalerLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (s *NetscalerService) NewDeleteNetscalerControlCenterParams(id string) *Del
 
 // Delete Netscaler Control Center
 func (s *NetscalerService) DeleteNetscalerControlCenter(p *DeleteNetscalerControlCenterParams) (*DeleteNetscalerControlCenterResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetscalerControlCenter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetscalerControlCenter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -688,7 +688,7 @@ func (s *NetscalerService) NewDeleteNetscalerLoadBalancerParams(lbdeviceid strin
 
 // delete a netscaler load balancer device
 func (s *NetscalerService) DeleteNetscalerLoadBalancer(p *DeleteNetscalerLoadBalancerParams) (*DeleteNetscalerLoadBalancerResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetscalerLoadBalancer", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetscalerLoadBalancer", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1431,7 +1431,7 @@ func (s *NetscalerService) NewRegisterNetscalerControlCenterParams(ipaddress str
 
 // Adds a netscaler control center device
 func (s *NetscalerService) RegisterNetscalerControlCenter(p *RegisterNetscalerControlCenterParams) (*RegisterNetscalerControlCenterResponse, error) {
-	resp, err := s.cs.newRequest("registerNetscalerControlCenter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerNetscalerControlCenter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1556,7 +1556,7 @@ func (s *NetscalerService) NewRegisterNetscalerServicePackageParams(description 
 
 // Registers NCC Service Package
 func (s *NetscalerService) RegisterNetscalerServicePackage(p *RegisterNetscalerServicePackageParams) (*RegisterNetscalerServicePackageResponse, error) {
-	resp, err := s.cs.newRequest("registerNetscalerServicePackage", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerNetscalerServicePackage", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NetworkACLService.go
+++ b/cloudstack/NetworkACLService.go
@@ -396,7 +396,7 @@ func (s *NetworkACLService) NewCreateNetworkACLParams(protocol string) *CreateNe
 
 // Creates a ACL rule in the given network (the network has to belong to VPC)
 func (s *NetworkACLService) CreateNetworkACL(p *CreateNetworkACLParams) (*CreateNetworkACLResponse, error) {
-	resp, err := s.cs.newRequest("createNetworkACL", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createNetworkACL", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +571,7 @@ func (s *NetworkACLService) NewCreateNetworkACLListParams(name string, vpcid str
 
 // Creates a network ACL. If no VPC is given, then it creates a global ACL that can be used by everyone.
 func (s *NetworkACLService) CreateNetworkACLList(p *CreateNetworkACLListParams) (*CreateNetworkACLListResponse, error) {
-	resp, err := s.cs.newRequest("createNetworkACLList", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createNetworkACLList", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +662,7 @@ func (s *NetworkACLService) NewDeleteNetworkACLParams(id string) *DeleteNetworkA
 
 // Deletes a network ACL
 func (s *NetworkACLService) DeleteNetworkACL(p *DeleteNetworkACLParams) (*DeleteNetworkACLResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetworkACL", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetworkACL", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -744,7 +744,7 @@ func (s *NetworkACLService) NewDeleteNetworkACLListParams(id string) *DeleteNetw
 
 // Deletes a network ACL
 func (s *NetworkACLService) DeleteNetworkACLList(p *DeleteNetworkACLListParams) (*DeleteNetworkACLListResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetworkACLList", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetworkACLList", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1860,7 +1860,7 @@ func (s *NetworkACLService) NewMoveNetworkAclItemParams(id string) *MoveNetworkA
 
 // Move an ACL rule to a position bettwen two other ACL rules of the same ACL network list
 func (s *NetworkACLService) MoveNetworkAclItem(p *MoveNetworkAclItemParams) (*MoveNetworkAclItemResponse, error) {
-	resp, err := s.cs.newRequest("moveNetworkAclItem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("moveNetworkAclItem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2009,7 +2009,7 @@ func (s *NetworkACLService) NewReplaceNetworkACLListParams(aclid string) *Replac
 
 // Replaces ACL associated with a network or private gateway
 func (s *NetworkACLService) ReplaceNetworkACLList(p *ReplaceNetworkACLListParams) (*ReplaceNetworkACLListResponse, error) {
-	resp, err := s.cs.newRequest("replaceNetworkACLList", p.toURLValues())
+	resp, err := s.cs.newPostRequest("replaceNetworkACLList", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2411,7 +2411,7 @@ func (s *NetworkACLService) NewUpdateNetworkACLItemParams(id string) *UpdateNetw
 
 // Updates ACL item with specified ID
 func (s *NetworkACLService) UpdateNetworkACLItem(p *UpdateNetworkACLItemParams) (*UpdateNetworkACLItemResponse, error) {
-	resp, err := s.cs.newRequest("updateNetworkACLItem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateNetworkACLItem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2609,7 +2609,7 @@ func (s *NetworkACLService) NewUpdateNetworkACLListParams(id string) *UpdateNetw
 
 // Updates network ACL list
 func (s *NetworkACLService) UpdateNetworkACLList(p *UpdateNetworkACLListParams) (*UpdateNetworkACLListResponse, error) {
-	resp, err := s.cs.newRequest("updateNetworkACLList", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateNetworkACLList", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NetworkDeviceService.go
+++ b/cloudstack/NetworkDeviceService.go
@@ -109,7 +109,7 @@ func (s *NetworkDeviceService) NewAddNetworkDeviceParams() *AddNetworkDevicePara
 
 // Adds a network device of one of the following types: ExternalDhcp, ExternalFirewall, ExternalLoadBalancer, PxeServer
 func (s *NetworkDeviceService) AddNetworkDevice(p *AddNetworkDeviceParams) (*AddNetworkDeviceResponse, error) {
-	resp, err := s.cs.newRequest("addNetworkDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addNetworkDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (s *NetworkDeviceService) NewDeleteNetworkDeviceParams(id string) *DeleteNe
 
 // Deletes network device.
 func (s *NetworkDeviceService) DeleteNetworkDevice(p *DeleteNetworkDeviceParams) (*DeleteNetworkDeviceResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetworkDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetworkDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NetworkOfferingService.go
+++ b/cloudstack/NetworkOfferingService.go
@@ -840,7 +840,7 @@ func (s *NetworkOfferingService) NewCreateNetworkOfferingParams(displaytext stri
 
 // Creates a network offering.
 func (s *NetworkOfferingService) CreateNetworkOffering(p *CreateNetworkOfferingParams) (*CreateNetworkOfferingResponse, error) {
-	resp, err := s.cs.newRequest("createNetworkOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createNetworkOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -966,7 +966,7 @@ func (s *NetworkOfferingService) NewDeleteNetworkOfferingParams(id string) *Dele
 
 // Deletes a network offering.
 func (s *NetworkOfferingService) DeleteNetworkOffering(p *DeleteNetworkOfferingParams) (*DeleteNetworkOfferingResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetworkOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetworkOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2024,7 +2024,7 @@ func (s *NetworkOfferingService) NewUpdateNetworkOfferingParams() *UpdateNetwork
 
 // Updates a network offering.
 func (s *NetworkOfferingService) UpdateNetworkOffering(p *UpdateNetworkOfferingParams) (*UpdateNetworkOfferingResponse, error) {
-	resp, err := s.cs.newRequest("updateNetworkOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateNetworkOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NetworkService.go
+++ b/cloudstack/NetworkService.go
@@ -244,7 +244,7 @@ func (s *NetworkService) NewAddNetworkServiceProviderParams(name string, physica
 
 // Adds a network serviceProvider to a physical network
 func (s *NetworkService) AddNetworkServiceProvider(p *AddNetworkServiceProviderParams) (*AddNetworkServiceProviderResponse, error) {
-	resp, err := s.cs.newRequest("addNetworkServiceProvider", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addNetworkServiceProvider", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +411,7 @@ func (s *NetworkService) NewAddOpenDaylightControllerParams(password string, phy
 
 // Adds an OpenDyalight controler
 func (s *NetworkService) AddOpenDaylightController(p *AddOpenDaylightControllerParams) (*AddOpenDaylightControllerResponse, error) {
-	resp, err := s.cs.newRequest("addOpenDaylightController", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addOpenDaylightController", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +526,7 @@ func (s *NetworkService) NewChangeBgpPeersForNetworkParams(networkid string) *Ch
 
 // Change the BGP peers for a network.
 func (s *NetworkService) ChangeBgpPeersForNetwork(p *ChangeBgpPeersForNetworkParams) (*ChangeBgpPeersForNetworkResponse, error) {
-	resp, err := s.cs.newRequest("changeBgpPeersForNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeBgpPeersForNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -674,7 +674,7 @@ func (s *NetworkService) NewCreateIpv4SubnetForGuestNetworkParams(parentid strin
 
 // Creates a IPv4 subnet for guest networks.
 func (s *NetworkService) CreateIpv4SubnetForGuestNetwork(p *CreateIpv4SubnetForGuestNetworkParams) (*CreateIpv4SubnetForGuestNetworkResponse, error) {
-	resp, err := s.cs.newRequest("createIpv4SubnetForGuestNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createIpv4SubnetForGuestNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1768,7 +1768,7 @@ func (s *NetworkService) NewCreateNetworkParams(name string, networkofferingid s
 
 // Creates a network
 func (s *NetworkService) CreateNetwork(p *CreateNetworkParams) (*CreateNetworkResponse, error) {
-	resp, err := s.cs.newRequest("createNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2106,7 +2106,7 @@ func (s *NetworkService) NewCreatePhysicalNetworkParams(name string, zoneid stri
 
 // Creates a physical network
 func (s *NetworkService) CreatePhysicalNetwork(p *CreatePhysicalNetworkParams) (*CreatePhysicalNetworkResponse, error) {
-	resp, err := s.cs.newRequest("createPhysicalNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createPhysicalNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2399,7 +2399,7 @@ func (s *NetworkService) NewCreateServiceInstanceParams(leftnetworkid string, na
 
 // Creates a system virtual-machine that implements network services
 func (s *NetworkService) CreateServiceInstance(p *CreateServiceInstanceParams) (*CreateServiceInstanceResponse, error) {
-	resp, err := s.cs.newRequest("createServiceInstance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createServiceInstance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2617,7 +2617,7 @@ func (s *NetworkService) NewCreateStorageNetworkIpRangeParams(gateway string, ne
 
 // Creates a Storage network IP range.
 func (s *NetworkService) CreateStorageNetworkIpRange(p *CreateStorageNetworkIpRangeParams) (*CreateStorageNetworkIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("createStorageNetworkIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createStorageNetworkIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2784,7 +2784,7 @@ func (s *NetworkService) NewDedicatePublicIpRangeParams(domainid string, id stri
 
 // Dedicates a Public IP range to an account
 func (s *NetworkService) DedicatePublicIpRange(p *DedicatePublicIpRangeParams) (*DedicatePublicIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("dedicatePublicIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicatePublicIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2875,7 +2875,7 @@ func (s *NetworkService) NewDeleteIpv4SubnetForGuestNetworkParams(id string) *De
 
 // Deletes an existing IPv4 subnet for guest network.
 func (s *NetworkService) DeleteIpv4SubnetForGuestNetwork(p *DeleteIpv4SubnetForGuestNetworkParams) (*DeleteIpv4SubnetForGuestNetworkResponse, error) {
-	resp, err := s.cs.newRequest("deleteIpv4SubnetForGuestNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteIpv4SubnetForGuestNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2982,7 +2982,7 @@ func (s *NetworkService) NewDeleteNetworkParams(id string) *DeleteNetworkParams 
 
 // Deletes a network
 func (s *NetworkService) DeleteNetwork(p *DeleteNetworkParams) (*DeleteNetworkResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3064,7 +3064,7 @@ func (s *NetworkService) NewDeleteNetworkServiceProviderParams(id string) *Delet
 
 // Deletes a Network Service Provider.
 func (s *NetworkService) DeleteNetworkServiceProvider(p *DeleteNetworkServiceProviderParams) (*DeleteNetworkServiceProviderResponse, error) {
-	resp, err := s.cs.newRequest("deleteNetworkServiceProvider", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNetworkServiceProvider", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3146,7 +3146,7 @@ func (s *NetworkService) NewDeleteOpenDaylightControllerParams(id string) *Delet
 
 // Removes an OpenDyalight controler
 func (s *NetworkService) DeleteOpenDaylightController(p *DeleteOpenDaylightControllerParams) (*DeleteOpenDaylightControllerResponse, error) {
-	resp, err := s.cs.newRequest("deleteOpenDaylightController", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteOpenDaylightController", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3236,7 +3236,7 @@ func (s *NetworkService) NewDeletePhysicalNetworkParams(id string) *DeletePhysic
 
 // Deletes a Physical Network.
 func (s *NetworkService) DeletePhysicalNetwork(p *DeletePhysicalNetworkParams) (*DeletePhysicalNetworkResponse, error) {
-	resp, err := s.cs.newRequest("deletePhysicalNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deletePhysicalNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3318,7 +3318,7 @@ func (s *NetworkService) NewDeleteStorageNetworkIpRangeParams(id string) *Delete
 
 // Deletes a storage network IP Range.
 func (s *NetworkService) DeleteStorageNetworkIpRange(p *DeleteStorageNetworkIpRangeParams) (*DeleteStorageNetworkIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("deleteStorageNetworkIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteStorageNetworkIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6520,7 +6520,7 @@ func (s *NetworkService) NewMigrateNetworkParams(networkid string, networkofferi
 
 // moves a network to another physical network
 func (s *NetworkService) MigrateNetwork(p *MigrateNetworkParams) (*MigrateNetworkResponse, error) {
-	resp, err := s.cs.newRequest("migrateNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6703,7 +6703,7 @@ func (s *NetworkService) NewReleasePublicIpRangeParams(id string) *ReleasePublic
 
 // Releases a Public IP range back to the system pool
 func (s *NetworkService) ReleasePublicIpRange(p *ReleasePublicIpRangeParams) (*ReleasePublicIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("releasePublicIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releasePublicIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6872,7 +6872,7 @@ func (s *NetworkService) NewRestartNetworkParams(id string) *RestartNetworkParam
 
 // Restarts the network; includes 1) restarting network elements - virtual routers, DHCP servers 2) reapplying all public IPs 3) reapplying loadBalancing/portForwarding rules
 func (s *NetworkService) RestartNetwork(p *RestartNetworkParams) (*RestartNetworkResponse, error) {
-	resp, err := s.cs.newRequest("restartNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("restartNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7393,7 +7393,7 @@ func (s *NetworkService) NewUpdateNetworkParams(id string) *UpdateNetworkParams 
 
 // Updates a network
 func (s *NetworkService) UpdateNetwork(p *UpdateNetworkParams) (*UpdateNetworkResponse, error) {
-	resp, err := s.cs.newRequest("updateNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7625,7 +7625,7 @@ func (s *NetworkService) NewUpdateNetworkServiceProviderParams(id string) *Updat
 
 // Updates a network serviceProvider of a physical network
 func (s *NetworkService) UpdateNetworkServiceProvider(p *UpdateNetworkServiceProviderParams) (*UpdateNetworkServiceProviderResponse, error) {
-	resp, err := s.cs.newRequest("updateNetworkServiceProvider", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateNetworkServiceProvider", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7814,7 +7814,7 @@ func (s *NetworkService) NewUpdatePhysicalNetworkParams(id string) *UpdatePhysic
 
 // Updates a physical network
 func (s *NetworkService) UpdatePhysicalNetwork(p *UpdatePhysicalNetworkParams) (*UpdatePhysicalNetworkResponse, error) {
-	resp, err := s.cs.newRequest("updatePhysicalNetwork", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updatePhysicalNetwork", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8007,7 +8007,7 @@ func (s *NetworkService) NewUpdateStorageNetworkIpRangeParams(id string) *Update
 
 // Update a Storage network IP range, only allowed when no IPs in this range have been allocated.
 func (s *NetworkService) UpdateStorageNetworkIpRange(p *UpdateStorageNetworkIpRangeParams) (*UpdateStorageNetworkIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("updateStorageNetworkIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateStorageNetworkIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8101,7 +8101,7 @@ func (s *NetworkService) NewDeleteGuestNetworkIpv6PrefixParams(id string) *Delet
 
 // Deletes an existing guest network IPv6 prefix.
 func (s *NetworkService) DeleteGuestNetworkIpv6Prefix(p *DeleteGuestNetworkIpv6PrefixParams) (*DeleteGuestNetworkIpv6PrefixResponse, error) {
-	resp, err := s.cs.newRequest("deleteGuestNetworkIpv6Prefix", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteGuestNetworkIpv6Prefix", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8208,7 +8208,7 @@ func (s *NetworkService) NewCreateGuestNetworkIpv6PrefixParams(prefix string, zo
 
 // Creates a guest network IPv6 prefix.
 func (s *NetworkService) CreateGuestNetworkIpv6Prefix(p *CreateGuestNetworkIpv6PrefixParams) (*CreateGuestNetworkIpv6PrefixResponse, error) {
-	resp, err := s.cs.newRequest("createGuestNetworkIpv6Prefix", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createGuestNetworkIpv6Prefix", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8582,7 +8582,7 @@ func (s *NetworkService) NewCreateNetworkPermissionsParams(networkid string) *Cr
 
 // Updates network permissions.
 func (s *NetworkService) CreateNetworkPermissions(p *CreateNetworkPermissionsParams) (*CreateNetworkPermissionsResponse, error) {
-	resp, err := s.cs.newRequest("createNetworkPermissions", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createNetworkPermissions", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8676,7 +8676,7 @@ func (s *NetworkService) NewResetNetworkPermissionsParams(networkid string) *Res
 
 // Resets network permissions.
 func (s *NetworkService) ResetNetworkPermissions(p *ResetNetworkPermissionsParams) (*ResetNetworkPermissionsResponse, error) {
-	resp, err := s.cs.newRequest("resetNetworkPermissions", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetNetworkPermissions", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8922,7 +8922,7 @@ func (s *NetworkService) NewRemoveNetworkPermissionsParams(networkid string) *Re
 
 // Removes network permissions.
 func (s *NetworkService) RemoveNetworkPermissions(p *RemoveNetworkPermissionsParams) (*RemoveNetworkPermissionsResponse, error) {
-	resp, err := s.cs.newRequest("removeNetworkPermissions", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeNetworkPermissions", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NicService.go
+++ b/cloudstack/NicService.go
@@ -107,7 +107,7 @@ func (s *NicService) NewAddIpToNicParams(nicid string) *AddIpToNicParams {
 
 // Assigns secondary IP to NIC
 func (s *NicService) AddIpToNic(p *AddIpToNicParams) (*AddIpToNicResponse, error) {
-	resp, err := s.cs.newRequest("addIpToNic", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addIpToNic", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +452,7 @@ func (s *NicService) NewRemoveIpFromNicParams(id string) *RemoveIpFromNicParams 
 
 // Removes secondary IP from the NIC.
 func (s *NicService) RemoveIpFromNic(p *RemoveIpFromNicParams) (*RemoveIpFromNicResponse, error) {
-	resp, err := s.cs.newRequest("removeIpFromNic", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeIpFromNic", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func (s *NicService) NewUpdateVmNicIpParams(nicid string) *UpdateVmNicIpParams {
 
 // Update the default Ip of a VM Nic
 func (s *NicService) UpdateVmNicIp(p *UpdateVmNicIpParams) (*UpdateVmNicIpResponse, error) {
-	resp, err := s.cs.newRequest("updateVmNicIp", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVmNicIp", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/NiciraNVPService.go
+++ b/cloudstack/NiciraNVPService.go
@@ -229,7 +229,7 @@ func (s *NiciraNVPService) NewAddNiciraNvpDeviceParams(hostname string, password
 
 // Adds a Nicira NVP device
 func (s *NiciraNVPService) AddNiciraNvpDevice(p *AddNiciraNvpDeviceParams) (*AddNiciraNvpDeviceResponse, error) {
-	resp, err := s.cs.newRequest("addNiciraNvpDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addNiciraNvpDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (s *NiciraNVPService) NewDeleteNiciraNvpDeviceParams(nvpdeviceid string) *D
 
 // delete a nicira nvp device
 func (s *NiciraNVPService) DeleteNiciraNvpDevice(p *DeleteNiciraNvpDeviceParams) (*DeleteNiciraNvpDeviceResponse, error) {
-	resp, err := s.cs.newRequest("deleteNiciraNvpDevice", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteNiciraNvpDevice", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/OauthService.go
+++ b/cloudstack/OauthService.go
@@ -465,7 +465,7 @@ func (s *OauthService) NewUpdateOauthProviderParams(id string) *UpdateOauthProvi
 
 // Updates the registered OAuth provider details
 func (s *OauthService) UpdateOauthProvider(p *UpdateOauthProviderParams) (*UpdateOauthProviderResponse, error) {
-	resp, err := s.cs.newRequest("updateOauthProvider", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateOauthProvider", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +541,7 @@ func (s *OauthService) NewDeleteOauthProviderParams(id string) *DeleteOauthProvi
 
 // Deletes the registered OAuth provider
 func (s *OauthService) DeleteOauthProvider(p *DeleteOauthProviderParams) (*DeleteOauthProviderResponse, error) {
-	resp, err := s.cs.newRequest("deleteOauthProvider", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteOauthProvider", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ObjectStoreService.go
+++ b/cloudstack/ObjectStoreService.go
@@ -309,7 +309,7 @@ func (s *ObjectStoreService) NewCreateBucketParams(name string, objectstorageid 
 
 // Creates a bucket in the specified object storage pool.
 func (s *ObjectStoreService) CreateBucket(p *CreateBucketParams) (*CreateBucketResponse, error) {
-	resp, err := s.cs.newRequest("createBucket", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createBucket", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +418,7 @@ func (s *ObjectStoreService) NewDeleteBucketParams(id string) *DeleteBucketParam
 
 // Deletes an empty Bucket.
 func (s *ObjectStoreService) DeleteBucket(p *DeleteBucketParams) (*DeleteBucketResponse, error) {
-	resp, err := s.cs.newRequest("deleteBucket", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteBucket", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +611,7 @@ func (s *ObjectStoreService) NewUpdateBucketParams(id string) *UpdateBucketParam
 
 // Updates Bucket properties
 func (s *ObjectStoreService) UpdateBucket(p *UpdateBucketParams) (*UpdateBucketResponse, error) {
-	resp, err := s.cs.newRequest("updateBucket", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateBucket", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/OutofbandManagementService.go
+++ b/cloudstack/OutofbandManagementService.go
@@ -105,7 +105,7 @@ func (s *OutofbandManagementService) NewChangeOutOfBandManagementPasswordParams(
 
 // Changes out-of-band management interface password on the host and updates the interface configuration in CloudStack if the operation succeeds, else reverts the old password
 func (s *OutofbandManagementService) ChangeOutOfBandManagementPassword(p *ChangeOutOfBandManagementPasswordParams) (*ChangeOutOfBandManagementPasswordResponse, error) {
-	resp, err := s.cs.newRequest("changeOutOfBandManagementPassword", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeOutOfBandManagementPassword", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (s *OutofbandManagementService) NewConfigureOutOfBandManagementParams(addre
 
 // Configures a host's out-of-band management interface
 func (s *OutofbandManagementService) ConfigureOutOfBandManagement(p *ConfigureOutOfBandManagementParams) (*OutOfBandManagementResponse, error) {
-	resp, err := s.cs.newRequest("configureOutOfBandManagement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configureOutOfBandManagement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +452,7 @@ func (s *OutofbandManagementService) NewIssueOutOfBandManagementPowerActionParam
 
 // Initiates the specified power action to the host's out-of-band management interface
 func (s *OutofbandManagementService) IssueOutOfBandManagementPowerAction(p *IssueOutOfBandManagementPowerActionParams) (*IssueOutOfBandManagementPowerActionResponse, error) {
-	resp, err := s.cs.newRequest("issueOutOfBandManagementPowerAction", p.toURLValues())
+	resp, err := s.cs.newPostRequest("issueOutOfBandManagementPowerAction", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/OvsElementService.go
+++ b/cloudstack/OvsElementService.go
@@ -108,7 +108,7 @@ func (s *OvsElementService) NewConfigureOvsElementParams(enabled bool, id string
 
 // Configures an ovs element.
 func (s *OvsElementService) ConfigureOvsElement(p *ConfigureOvsElementParams) (*OvsElementResponse, error) {
-	resp, err := s.cs.newRequest("configureOvsElement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configureOvsElement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/PodService.go
+++ b/cloudstack/PodService.go
@@ -248,7 +248,7 @@ func (s *PodService) NewCreateManagementNetworkIpRangeParams(gateway string, net
 
 // Creates a Management network IP range.
 func (s *PodService) CreateManagementNetworkIpRange(p *CreateManagementNetworkIpRangeParams) (*CreateManagementNetworkIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("createManagementNetworkIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createManagementNetworkIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (s *PodService) NewCreatePodParams(name string, zoneid string) *CreatePodPa
 
 // Creates a new Pod.
 func (s *PodService) CreatePod(p *CreatePodParams) (*CreatePodResponse, error) {
-	resp, err := s.cs.newRequest("createPod", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createPod", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -674,7 +674,7 @@ func (s *PodService) NewDedicatePodParams(domainid string, podid string) *Dedica
 
 // Dedicates a Pod.
 func (s *PodService) DedicatePod(p *DedicatePodParams) (*DedicatePodResponse, error) {
-	resp, err := s.cs.newRequest("dedicatePod", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicatePod", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -840,7 +840,7 @@ func (s *PodService) NewDeleteManagementNetworkIpRangeParams(endip string, podid
 
 // Deletes a management network IP range. This action is only allowed when no IPs in this range are allocated.
 func (s *PodService) DeleteManagementNetworkIpRange(p *DeleteManagementNetworkIpRangeParams) (*DeleteManagementNetworkIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("deleteManagementNetworkIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteManagementNetworkIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -922,7 +922,7 @@ func (s *PodService) NewDeletePodParams(id string) *DeletePodParams {
 
 // Deletes a Pod.
 func (s *PodService) DeletePod(p *DeletePodParams) (*DeletePodResponse, error) {
-	resp, err := s.cs.newRequest("deletePod", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deletePod", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1599,7 +1599,7 @@ func (s *PodService) NewReleaseDedicatedPodParams(podid string) *ReleaseDedicate
 
 // Release the dedication for the pod
 func (s *PodService) ReleaseDedicatedPod(p *ReleaseDedicatedPodParams) (*ReleaseDedicatedPodResponse, error) {
-	resp, err := s.cs.newRequest("releaseDedicatedPod", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseDedicatedPod", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1825,7 +1825,7 @@ func (s *PodService) NewUpdatePodParams(id string) *UpdatePodParams {
 
 // Updates a Pod.
 func (s *PodService) UpdatePod(p *UpdatePodParams) (*UpdatePodResponse, error) {
-	resp, err := s.cs.newRequest("updatePod", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updatePod", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2027,7 +2027,7 @@ func (s *PodService) NewUpdatePodManagementNetworkIpRangeParams(currentendip str
 
 // Updates a management network IP range. Only allowed when no IPs are allocated.
 func (s *PodService) UpdatePodManagementNetworkIpRange(p *UpdatePodManagementNetworkIpRangeParams) (*UpdatePodManagementNetworkIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("updatePodManagementNetworkIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updatePodManagementNetworkIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/PoolService.go
+++ b/cloudstack/PoolService.go
@@ -415,7 +415,7 @@ func (s *PoolService) NewCreateStoragePoolParams(name string, url string, zoneid
 
 // Creates a storage pool.
 func (s *PoolService) CreateStoragePool(p *CreateStoragePoolParams) (*CreateStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("createStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func (s *PoolService) NewDeleteStoragePoolParams(id string) *DeleteStoragePoolPa
 
 // Deletes a storage pool.
 func (s *PoolService) DeleteStoragePool(p *DeleteStoragePoolParams) (*DeleteStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("deleteStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1376,7 +1376,7 @@ func (s *PoolService) NewSyncStoragePoolParams(id string) *SyncStoragePoolParams
 
 // Sync storage pool with management server (currently supported for Datastore Cluster in VMware and syncs the datastores in it)
 func (s *PoolService) SyncStoragePool(p *SyncStoragePoolParams) (*SyncStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("syncStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("syncStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1691,7 +1691,7 @@ func (s *PoolService) NewUpdateStoragePoolParams(id string) *UpdateStoragePoolPa
 
 // Updates a storage pool.
 func (s *PoolService) UpdateStoragePool(p *UpdateStoragePoolParams) (*UpdateStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("updateStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/PortableIPService.go
+++ b/cloudstack/PortableIPService.go
@@ -209,7 +209,7 @@ func (s *PortableIPService) NewCreatePortableIpRangeParams(endip string, gateway
 
 // adds a range of portable public IP's to a region
 func (s *PortableIPService) CreatePortableIpRange(p *CreatePortableIpRangeParams) (*CreatePortableIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("createPortableIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createPortableIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (s *PortableIPService) NewDeletePortableIpRangeParams(id string) *DeletePor
 
 // deletes a range of portable public IP's associated with a region
 func (s *PortableIPService) DeletePortableIpRange(p *DeletePortableIpRangeParams) (*DeletePortableIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("deletePortableIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deletePortableIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ProjectService.go
+++ b/cloudstack/ProjectService.go
@@ -121,7 +121,7 @@ func (s *ProjectService) NewActivateProjectParams(id string) *ActivateProjectPar
 
 // Activates a project
 func (s *ProjectService) ActivateProject(p *ActivateProjectParams) (*ActivateProjectResponse, error) {
-	resp, err := s.cs.newRequest("activateProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("activateProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +349,7 @@ func (s *ProjectService) NewAddAccountToProjectParams(projectid string) *AddAcco
 
 // Adds account to a project
 func (s *ProjectService) AddAccountToProject(p *AddAccountToProjectParams) (*AddAccountToProjectResponse, error) {
-	resp, err := s.cs.newRequest("addAccountToProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addAccountToProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ func (s *ProjectService) NewAddUserToProjectParams(projectid string, username st
 
 // Adds user to a project
 func (s *ProjectService) AddUserToProject(p *AddUserToProjectParams) (*AddUserToProjectResponse, error) {
-	resp, err := s.cs.newRequest("addUserToProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addUserToProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +731,7 @@ func (s *ProjectService) NewCreateProjectParams(displaytext string, name string)
 
 // Creates a project
 func (s *ProjectService) CreateProject(p *CreateProjectParams) (*CreateProjectResponse, error) {
-	resp, err := s.cs.newRequest("createProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -888,7 +888,7 @@ func (s *ProjectService) NewDeleteAccountFromProjectParams(account string, proje
 
 // Deletes account from the project
 func (s *ProjectService) DeleteAccountFromProject(p *DeleteAccountFromProjectParams) (*DeleteAccountFromProjectResponse, error) {
-	resp, err := s.cs.newRequest("deleteAccountFromProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteAccountFromProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -995,7 +995,7 @@ func (s *ProjectService) NewDeleteUserFromProjectParams(projectid string, userid
 
 // Deletes user from the project
 func (s *ProjectService) DeleteUserFromProject(p *DeleteUserFromProjectParams) (*DeleteUserFromProjectResponse, error) {
-	resp, err := s.cs.newRequest("deleteUserFromProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteUserFromProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1102,7 +1102,7 @@ func (s *ProjectService) NewDeleteProjectParams(id string) *DeleteProjectParams 
 
 // Deletes a project
 func (s *ProjectService) DeleteProject(p *DeleteProjectParams) (*DeleteProjectResponse, error) {
-	resp, err := s.cs.newRequest("deleteProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1184,7 +1184,7 @@ func (s *ProjectService) NewDeleteProjectInvitationParams(id string) *DeleteProj
 
 // Deletes project invitation
 func (s *ProjectService) DeleteProjectInvitation(p *DeleteProjectInvitationParams) (*DeleteProjectInvitationResponse, error) {
-	resp, err := s.cs.newRequest("deleteProjectInvitation", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteProjectInvitation", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2192,7 +2192,7 @@ func (s *ProjectService) NewSuspendProjectParams(id string) *SuspendProjectParam
 
 // Suspends a project
 func (s *ProjectService) SuspendProject(p *SuspendProjectParams) (*SuspendProjectResponse, error) {
-	resp, err := s.cs.newRequest("suspendProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("suspendProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2469,7 +2469,7 @@ func (s *ProjectService) NewUpdateProjectParams(id string) *UpdateProjectParams 
 
 // Updates a project
 func (s *ProjectService) UpdateProject(p *UpdateProjectParams) (*UpdateProjectResponse, error) {
-	resp, err := s.cs.newRequest("updateProject", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateProject", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2698,7 +2698,7 @@ func (s *ProjectService) NewUpdateProjectInvitationParams(projectid string) *Upd
 
 // Accepts or declines project invitation
 func (s *ProjectService) UpdateProjectInvitation(p *UpdateProjectInvitationParams) (*UpdateProjectInvitationResponse, error) {
-	resp, err := s.cs.newRequest("updateProjectInvitation", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateProjectInvitation", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2980,7 +2980,7 @@ func (s *ProjectService) NewCreateProjectRolePermissionParams(permission string,
 
 // Adds API permissions to a project role
 func (s *ProjectService) CreateProjectRolePermission(p *CreateProjectRolePermissionParams) (*CreateProjectRolePermissionResponse, error) {
-	resp, err := s.cs.newRequest("createProjectRolePermission", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createProjectRolePermission", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3150,7 +3150,7 @@ func (s *ProjectService) NewUpdateProjectRolePermissionParams(projectid string, 
 
 // Updates a project role permission and/or order
 func (s *ProjectService) UpdateProjectRolePermission(p *UpdateProjectRolePermissionParams) (*UpdateProjectRolePermissionResponse, error) {
-	resp, err := s.cs.newRequest("updateProjectRolePermission", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateProjectRolePermission", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3269,7 +3269,7 @@ func (s *ProjectService) NewDeleteProjectRolePermissionParams(id string, project
 
 // Deletes a project role permission in the project
 func (s *ProjectService) DeleteProjectRolePermission(p *DeleteProjectRolePermissionParams) (*DeleteProjectRolePermissionResponse, error) {
-	resp, err := s.cs.newRequest("deleteProjectRolePermission", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteProjectRolePermission", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3412,7 +3412,7 @@ func (s *ProjectService) NewCreateProjectRoleParams(name string, projectid strin
 
 // Creates a Project role
 func (s *ProjectService) CreateProjectRole(p *CreateProjectRoleParams) (*CreateProjectRoleResponse, error) {
-	resp, err := s.cs.newRequest("createProjectRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createProjectRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3558,7 +3558,7 @@ func (s *ProjectService) NewUpdateProjectRoleParams(id string, projectid string)
 
 // Creates a Project role
 func (s *ProjectService) UpdateProjectRole(p *UpdateProjectRoleParams) (*UpdateProjectRoleResponse, error) {
-	resp, err := s.cs.newRequest("updateProjectRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateProjectRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3656,7 +3656,7 @@ func (s *ProjectService) NewDeleteProjectRoleParams(id string, projectid string)
 
 // Delete Project roles in CloudStack
 func (s *ProjectService) DeleteProjectRole(p *DeleteProjectRoleParams) (*DeleteProjectRoleResponse, error) {
-	resp, err := s.cs.newRequest("deleteProjectRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteProjectRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/QuotaService.go
+++ b/cloudstack/QuotaService.go
@@ -192,7 +192,7 @@ func (s *QuotaService) NewQuotaBalanceParams(account string, domainid string) *Q
 
 // Create a quota balance statement
 func (s *QuotaService) QuotaBalance(p *QuotaBalanceParams) (*QuotaBalanceResponse, error) {
-	resp, err := s.cs.newPostRequest("quotaBalance", p.toURLValues())
+	resp, err := s.cs.newRequest("quotaBalance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (s *QuotaService) NewQuotaIsEnabledParams() *QuotaIsEnabledParams {
 
 // Return true if the plugin is enabled
 func (s *QuotaService) QuotaIsEnabled(p *QuotaIsEnabledParams) (*QuotaIsEnabledResponse, error) {
-	resp, err := s.cs.newPostRequest("quotaIsEnabled", p.toURLValues())
+	resp, err := s.cs.newRequest("quotaIsEnabled", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +598,7 @@ func (s *QuotaService) NewQuotaStatementParams(account string, domainid string, 
 
 // Create a quota statement
 func (s *QuotaService) QuotaStatement(p *QuotaStatementParams) (*QuotaStatementResponse, error) {
-	resp, err := s.cs.newPostRequest("quotaStatement", p.toURLValues())
+	resp, err := s.cs.newRequest("quotaStatement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +801,7 @@ func (s *QuotaService) NewQuotaSummaryParams() *QuotaSummaryParams {
 
 // Lists balance and quota usage for all accounts
 func (s *QuotaService) QuotaSummary(p *QuotaSummaryParams) (*QuotaSummaryResponse, error) {
-	resp, err := s.cs.newPostRequest("quotaSummary", p.toURLValues())
+	resp, err := s.cs.newRequest("quotaSummary", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1449,7 +1449,7 @@ func (s *QuotaService) NewQuotaTariffListParams() *QuotaTariffListParams {
 
 // Lists all quota tariff plans
 func (s *QuotaService) QuotaTariffList(p *QuotaTariffListParams) (*QuotaTariffListResponse, error) {
-	resp, err := s.cs.newPostRequest("quotaTariffList", p.toURLValues())
+	resp, err := s.cs.newRequest("quotaTariffList", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/QuotaService.go
+++ b/cloudstack/QuotaService.go
@@ -192,7 +192,7 @@ func (s *QuotaService) NewQuotaBalanceParams(account string, domainid string) *Q
 
 // Create a quota balance statement
 func (s *QuotaService) QuotaBalance(p *QuotaBalanceParams) (*QuotaBalanceResponse, error) {
-	resp, err := s.cs.newRequest("quotaBalance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaBalance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +364,7 @@ func (s *QuotaService) NewQuotaCreditsParams(account string, domainid string, va
 
 // Add +-credits to an account
 func (s *QuotaService) QuotaCredits(p *QuotaCreditsParams) (*QuotaCreditsResponse, error) {
-	resp, err := s.cs.newRequest("quotaCredits", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaCredits", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (s *QuotaService) NewQuotaIsEnabledParams() *QuotaIsEnabledParams {
 
 // Return true if the plugin is enabled
 func (s *QuotaService) QuotaIsEnabled(p *QuotaIsEnabledParams) (*QuotaIsEnabledResponse, error) {
-	resp, err := s.cs.newRequest("quotaIsEnabled", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaIsEnabled", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +598,7 @@ func (s *QuotaService) NewQuotaStatementParams(account string, domainid string, 
 
 // Create a quota statement
 func (s *QuotaService) QuotaStatement(p *QuotaStatementParams) (*QuotaStatementResponse, error) {
-	resp, err := s.cs.newRequest("quotaStatement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaStatement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +801,7 @@ func (s *QuotaService) NewQuotaSummaryParams() *QuotaSummaryParams {
 
 // Lists balance and quota usage for all accounts
 func (s *QuotaService) QuotaSummary(p *QuotaSummaryParams) (*QuotaSummaryResponse, error) {
-	resp, err := s.cs.newRequest("quotaSummary", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaSummary", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1135,7 +1135,7 @@ func (s *QuotaService) NewQuotaTariffDeleteParams(id string) *QuotaTariffDeleteP
 
 // Marks a quota tariff as removed.
 func (s *QuotaService) QuotaTariffDelete(p *QuotaTariffDeleteParams) (*QuotaTariffDeleteResponse, error) {
-	resp, err := s.cs.newRequest("quotaTariffDelete", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaTariffDelete", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1449,7 +1449,7 @@ func (s *QuotaService) NewQuotaTariffListParams() *QuotaTariffListParams {
 
 // Lists all quota tariff plans
 func (s *QuotaService) QuotaTariffList(p *QuotaTariffListParams) (*QuotaTariffListResponse, error) {
-	resp, err := s.cs.newRequest("quotaTariffList", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaTariffList", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1705,7 +1705,7 @@ func (s *QuotaService) NewQuotaTariffUpdateParams(name string) *QuotaTariffUpdat
 
 // Update the tariff plan for a resource
 func (s *QuotaService) QuotaTariffUpdate(p *QuotaTariffUpdateParams) (*QuotaTariffUpdateResponse, error) {
-	resp, err := s.cs.newRequest("quotaTariffUpdate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaTariffUpdate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1760,7 +1760,7 @@ func (s *QuotaService) NewQuotaUpdateParams() *QuotaUpdateParams {
 
 // Update quota calculations, alerts and statements
 func (s *QuotaService) QuotaUpdate(p *QuotaUpdateParams) (*QuotaUpdateResponse, error) {
-	resp, err := s.cs.newRequest("quotaUpdate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("quotaUpdate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/RegionService.go
+++ b/cloudstack/RegionService.go
@@ -134,7 +134,7 @@ func (s *RegionService) NewAddRegionParams(endpoint string, id int, name string)
 
 // Adds a Region
 func (s *RegionService) AddRegion(p *AddRegionParams) (*AddRegionResponse, error) {
-	resp, err := s.cs.newRequest("addRegion", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addRegion", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (s *RegionService) NewRemoveRegionParams(id int) *RemoveRegionParams {
 
 // Removes specified region
 func (s *RegionService) RemoveRegion(p *RemoveRegionParams) (*RemoveRegionResponse, error) {
-	resp, err := s.cs.newRequest("removeRegion", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeRegion", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +521,7 @@ func (s *RegionService) NewUpdateRegionParams(id int) *UpdateRegionParams {
 
 // Updates a region
 func (s *RegionService) UpdateRegion(p *UpdateRegionParams) (*UpdateRegionResponse, error) {
-	resp, err := s.cs.newRequest("updateRegion", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateRegion", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/RegistrationService.go
+++ b/cloudstack/RegistrationService.go
@@ -221,7 +221,7 @@ func (s *RegistrationService) NewRegisterOauthProviderParams(clientid string, de
 
 // Register the OAuth2 provider in CloudStack
 func (s *RegistrationService) RegisterOauthProvider(p *RegisterOauthProviderParams) (*RegisterOauthProviderResponse, error) {
-	resp, err := s.cs.newRequest("registerOauthProvider", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerOauthProvider", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ResourceIconService.go
+++ b/cloudstack/ResourceIconService.go
@@ -108,7 +108,7 @@ func (s *ResourceIconService) NewDeleteResourceIconParams(resourceids []string, 
 
 // deletes the resource icon from the specified resource(s)
 func (s *ResourceIconService) DeleteResourceIcon(p *DeleteResourceIconParams) (*DeleteResourceIconResponse, error) {
-	resp, err := s.cs.newRequest("deleteResourceIcon", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteResourceIcon", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (s *ResourceIconService) NewUploadResourceIconParams(base64image string, re
 
 // Uploads an icon for the specified resource(s)
 func (s *ResourceIconService) UploadResourceIcon(p *UploadResourceIconParams) (*UploadResourceIconResponse, error) {
-	resp, err := s.cs.newRequest("uploadResourceIcon", p.toURLValues())
+	resp, err := s.cs.newPostRequest("uploadResourceIcon", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ResourceService.go
+++ b/cloudstack/ResourceService.go
@@ -149,7 +149,7 @@ func (s *ResourceService) NewPurgeExpungedResourcesParams() *PurgeExpungedResour
 
 // Purge expunged resources
 func (s *ResourceService) PurgeExpungedResources(p *PurgeExpungedResourcesParams) (*PurgeExpungedResourcesResponse, error) {
-	resp, err := s.cs.newRequest("purgeExpungedResources", p.toURLValues())
+	resp, err := s.cs.newPostRequest("purgeExpungedResources", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ResourcemetadataService.go
+++ b/cloudstack/ResourcemetadataService.go
@@ -165,7 +165,7 @@ func (s *ResourcemetadataService) NewAddResourceDetailParams(details map[string]
 
 // Adds detail for the Resource.
 func (s *ResourcemetadataService) AddResourceDetail(p *AddResourceDetailParams) (*AddResourceDetailResponse, error) {
-	resp, err := s.cs.newRequest("addResourceDetail", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addResourceDetail", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -831,7 +831,7 @@ func (s *ResourcemetadataService) NewRemoveResourceDetailParams(resourceid strin
 
 // Removes detail for the Resource.
 func (s *ResourcemetadataService) RemoveResourceDetail(p *RemoveResourceDetailParams) (*RemoveResourceDetailResponse, error) {
-	resp, err := s.cs.newRequest("removeResourceDetail", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeResourceDetail", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ResourcetagsService.go
+++ b/cloudstack/ResourcetagsService.go
@@ -165,7 +165,7 @@ func (s *ResourcetagsService) NewCreateTagsParams(resourceids []string, resource
 
 // Creates resource tag(s)
 func (s *ResourcetagsService) CreateTags(p *CreateTagsParams) (*CreateTagsResponse, error) {
-	resp, err := s.cs.newRequest("createTags", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createTags", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +303,7 @@ func (s *ResourcetagsService) NewDeleteTagsParams(resourceids []string, resource
 
 // Deleting resource tag(s)
 func (s *ResourcetagsService) DeleteTags(p *DeleteTagsParams) (*DeleteTagsResponse, error) {
-	resp, err := s.cs.newRequest("deleteTags", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteTags", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/RoleService.go
+++ b/cloudstack/RoleService.go
@@ -202,7 +202,7 @@ func (s *RoleService) NewCreateRoleParams(name string) *CreateRoleParams {
 
 // Creates a role
 func (s *RoleService) CreateRole(p *CreateRoleParams) (*CreateRoleResponse, error) {
-	resp, err := s.cs.newRequest("createRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (s *RoleService) NewCreateRolePermissionParams(permission string, roleid st
 
 // Adds an API permission to a role
 func (s *RoleService) CreateRolePermission(p *CreateRolePermissionParams) (*CreateRolePermissionResponse, error) {
-	resp, err := s.cs.newRequest("createRolePermission", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createRolePermission", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (s *RoleService) NewDeleteRoleParams(id string) *DeleteRoleParams {
 
 // Deletes a role
 func (s *RoleService) DeleteRole(p *DeleteRoleParams) (*DeleteRoleResponse, error) {
-	resp, err := s.cs.newRequest("deleteRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -519,7 +519,7 @@ func (s *RoleService) NewDeleteRolePermissionParams(id string) *DeleteRolePermis
 
 // Deletes a role permission
 func (s *RoleService) DeleteRolePermission(p *DeleteRolePermissionParams) (*DeleteRolePermissionResponse, error) {
-	resp, err := s.cs.newRequest("deleteRolePermission", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteRolePermission", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +613,7 @@ func (s *RoleService) NewDisableRoleParams(id string) *DisableRoleParams {
 
 // Disables a role
 func (s *RoleService) DisableRole(p *DisableRoleParams) (*DisableRoleResponse, error) {
-	resp, err := s.cs.newRequest("disableRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +707,7 @@ func (s *RoleService) NewEnableRoleParams(id string) *EnableRoleParams {
 
 // Enables a role
 func (s *RoleService) EnableRole(p *EnableRoleParams) (*EnableRoleResponse, error) {
-	resp, err := s.cs.newRequest("enableRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -928,7 +928,7 @@ func (s *RoleService) NewImportRoleParams(name string, rules map[string]string) 
 
 // Imports a role based on provided map of rule permissions
 func (s *RoleService) ImportRole(p *ImportRoleParams) (*ImportRoleResponse, error) {
-	resp, err := s.cs.newRequest("importRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("importRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1480,7 +1480,7 @@ func (s *RoleService) NewUpdateRoleParams(id string) *UpdateRoleParams {
 
 // Updates a role
 func (s *RoleService) UpdateRole(p *UpdateRoleParams) (*UpdateRoleResponse, error) {
-	resp, err := s.cs.newRequest("updateRole", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateRole", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1625,7 +1625,7 @@ func (s *RoleService) NewUpdateRolePermissionParams(roleid string) *UpdateRolePe
 
 // Updates a role permission order
 func (s *RoleService) UpdateRolePermission(p *UpdateRolePermissionParams) (*UpdateRolePermissionResponse, error) {
-	resp, err := s.cs.newRequest("updateRolePermission", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateRolePermission", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/RollingMaintenanceService.go
+++ b/cloudstack/RollingMaintenanceService.go
@@ -227,7 +227,7 @@ func (s *RollingMaintenanceService) NewStartRollingMaintenanceParams() *StartRol
 
 // Start rolling maintenance
 func (s *RollingMaintenanceService) StartRollingMaintenance(p *StartRollingMaintenanceParams) (*StartRollingMaintenanceResponse, error) {
-	resp, err := s.cs.newRequest("startRollingMaintenance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startRollingMaintenance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/RouterService.go
+++ b/cloudstack/RouterService.go
@@ -126,7 +126,7 @@ func (s *RouterService) NewChangeServiceForRouterParams(id string, serviceofferi
 
 // Upgrades domain router to a new service offering
 func (s *RouterService) ChangeServiceForRouter(p *ChangeServiceForRouterParams) (*ChangeServiceForRouterResponse, error) {
-	resp, err := s.cs.newRequest("changeServiceForRouter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeServiceForRouter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (s *RouterService) NewConfigureVirtualRouterElementParams(enabled bool, id 
 
 // Configures a virtual router element.
 func (s *RouterService) ConfigureVirtualRouterElement(p *ConfigureVirtualRouterElementParams) (*VirtualRouterElementResponse, error) {
-	resp, err := s.cs.newRequest("configureVirtualRouterElement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("configureVirtualRouterElement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (s *RouterService) NewCreateVirtualRouterElementParams(nspid string) *Creat
 
 // Create a virtual router element.
 func (s *RouterService) CreateVirtualRouterElement(p *CreateVirtualRouterElementParams) (*CreateVirtualRouterElementResponse, error) {
-	resp, err := s.cs.newRequest("createVirtualRouterElement", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVirtualRouterElement", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (s *RouterService) NewDestroyRouterParams(id string) *DestroyRouterParams {
 
 // Destroys a router.
 func (s *RouterService) DestroyRouter(p *DestroyRouterParams) (*DestroyRouterResponse, error) {
-	resp, err := s.cs.newRequest("destroyRouter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("destroyRouter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1690,7 +1690,7 @@ func (s *RouterService) NewRebootRouterParams(id string) *RebootRouterParams {
 
 // Starts a router.
 func (s *RouterService) RebootRouter(p *RebootRouterParams) (*RebootRouterResponse, error) {
-	resp, err := s.cs.newRequest("rebootRouter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("rebootRouter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1837,7 +1837,7 @@ func (s *RouterService) NewStartRouterParams(id string) *StartRouterParams {
 
 // Starts a router.
 func (s *RouterService) StartRouter(p *StartRouterParams) (*StartRouterResponse, error) {
-	resp, err := s.cs.newRequest("startRouter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startRouter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2009,7 +2009,7 @@ func (s *RouterService) NewStopRouterParams(id string) *StopRouterParams {
 
 // Stops a router.
 func (s *RouterService) StopRouter(p *StopRouterParams) (*StopRouterResponse, error) {
-	resp, err := s.cs.newRequest("stopRouter", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopRouter", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/SSHService.go
+++ b/cloudstack/SSHService.go
@@ -162,7 +162,7 @@ func (s *SSHService) NewCreateSSHKeyPairParams(name string) *CreateSSHKeyPairPar
 
 // Create a new keypair and returns the private key
 func (s *SSHService) CreateSSHKeyPair(p *CreateSSHKeyPairParams) (*CreateSSHKeyPairResponse, error) {
-	resp, err := s.cs.newRequest("createSSHKeyPair", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSSHKeyPair", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +313,7 @@ func (s *SSHService) NewDeleteSSHKeyPairParams(name string) *DeleteSSHKeyPairPar
 
 // Deletes a keypair by name
 func (s *SSHService) DeleteSSHKeyPair(p *DeleteSSHKeyPairParams) (*DeleteSSHKeyPairResponse, error) {
-	resp, err := s.cs.newRequest("deleteSSHKeyPair", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteSSHKeyPair", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -909,7 +909,7 @@ func (s *SSHService) NewRegisterSSHKeyPairParams(name string, publickey string) 
 
 // Register a public key in a keypair under a certain name
 func (s *SSHService) RegisterSSHKeyPair(p *RegisterSSHKeyPairParams) (*RegisterSSHKeyPairResponse, error) {
-	resp, err := s.cs.newRequest("registerSSHKeyPair", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerSSHKeyPair", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1108,7 +1108,7 @@ func (s *SSHService) NewResetSSHKeyForVirtualMachineParams(id string) *ResetSSHK
 
 // Resets the SSH Key for virtual machine. The virtual machine must be in a "Stopped" state. [async]
 func (s *SSHService) ResetSSHKeyForVirtualMachine(p *ResetSSHKeyForVirtualMachineParams) (*ResetSSHKeyForVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("resetSSHKeyForVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetSSHKeyForVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/SecurityGroupService.go
+++ b/cloudstack/SecurityGroupService.go
@@ -400,7 +400,7 @@ func (s *SecurityGroupService) NewAuthorizeSecurityGroupEgressParams() *Authoriz
 
 // Authorizes a particular egress rule for this security group
 func (s *SecurityGroupService) AuthorizeSecurityGroupEgress(p *AuthorizeSecurityGroupEgressParams) (*AuthorizeSecurityGroupEgressResponse, error) {
-	resp, err := s.cs.newRequest("authorizeSecurityGroupEgress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("authorizeSecurityGroupEgress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -772,7 +772,7 @@ func (s *SecurityGroupService) NewAuthorizeSecurityGroupIngressParams() *Authori
 
 // Authorizes a particular ingress rule for this security group
 func (s *SecurityGroupService) AuthorizeSecurityGroupIngress(p *AuthorizeSecurityGroupIngressParams) (*AuthorizeSecurityGroupIngressResponse, error) {
-	resp, err := s.cs.newRequest("authorizeSecurityGroupIngress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("authorizeSecurityGroupIngress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -968,7 +968,7 @@ func (s *SecurityGroupService) NewCreateSecurityGroupParams(name string) *Create
 
 // Creates a security group
 func (s *SecurityGroupService) CreateSecurityGroup(p *CreateSecurityGroupParams) (*CreateSecurityGroupResponse, error) {
-	resp, err := s.cs.newRequest("createSecurityGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSecurityGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1159,7 +1159,7 @@ func (s *SecurityGroupService) NewDeleteSecurityGroupParams() *DeleteSecurityGro
 
 // Deletes security group
 func (s *SecurityGroupService) DeleteSecurityGroup(p *DeleteSecurityGroupParams) (*DeleteSecurityGroupResponse, error) {
-	resp, err := s.cs.newRequest("deleteSecurityGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteSecurityGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1704,7 +1704,7 @@ func (s *SecurityGroupService) NewRevokeSecurityGroupEgressParams(id string) *Re
 
 // Deletes a particular egress rule from this security group
 func (s *SecurityGroupService) RevokeSecurityGroupEgress(p *RevokeSecurityGroupEgressParams) (*RevokeSecurityGroupEgressResponse, error) {
-	resp, err := s.cs.newRequest("revokeSecurityGroupEgress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("revokeSecurityGroupEgress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1786,7 +1786,7 @@ func (s *SecurityGroupService) NewRevokeSecurityGroupIngressParams(id string) *R
 
 // Deletes a particular ingress rule from this security group
 func (s *SecurityGroupService) RevokeSecurityGroupIngress(p *RevokeSecurityGroupIngressParams) (*RevokeSecurityGroupIngressResponse, error) {
-	resp, err := s.cs.newRequest("revokeSecurityGroupIngress", p.toURLValues())
+	resp, err := s.cs.newPostRequest("revokeSecurityGroupIngress", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1916,7 +1916,7 @@ func (s *SecurityGroupService) NewUpdateSecurityGroupParams(id string) *UpdateSe
 
 // Updates a security group
 func (s *SecurityGroupService) UpdateSecurityGroup(p *UpdateSecurityGroupParams) (*UpdateSecurityGroupResponse, error) {
-	resp, err := s.cs.newRequest("updateSecurityGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateSecurityGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ServiceOfferingService.go
+++ b/cloudstack/ServiceOfferingService.go
@@ -1257,7 +1257,7 @@ func (s *ServiceOfferingService) NewCreateServiceOfferingParams(displaytext stri
 
 // Creates a service offering.
 func (s *ServiceOfferingService) CreateServiceOffering(p *CreateServiceOfferingParams) (*CreateServiceOfferingResponse, error) {
-	resp, err := s.cs.newRequest("createServiceOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createServiceOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1379,7 +1379,7 @@ func (s *ServiceOfferingService) NewDeleteServiceOfferingParams(id string) *Dele
 
 // Deletes a service offering.
 func (s *ServiceOfferingService) DeleteServiceOffering(p *DeleteServiceOfferingParams) (*DeleteServiceOfferingResponse, error) {
-	resp, err := s.cs.newRequest("deleteServiceOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteServiceOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2385,7 +2385,7 @@ func (s *ServiceOfferingService) NewUpdateServiceOfferingParams(id string) *Upda
 
 // Updates a service offering.
 func (s *ServiceOfferingService) UpdateServiceOffering(p *UpdateServiceOfferingParams) (*UpdateServiceOfferingResponse, error) {
-	resp, err := s.cs.newRequest("updateServiceOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateServiceOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/SharedFileSystemService.go
+++ b/cloudstack/SharedFileSystemService.go
@@ -203,7 +203,7 @@ func (s *SharedFileSystemService) NewChangeSharedFileSystemDiskOfferingParams(id
 
 // Change Disk offering of a Shared FileSystem
 func (s *SharedFileSystemService) ChangeSharedFileSystemDiskOffering(p *ChangeSharedFileSystemDiskOfferingParams) (*ChangeSharedFileSystemDiskOfferingResponse, error) {
-	resp, err := s.cs.newRequest("changeSharedFileSystemDiskOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeSharedFileSystemDiskOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (s *SharedFileSystemService) NewChangeSharedFileSystemServiceOfferingParams
 
 // Change Service offering of a Shared FileSystem
 func (s *SharedFileSystemService) ChangeSharedFileSystemServiceOffering(p *ChangeSharedFileSystemServiceOfferingParams) (*ChangeSharedFileSystemServiceOfferingResponse, error) {
-	resp, err := s.cs.newRequest("changeSharedFileSystemServiceOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeSharedFileSystemServiceOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -802,7 +802,7 @@ func (s *SharedFileSystemService) NewCreateSharedFileSystemParams(diskofferingid
 
 // Create a new Shared File System of specified size and disk offering, attached to the given network
 func (s *SharedFileSystemService) CreateSharedFileSystem(p *CreateSharedFileSystemParams) (*CreateSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("createSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -978,7 +978,7 @@ func (s *SharedFileSystemService) NewDestroySharedFileSystemParams() *DestroySha
 
 // Destroy a Shared FileSystem by id
 func (s *SharedFileSystemService) DestroySharedFileSystem(p *DestroySharedFileSystemParams) (*DestroySharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("destroySharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("destroySharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1059,7 +1059,7 @@ func (s *SharedFileSystemService) NewExpungeSharedFileSystemParams() *ExpungeSha
 
 // Expunge a Shared FileSystem by id
 func (s *SharedFileSystemService) ExpungeSharedFileSystem(p *ExpungeSharedFileSystemParams) (*ExpungeSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("expungeSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("expungeSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1823,7 +1823,7 @@ func (s *SharedFileSystemService) NewRecoverSharedFileSystemParams() *RecoverSha
 
 // Recover a Shared FileSystem by id
 func (s *SharedFileSystemService) RecoverSharedFileSystem(p *RecoverSharedFileSystemParams) (*RecoverSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("recoverSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("recoverSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1942,7 +1942,7 @@ func (s *SharedFileSystemService) NewRestartSharedFileSystemParams(id string) *R
 
 // Restart a Shared FileSystem
 func (s *SharedFileSystemService) RestartSharedFileSystem(p *RestartSharedFileSystemParams) (*RestartSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("restartSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("restartSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2024,7 +2024,7 @@ func (s *SharedFileSystemService) NewStartSharedFileSystemParams(id string) *Sta
 
 // Start a Shared FileSystem
 func (s *SharedFileSystemService) StartSharedFileSystem(p *StartSharedFileSystemParams) (*StartSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("startSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2176,7 +2176,7 @@ func (s *SharedFileSystemService) NewStopSharedFileSystemParams(id string) *Stop
 
 // Stop a Shared FileSystem
 func (s *SharedFileSystemService) StopSharedFileSystem(p *StopSharedFileSystemParams) (*StopSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("stopSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2351,7 +2351,7 @@ func (s *SharedFileSystemService) NewUpdateSharedFileSystemParams(id string) *Up
 
 // Update a Shared FileSystem
 func (s *SharedFileSystemService) UpdateSharedFileSystem(p *UpdateSharedFileSystemParams) (*UpdateSharedFileSystemResponse, error) {
-	resp, err := s.cs.newRequest("updateSharedFileSystem", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateSharedFileSystem", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/SnapshotService.go
+++ b/cloudstack/SnapshotService.go
@@ -114,7 +114,7 @@ func (s *SnapshotService) NewArchiveSnapshotParams(id string) *ArchiveSnapshotPa
 
 // Archives (moves) a snapshot on primary storage to secondary storage
 func (s *SnapshotService) ArchiveSnapshot(p *ArchiveSnapshotParams) (*ArchiveSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("archiveSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("archiveSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (s *SnapshotService) NewCopySnapshotParams(id string) *CopySnapshotParams {
 
 // Copies a snapshot from one zone to another.
 func (s *SnapshotService) CopySnapshot(p *CopySnapshotParams) (*CopySnapshotResponse, error) {
-	resp, err := s.cs.newRequest("copySnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("copySnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (s *SnapshotService) NewCreateSnapshotParams(volumeid string) *CreateSnapsh
 
 // Creates an instant snapshot of a volume.
 func (s *SnapshotService) CreateSnapshot(p *CreateSnapshotParams) (*CreateSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("createSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -891,7 +891,7 @@ func (s *SnapshotService) NewCreateSnapshotFromVMSnapshotParams(vmsnapshotid str
 
 // Creates an instant snapshot of a volume from existing vm snapshot.
 func (s *SnapshotService) CreateSnapshotFromVMSnapshot(p *CreateSnapshotFromVMSnapshotParams) (*CreateSnapshotFromVMSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("createSnapshotFromVMSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSnapshotFromVMSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1214,7 +1214,7 @@ func (s *SnapshotService) NewCreateSnapshotPolicyParams(intervaltype string, max
 
 // Creates a snapshot policy for the account.
 func (s *SnapshotService) CreateSnapshotPolicy(p *CreateSnapshotPolicyParams) (*CreateSnapshotPolicyResponse, error) {
-	resp, err := s.cs.newRequest("createSnapshotPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createSnapshotPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1387,7 +1387,7 @@ func (s *SnapshotService) NewCreateVMSnapshotParams(virtualmachineid string) *Cr
 
 // Creates snapshot for a vm.
 func (s *SnapshotService) CreateVMSnapshot(p *CreateVMSnapshotParams) (*CreateVMSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("createVMSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVMSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1519,7 +1519,7 @@ func (s *SnapshotService) NewDeleteSnapshotParams(id string) *DeleteSnapshotPara
 
 // Deletes a snapshot of a disk volume.
 func (s *SnapshotService) DeleteSnapshot(p *DeleteSnapshotParams) (*DeleteSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("deleteSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1625,7 +1625,7 @@ func (s *SnapshotService) NewDeleteSnapshotPoliciesParams() *DeleteSnapshotPolic
 
 // Deletes snapshot policies for the account.
 func (s *SnapshotService) DeleteSnapshotPolicies(p *DeleteSnapshotPoliciesParams) (*DeleteSnapshotPoliciesResponse, error) {
-	resp, err := s.cs.newRequest("deleteSnapshotPolicies", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteSnapshotPolicies", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1719,7 +1719,7 @@ func (s *SnapshotService) NewDeleteVMSnapshotParams(vmsnapshotid string) *Delete
 
 // Deletes a vmsnapshot.
 func (s *SnapshotService) DeleteVMSnapshot(p *DeleteVMSnapshotParams) (*DeleteVMSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("deleteVMSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVMSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1826,7 +1826,7 @@ func (s *SnapshotService) NewExtractSnapshotParams(id string, zoneid string) *Ex
 
 // Returns a download URL for extracting a snapshot. It must be in the Backed Up state.
 func (s *SnapshotService) ExtractSnapshot(p *ExtractSnapshotParams) (*ExtractSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("extractSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("extractSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3286,7 +3286,7 @@ func (s *SnapshotService) NewRevertSnapshotParams(id string) *RevertSnapshotPara
 
 // This is supposed to revert a volume snapshot. This command is only supported with KVM so far
 func (s *SnapshotService) RevertSnapshot(p *RevertSnapshotParams) (*RevertSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("revertSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("revertSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3430,7 +3430,7 @@ func (s *SnapshotService) NewRevertToVMSnapshotParams(vmsnapshotid string) *Reve
 
 // Revert VM from a vmsnapshot.
 func (s *SnapshotService) RevertToVMSnapshot(p *RevertToVMSnapshotParams) (*RevertToVMSnapshotResponse, error) {
-	resp, err := s.cs.newRequest("revertToVMSnapshot", p.toURLValues())
+	resp, err := s.cs.newPostRequest("revertToVMSnapshot", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3726,7 +3726,7 @@ func (s *SnapshotService) NewUpdateSnapshotPolicyParams() *UpdateSnapshotPolicyP
 
 // Updates the snapshot policy.
 func (s *SnapshotService) UpdateSnapshotPolicy(p *UpdateSnapshotPolicyParams) (*UpdateSnapshotPolicyResponse, error) {
-	resp, err := s.cs.newRequest("updateSnapshotPolicy", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateSnapshotPolicy", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/StoragePoolService.go
+++ b/cloudstack/StoragePoolService.go
@@ -107,7 +107,7 @@ func (s *StoragePoolService) NewCancelStorageMaintenanceParams(id string) *Cance
 
 // Cancels maintenance for primary storage
 func (s *StoragePoolService) CancelStorageMaintenance(p *CancelStorageMaintenanceParams) (*CancelStorageMaintenanceResponse, error) {
-	resp, err := s.cs.newRequest("cancelStorageMaintenance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("cancelStorageMaintenance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ func (s *StoragePoolService) NewChangeStoragePoolScopeParams(id string, scope st
 
 // Changes the scope of a storage pool when the pool is in Disabled state.This feature is officially tested and supported for Hypervisors: KVM and VMware, Protocols: NFS and Ceph, and Storage Provider: DefaultPrimary. There might be extra steps involved to make this work for other hypervisors and storage options.
 func (s *StoragePoolService) ChangeStoragePoolScope(p *ChangeStoragePoolScopeParams) (*ChangeStoragePoolScopeResponse, error) {
-	resp, err := s.cs.newRequest("changeStoragePoolScope", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeStoragePoolScope", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (s *StoragePoolService) NewEnableStorageMaintenanceParams(id string) *Enabl
 
 // Puts storage pool into maintenance state
 func (s *StoragePoolService) EnableStorageMaintenance(p *EnableStorageMaintenanceParams) (*EnableStorageMaintenanceResponse, error) {
-	resp, err := s.cs.newRequest("enableStorageMaintenance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableStorageMaintenance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1369,7 +1369,7 @@ func (s *StoragePoolService) NewUpdateObjectStoragePoolParams(id string) *Update
 
 // Updates object storage pool
 func (s *StoragePoolService) UpdateObjectStoragePool(p *UpdateObjectStoragePoolParams) (*UpdateObjectStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("updateObjectStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateObjectStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1546,7 +1546,7 @@ func (s *StoragePoolService) NewAddObjectStoragePoolParams(name string, provider
 
 // Adds a object storage pool
 func (s *StoragePoolService) AddObjectStoragePool(p *AddObjectStoragePoolParams) (*AddObjectStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("addObjectStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addObjectStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1621,7 +1621,7 @@ func (s *StoragePoolService) NewDeleteObjectStoragePoolParams(id string) *Delete
 
 // Deletes an Object Storage Pool
 func (s *StoragePoolService) DeleteObjectStoragePool(p *DeleteObjectStoragePoolParams) (*DeleteObjectStoragePoolResponse, error) {
-	resp, err := s.cs.newRequest("deleteObjectStoragePool", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteObjectStoragePool", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/StratosphereSSPService.go
+++ b/cloudstack/StratosphereSSPService.go
@@ -201,7 +201,7 @@ func (s *StratosphereSSPService) NewAddStratosphereSspParams(name string, url st
 
 // Adds stratosphere ssp server
 func (s *StratosphereSSPService) AddStratosphereSsp(p *AddStratosphereSspParams) (*AddStratosphereSspResponse, error) {
-	resp, err := s.cs.newRequest("addStratosphereSsp", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addStratosphereSsp", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (s *StratosphereSSPService) NewDeleteStratosphereSspParams(hostid string) *
 
 // Removes stratosphere ssp server
 func (s *StratosphereSSPService) DeleteStratosphereSsp(p *DeleteStratosphereSspParams) (*DeleteStratosphereSspResponse, error) {
-	resp, err := s.cs.newRequest("deleteStratosphereSsp", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteStratosphereSsp", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/SwiftService.go
+++ b/cloudstack/SwiftService.go
@@ -153,7 +153,7 @@ func (s *SwiftService) NewAddSwiftParams(url string) *AddSwiftParams {
 
 // Adds Swift.
 func (s *SwiftService) AddSwift(p *AddSwiftParams) (*AddSwiftResponse, error) {
-	resp, err := s.cs.newRequest("addSwift", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addSwift", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/SystemVMService.go
+++ b/cloudstack/SystemVMService.go
@@ -155,7 +155,7 @@ func (s *SystemVMService) NewChangeServiceForSystemVmParams(id string, serviceof
 
 // Changes the service offering for a system vm (console proxy or secondary storage). The system vm must be in a "Stopped" state for this command to take effect.
 func (s *SystemVMService) ChangeServiceForSystemVm(p *ChangeServiceForSystemVmParams) (*ChangeServiceForSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("changeServiceForSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeServiceForSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func (s *SystemVMService) NewDestroySystemVmParams(id string) *DestroySystemVmPa
 
 // Destroys a system virtual machine.
 func (s *SystemVMService) DestroySystemVm(p *DestroySystemVmParams) (*DestroySystemVmResponse, error) {
-	resp, err := s.cs.newRequest("destroySystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("destroySystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1213,7 +1213,7 @@ func (s *SystemVMService) NewMigrateSystemVmParams(virtualmachineid string) *Mig
 
 // Attempts Migration of a system virtual machine to the host specified.
 func (s *SystemVMService) MigrateSystemVm(p *MigrateSystemVmParams) (*MigrateSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("migrateSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1361,7 +1361,7 @@ func (s *SystemVMService) NewRebootSystemVmParams(id string) *RebootSystemVmPara
 
 // Reboots a system VM.
 func (s *SystemVMService) RebootSystemVm(p *RebootSystemVmParams) (*RebootSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("rebootSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("rebootSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1536,7 +1536,7 @@ func (s *SystemVMService) NewScaleSystemVmParams(id string, serviceofferingid st
 
 // Scale the service offering for a system vm (console proxy or secondary storage). The system vm must be in a "Stopped" state for this command to take effect.
 func (s *SystemVMService) ScaleSystemVm(p *ScaleSystemVmParams) (*ScaleSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("scaleSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("scaleSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1659,7 +1659,7 @@ func (s *SystemVMService) NewStartSystemVmParams(id string) *StartSystemVmParams
 
 // Starts a system virtual machine.
 func (s *SystemVMService) StartSystemVm(p *StartSystemVmParams) (*StartSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("startSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1807,7 +1807,7 @@ func (s *SystemVMService) NewStopSystemVmParams(id string) *StopSystemVmParams {
 
 // Stops a system VM.
 func (s *SystemVMService) StopSystemVm(p *StopSystemVmParams) (*StopSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("stopSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1954,7 +1954,7 @@ func (s *SystemVMService) NewPatchSystemVmParams() *PatchSystemVmParams {
 
 // Attempts to live patch systemVMs - CPVM, SSVM
 func (s *SystemVMService) PatchSystemVm(p *PatchSystemVmParams) (*PatchSystemVmResponse, error) {
-	resp, err := s.cs.newRequest("patchSystemVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("patchSystemVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/TemplateService.go
+++ b/cloudstack/TemplateService.go
@@ -180,7 +180,7 @@ func (s *TemplateService) NewCopyTemplateParams(id string) *CopyTemplateParams {
 
 // Copies a template from one zone to another.
 func (s *TemplateService) CopyTemplate(p *CopyTemplateParams) (*CopyTemplateResponse, error) {
-	resp, err := s.cs.newRequest("copyTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("copyTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +814,7 @@ func (s *TemplateService) NewCreateTemplateParams(displaytext string, name strin
 
 // Creates a template of a virtual machine. The virtual machine must be in a STOPPED state. A template created from this command is automatically designated as a private template visible to the account that created it.
 func (s *TemplateService) CreateTemplate(p *CreateTemplateParams) (*CreateTemplateResponse, error) {
-	resp, err := s.cs.newRequest("createTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1054,7 +1054,7 @@ func (s *TemplateService) NewDeleteTemplateParams(id string) *DeleteTemplatePara
 
 // Deletes a template from the system. All virtual machines using the deleted template will not be affected.
 func (s *TemplateService) DeleteTemplate(p *DeleteTemplateParams) (*DeleteTemplateResponse, error) {
-	resp, err := s.cs.newRequest("deleteTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1209,7 +1209,7 @@ func (s *TemplateService) NewExtractTemplateParams(id string, mode string) *Extr
 
 // Extracts a template
 func (s *TemplateService) ExtractTemplate(p *ExtractTemplateParams) (*ExtractTemplateResponse, error) {
-	resp, err := s.cs.newRequest("extractTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("extractTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2910,7 +2910,7 @@ func (s *TemplateService) NewPrepareTemplateParams(templateid string, zoneid str
 
 // load template into primary storage
 func (s *TemplateService) PrepareTemplate(p *PrepareTemplateParams) (*PrepareTemplateResponse, error) {
-	resp, err := s.cs.newRequest("prepareTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("prepareTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3699,7 +3699,7 @@ func (s *TemplateService) NewRegisterTemplateParams(displaytext string, format s
 
 // Registers an existing template into the CloudStack cloud.
 func (s *TemplateService) RegisterTemplate(p *RegisterTemplateParams) (*RegisterTemplateResponse, error) {
-	resp, err := s.cs.newRequest("registerTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4245,7 +4245,7 @@ func (s *TemplateService) NewUpdateTemplateParams(id string) *UpdateTemplatePara
 
 // Updates attributes of a template.
 func (s *TemplateService) UpdateTemplate(p *UpdateTemplateParams) (*UpdateTemplateResponse, error) {
-	resp, err := s.cs.newRequest("updateTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4540,7 +4540,7 @@ func (s *TemplateService) NewUpdateTemplatePermissionsParams(id string) *UpdateT
 
 // Updates a template visibility permissions. A public template is visible to all accounts within the same domain. A private template is visible only to the owner of the template. A privileged template is a private template with account permissions added. Only accounts specified under the template permissions are visible to them.
 func (s *TemplateService) UpdateTemplatePermissions(p *UpdateTemplatePermissionsParams) (*UpdateTemplatePermissionsResponse, error) {
-	resp, err := s.cs.newRequest("updateTemplatePermissions", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateTemplatePermissions", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4753,7 +4753,7 @@ func (s *TemplateService) NewUpgradeRouterTemplateParams() *UpgradeRouterTemplat
 
 // Upgrades router to use newer template
 func (s *TemplateService) UpgradeRouterTemplate(p *UpgradeRouterTemplateParams) (*UpgradeRouterTemplateResponse, error) {
-	resp, err := s.cs.newRequest("upgradeRouterTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("upgradeRouterTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4889,7 +4889,7 @@ func (s *TemplateService) NewLinkUserDataToTemplateParams() *LinkUserDataToTempl
 
 // Link or unlink a userdata to a template.
 func (s *TemplateService) LinkUserDataToTemplate(p *LinkUserDataToTemplateParams) (*LinkUserDataToTemplateResponse, error) {
-	resp, err := s.cs.newRequest("linkUserDataToTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("linkUserDataToTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/UCSService.go
+++ b/cloudstack/UCSService.go
@@ -191,7 +191,7 @@ func (s *UCSService) NewAddUcsManagerParams(password string, url string, usernam
 
 // Adds a Ucs manager
 func (s *UCSService) AddUcsManager(p *AddUcsManagerParams) (*AddUcsManagerResponse, error) {
-	resp, err := s.cs.newRequest("addUcsManager", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addUcsManager", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (s *UCSService) NewAssociateUcsProfileToBladeParams(bladeid string, profile
 
 // associate a profile to a blade
 func (s *UCSService) AssociateUcsProfileToBlade(p *AssociateUcsProfileToBladeParams) (*AssociateUcsProfileToBladeResponse, error) {
-	resp, err := s.cs.newRequest("associateUcsProfileToBlade", p.toURLValues())
+	resp, err := s.cs.newPostRequest("associateUcsProfileToBlade", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func (s *UCSService) NewDeleteUcsManagerParams(ucsmanagerid string) *DeleteUcsMa
 
 // Delete a Ucs manager
 func (s *UCSService) DeleteUcsManager(p *DeleteUcsManagerParams) (*DeleteUcsManagerResponse, error) {
-	resp, err := s.cs.newRequest("deleteUcsManager", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteUcsManager", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -176,7 +176,7 @@ func (s *UsageService) NewAddTrafficMonitorParams(url string, zoneid string) *Ad
 
 // Adds Traffic Monitor Host for Direct Network Usage
 func (s *UsageService) AddTrafficMonitor(p *AddTrafficMonitorParams) (*AddTrafficMonitorResponse, error) {
-	resp, err := s.cs.newRequest("addTrafficMonitor", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addTrafficMonitor", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (s *UsageService) NewAddTrafficTypeParams(physicalnetworkid string, traffic
 
 // Adds traffic type to a physical network
 func (s *UsageService) AddTrafficType(p *AddTrafficTypeParams) (*AddTrafficTypeResponse, error) {
-	resp, err := s.cs.newRequest("addTrafficType", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addTrafficType", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (s *UsageService) NewDeleteTrafficMonitorParams(id string) *DeleteTrafficMo
 
 // Deletes an traffic monitor host.
 func (s *UsageService) DeleteTrafficMonitor(p *DeleteTrafficMonitorParams) (*DeleteTrafficMonitorResponse, error) {
-	resp, err := s.cs.newRequest("deleteTrafficMonitor", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteTrafficMonitor", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +626,7 @@ func (s *UsageService) NewDeleteTrafficTypeParams(id string) *DeleteTrafficTypeP
 
 // Deletes traffic type of a physical network
 func (s *UsageService) DeleteTrafficType(p *DeleteTrafficTypeParams) (*DeleteTrafficTypeResponse, error) {
-	resp, err := s.cs.newRequest("deleteTrafficType", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteTrafficType", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +755,7 @@ func (s *UsageService) NewGenerateUsageRecordsParams() *GenerateUsageRecordsPara
 
 // Generates usage records. This will generate records only if there any records to be generated, i.e if the scheduled usage job was not run or failed
 func (s *UsageService) GenerateUsageRecords(p *GenerateUsageRecordsParams) (*GenerateUsageRecordsResponse, error) {
-	resp, err := s.cs.newRequest("generateUsageRecords", p.toURLValues())
+	resp, err := s.cs.newPostRequest("generateUsageRecords", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1832,7 +1832,7 @@ func (s *UsageService) NewRemoveRawUsageRecordsParams(interval int) *RemoveRawUs
 
 // Safely removes raw records from cloud_usage table
 func (s *UsageService) RemoveRawUsageRecords(p *RemoveRawUsageRecordsParams) (*RemoveRawUsageRecordsResponse, error) {
-	resp, err := s.cs.newRequest("removeRawUsageRecords", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeRawUsageRecords", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2046,7 +2046,7 @@ func (s *UsageService) NewUpdateTrafficTypeParams(id string) *UpdateTrafficTypeP
 
 // Updates traffic type of a physical network
 func (s *UsageService) UpdateTrafficType(p *UpdateTrafficTypeParams) (*UpdateTrafficTypeResponse, error) {
-	resp, err := s.cs.newRequest("updateTrafficType", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateTrafficType", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/UserService.go
+++ b/cloudstack/UserService.go
@@ -409,7 +409,7 @@ func (s *UserService) NewDeleteUserParams(id string) *DeleteUserParams {
 
 // Deletes a user for an account
 func (s *UserService) DeleteUser(p *DeleteUserParams) (*DeleteUserResponse, error) {
-	resp, err := s.cs.newRequest("deleteUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -503,7 +503,7 @@ func (s *UserService) NewDisableUserParams(id string) *DisableUserParams {
 
 // Disables a user account
 func (s *UserService) DisableUser(p *DisableUserParams) (*DisableUserResponse, error) {
-	resp, err := s.cs.newRequest("disableUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +612,7 @@ func (s *UserService) NewEnableUserParams(id string) *EnableUserParams {
 
 // Enables a user account
 func (s *UserService) EnableUser(p *EnableUserParams) (*EnableUserResponse, error) {
-	resp, err := s.cs.newRequest("enableUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1403,7 +1403,7 @@ func (s *UserService) NewLockUserParams(id string) *LockUserParams {
 
 // Locks a user account
 func (s *UserService) LockUser(p *LockUserParams) (*LockUserResponse, error) {
-	resp, err := s.cs.newRequest("lockUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("lockUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1496,7 +1496,7 @@ func (s *UserService) NewRegisterUserKeysParams(id string) *RegisterUserKeysPara
 
 // This command allows a user to register for the developer API, returning a secret key and an API key. This request is made through the integration API port, so it is a privileged command and must be made on behalf of a user. It is up to the implementer just how the username and password are entered, and then how that translates to an integration API request. Both secret key and API key should be returned to the user
 func (s *UserService) RegisterUserKeys(p *RegisterUserKeysParams) (*RegisterUserKeysResponse, error) {
-	resp, err := s.cs.newRequest("registerUserKeys", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerUserKeys", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2353,7 +2353,7 @@ func (s *UserService) NewDeleteUserDataParams(id string) *DeleteUserDataParams {
 
 // Deletes a userdata
 func (s *UserService) DeleteUserData(p *DeleteUserDataParams) (*DeleteUserDataResponse, error) {
-	resp, err := s.cs.newRequest("deleteUserData", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteUserData", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2727,7 +2727,7 @@ func (s *UserService) NewMoveUserParams(id string) *MoveUserParams {
 
 // Moves a user to another account in the same domain.
 func (s *UserService) MoveUser(p *MoveUserParams) (*MoveUserResponse, error) {
-	resp, err := s.cs.newRequest("moveUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("moveUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3133,7 +3133,7 @@ func (s *UserService) NewVerifyOAuthCodeAndGetUserParams(provider string) *Verif
 
 // Verify the OAuth Code and fetch the corresponding user from provider
 func (s *UserService) VerifyOAuthCodeAndGetUser(p *VerifyOAuthCodeAndGetUserParams) (*VerifyOAuthCodeAndGetUserResponse, error) {
-	resp, err := s.cs.newRequest("verifyOAuthCodeAndGetUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("verifyOAuthCodeAndGetUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/UserService.go
+++ b/cloudstack/UserService.go
@@ -3133,7 +3133,7 @@ func (s *UserService) NewVerifyOAuthCodeAndGetUserParams(provider string) *Verif
 
 // Verify the OAuth Code and fetch the corresponding user from provider
 func (s *UserService) VerifyOAuthCodeAndGetUser(p *VerifyOAuthCodeAndGetUserParams) (*VerifyOAuthCodeAndGetUserResponse, error) {
-	resp, err := s.cs.newPostRequest("verifyOAuthCodeAndGetUser", p.toURLValues())
+	resp, err := s.cs.newRequest("verifyOAuthCodeAndGetUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VLANService.go
+++ b/cloudstack/VLANService.go
@@ -529,7 +529,7 @@ func (s *VLANService) NewCreateVlanIpRangeParams() *CreateVlanIpRangeParams {
 
 // Creates a VLAN IP range.
 func (s *VLANService) CreateVlanIpRange(p *CreateVlanIpRangeParams) (*CreateVlanIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("createVlanIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVlanIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +721,7 @@ func (s *VLANService) NewDedicateGuestVlanRangeParams(physicalnetworkid string, 
 
 // Dedicates a guest vlan range to an account
 func (s *VLANService) DedicateGuestVlanRange(p *DedicateGuestVlanRangeParams) (*DedicateGuestVlanRangeResponse, error) {
-	resp, err := s.cs.newRequest("dedicateGuestVlanRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicateGuestVlanRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -800,7 +800,7 @@ func (s *VLANService) NewDeleteVlanIpRangeParams(id string) *DeleteVlanIpRangePa
 
 // Deletes a VLAN IP range.
 func (s *VLANService) DeleteVlanIpRange(p *DeleteVlanIpRangeParams) (*DeleteVlanIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("deleteVlanIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVlanIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1643,7 +1643,7 @@ func (s *VLANService) NewReleaseDedicatedGuestVlanRangeParams(id string) *Releas
 
 // Releases a dedicated guest vlan range to the system
 func (s *VLANService) ReleaseDedicatedGuestVlanRange(p *ReleaseDedicatedGuestVlanRangeParams) (*ReleaseDedicatedGuestVlanRangeResponse, error) {
-	resp, err := s.cs.newRequest("releaseDedicatedGuestVlanRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseDedicatedGuestVlanRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2199,7 +2199,7 @@ func (s *VLANService) NewUpdateVlanIpRangeParams(id string) *UpdateVlanIpRangePa
 
 // Updates a VLAN IP range.
 func (s *VLANService) UpdateVlanIpRange(p *UpdateVlanIpRangeParams) (*UpdateVlanIpRangeResponse, error) {
-	resp, err := s.cs.newRequest("updateVlanIpRange", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVlanIpRange", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VMGroupService.go
+++ b/cloudstack/VMGroupService.go
@@ -160,7 +160,7 @@ func (s *VMGroupService) NewCreateInstanceGroupParams(name string) *CreateInstan
 
 // Creates a vm group
 func (s *VMGroupService) CreateInstanceGroup(p *CreateInstanceGroupParams) (*CreateInstanceGroupResponse, error) {
-	resp, err := s.cs.newRequest("createInstanceGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createInstanceGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (s *VMGroupService) NewDeleteInstanceGroupParams(id string) *DeleteInstance
 
 // Deletes a vm group
 func (s *VMGroupService) DeleteInstanceGroup(p *DeleteInstanceGroupParams) (*DeleteInstanceGroupResponse, error) {
-	resp, err := s.cs.newRequest("deleteInstanceGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteInstanceGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -735,7 +735,7 @@ func (s *VMGroupService) NewUpdateInstanceGroupParams(id string) *UpdateInstance
 
 // Updates a vm group
 func (s *VMGroupService) UpdateInstanceGroup(p *UpdateInstanceGroupParams) (*UpdateInstanceGroupResponse, error) {
-	resp, err := s.cs.newRequest("updateInstanceGroup", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateInstanceGroup", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -362,7 +362,7 @@ func (s *VPCService) NewCreatePrivateGatewayParams(gateway string, ipaddress str
 
 // Creates a private gateway
 func (s *VPCService) CreatePrivateGateway(p *CreatePrivateGatewayParams) (*CreatePrivateGatewayResponse, error) {
-	resp, err := s.cs.newRequest("createPrivateGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createPrivateGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func (s *VPCService) NewCreateStaticRouteParams(cidr string, gatewayid string) *
 
 // Creates a static route
 func (s *VPCService) CreateStaticRoute(p *CreateStaticRouteParams) (*CreateStaticRouteResponse, error) {
-	resp, err := s.cs.newRequest("createStaticRoute", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createStaticRoute", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1057,7 +1057,7 @@ func (s *VPCService) NewCreateVPCParams(displaytext string, name string, vpcoffe
 
 // Creates a VPC
 func (s *VPCService) CreateVPC(p *CreateVPCParams) (*CreateVPCResponse, error) {
-	resp, err := s.cs.newRequest("createVPC", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVPC", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1554,7 +1554,7 @@ func (s *VPCService) NewCreateVPCOfferingParams(displaytext string, name string)
 
 // Creates VPC offering
 func (s *VPCService) CreateVPCOffering(p *CreateVPCOfferingParams) (*CreateVPCOfferingResponse, error) {
-	resp, err := s.cs.newRequest("createVPCOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVPCOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1679,7 +1679,7 @@ func (s *VPCService) NewDeletePrivateGatewayParams(id string) *DeletePrivateGate
 
 // Deletes a Private gateway
 func (s *VPCService) DeletePrivateGateway(p *DeletePrivateGatewayParams) (*DeletePrivateGatewayResponse, error) {
-	resp, err := s.cs.newRequest("deletePrivateGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deletePrivateGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1761,7 +1761,7 @@ func (s *VPCService) NewDeleteStaticRouteParams(id string) *DeleteStaticRoutePar
 
 // Deletes a static route
 func (s *VPCService) DeleteStaticRoute(p *DeleteStaticRouteParams) (*DeleteStaticRouteResponse, error) {
-	resp, err := s.cs.newRequest("deleteStaticRoute", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteStaticRoute", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1843,7 +1843,7 @@ func (s *VPCService) NewDeleteVPCParams(id string) *DeleteVPCParams {
 
 // Deletes a VPC
 func (s *VPCService) DeleteVPC(p *DeleteVPCParams) (*DeleteVPCResponse, error) {
-	resp, err := s.cs.newRequest("deleteVPC", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVPC", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1925,7 +1925,7 @@ func (s *VPCService) NewDeleteVPCOfferingParams(id string) *DeleteVPCOfferingPar
 
 // Deletes VPC offering
 func (s *VPCService) DeleteVPCOffering(p *DeleteVPCOfferingParams) (*DeleteVPCOfferingResponse, error) {
-	resp, err := s.cs.newRequest("deleteVPCOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVPCOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4028,7 +4028,7 @@ func (s *VPCService) NewMigrateVPCParams(vpcid string, vpcofferingid string) *Mi
 
 // moves a vpc to another physical network
 func (s *VPCService) MigrateVPC(p *MigrateVPCParams) (*MigrateVPCResponse, error) {
-	resp, err := s.cs.newRequest("migrateVPC", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateVPC", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4248,7 +4248,7 @@ func (s *VPCService) NewRestartVPCParams(id string) *RestartVPCParams {
 
 // Restarts a VPC
 func (s *VPCService) RestartVPC(p *RestartVPCParams) (*RestartVPCResponse, error) {
-	resp, err := s.cs.newRequest("restartVPC", p.toURLValues())
+	resp, err := s.cs.newPostRequest("restartVPC", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4476,7 +4476,7 @@ func (s *VPCService) NewUpdateVPCParams(id string) *UpdateVPCParams {
 
 // Updates a VPC
 func (s *VPCService) UpdateVPC(p *UpdateVPCParams) (*UpdateVPCResponse, error) {
-	resp, err := s.cs.newRequest("updateVPC", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVPC", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4766,7 +4766,7 @@ func (s *VPCService) NewUpdateVPCOfferingParams(id string) *UpdateVPCOfferingPar
 
 // Updates VPC offering
 func (s *VPCService) UpdateVPCOffering(p *UpdateVPCOfferingParams) (*UpdateVPCOfferingResponse, error) {
-	resp, err := s.cs.newRequest("updateVPCOffering", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVPCOffering", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VPCService.go
+++ b/cloudstack/VPCService.go
@@ -33,7 +33,7 @@ type VPCServiceIface interface {
 	CreateStaticRoute(p *CreateStaticRouteParams) (*CreateStaticRouteResponse, error)
 	NewCreateStaticRouteParams(cidr string, gatewayid string) *CreateStaticRouteParams
 	CreateVPC(p *CreateVPCParams) (*CreateVPCResponse, error)
-	NewCreateVPCParams(displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams
+	NewCreateVPCParams(cidr string, displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams
 	CreateVPCOffering(p *CreateVPCOfferingParams) (*CreateVPCOfferingResponse, error)
 	NewCreateVPCOfferingParams(displaytext string, name string) *CreateVPCOfferingParams
 	DeletePrivateGateway(p *DeletePrivateGatewayParams) (*DeletePrivateGatewayResponse, error)
@@ -1045,9 +1045,10 @@ func (p *CreateVPCParams) GetZoneid() (string, bool) {
 
 // You should always use this function to get a new CreateVPCParams instance,
 // as then you are sure you have configured all required params
-func (s *VPCService) NewCreateVPCParams(displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams {
+func (s *VPCService) NewCreateVPCParams(cidr string, displaytext string, name string, vpcofferingid string, zoneid string) *CreateVPCParams {
 	p := &CreateVPCParams{}
 	p.p = make(map[string]interface{})
+	p.p["cidr"] = cidr
 	p.p["displaytext"] = displaytext
 	p.p["name"] = name
 	p.p["vpcofferingid"] = vpcofferingid

--- a/cloudstack/VPCService_mock.go
+++ b/cloudstack/VPCService_mock.go
@@ -464,17 +464,17 @@ func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCOfferingParams(displaytex
 }
 
 // NewCreateVPCParams mocks base method.
-func (m *MockVPCServiceIface) NewCreateVPCParams(displaytext, name, vpcofferingid, zoneid string) *CreateVPCParams {
+func (m *MockVPCServiceIface) NewCreateVPCParams(cidr, displaytext, name, vpcofferingid, zoneid string) *CreateVPCParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreateVPCParams", displaytext, name, vpcofferingid, zoneid)
+	ret := m.ctrl.Call(m, "NewCreateVPCParams", cidr, displaytext, name, vpcofferingid, zoneid)
 	ret0, _ := ret[0].(*CreateVPCParams)
 	return ret0
 }
 
 // NewCreateVPCParams indicates an expected call of NewCreateVPCParams.
-func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCParams(displaytext, name, vpcofferingid, zoneid any) *gomock.Call {
+func (mr *MockVPCServiceIfaceMockRecorder) NewCreateVPCParams(cidr, displaytext, name, vpcofferingid, zoneid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateVPCParams", reflect.TypeOf((*MockVPCServiceIface)(nil).NewCreateVPCParams), displaytext, name, vpcofferingid, zoneid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreateVPCParams", reflect.TypeOf((*MockVPCServiceIface)(nil).NewCreateVPCParams), cidr, displaytext, name, vpcofferingid, zoneid)
 }
 
 // NewDeletePrivateGatewayParams mocks base method.

--- a/cloudstack/VPNService.go
+++ b/cloudstack/VPNService.go
@@ -437,7 +437,7 @@ func (s *VPNService) NewCreateRemoteAccessVpnParams(publicipid string) *CreateRe
 
 // Creates a l2tp/ipsec remote access vpn
 func (s *VPNService) CreateRemoteAccessVpn(p *CreateRemoteAccessVpnParams) (*CreateRemoteAccessVpnResponse, error) {
-	resp, err := s.cs.newRequest("createRemoteAccessVpn", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createRemoteAccessVpn", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func (s *VPNService) NewCreateVpnConnectionParams(s2scustomergatewayid string, s
 
 // Create site to site vpn connection
 func (s *VPNService) CreateVpnConnection(p *CreateVpnConnectionParams) (*CreateVpnConnectionResponse, error) {
-	resp, err := s.cs.newRequest("createVpnConnection", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVpnConnection", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1066,7 +1066,7 @@ func (s *VPNService) NewCreateVpnCustomerGatewayParams(cidrlist string, esppolic
 
 // Creates site to site vpn customer gateway
 func (s *VPNService) CreateVpnCustomerGateway(p *CreateVpnCustomerGatewayParams) (*CreateVpnCustomerGatewayResponse, error) {
-	resp, err := s.cs.newRequest("createVpnCustomerGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVpnCustomerGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1198,7 +1198,7 @@ func (s *VPNService) NewCreateVpnGatewayParams(vpcid string) *CreateVpnGatewayPa
 
 // Creates site to site vpn local gateway
 func (s *VPNService) CreateVpnGateway(p *CreateVpnGatewayParams) (*CreateVpnGatewayResponse, error) {
-	resp, err := s.cs.newRequest("createVpnGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVpnGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1295,7 +1295,7 @@ func (s *VPNService) NewDeleteRemoteAccessVpnParams(publicipid string) *DeleteRe
 
 // Destroys a l2tp/ipsec remote access vpn
 func (s *VPNService) DeleteRemoteAccessVpn(p *DeleteRemoteAccessVpnParams) (*DeleteRemoteAccessVpnResponse, error) {
-	resp, err := s.cs.newRequest("deleteRemoteAccessVpn", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteRemoteAccessVpn", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1377,7 +1377,7 @@ func (s *VPNService) NewDeleteVpnConnectionParams(id string) *DeleteVpnConnectio
 
 // Delete site to site vpn connection
 func (s *VPNService) DeleteVpnConnection(p *DeleteVpnConnectionParams) (*DeleteVpnConnectionResponse, error) {
-	resp, err := s.cs.newRequest("deleteVpnConnection", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVpnConnection", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1459,7 +1459,7 @@ func (s *VPNService) NewDeleteVpnCustomerGatewayParams(id string) *DeleteVpnCust
 
 // Delete site to site vpn customer gateway
 func (s *VPNService) DeleteVpnCustomerGateway(p *DeleteVpnCustomerGatewayParams) (*DeleteVpnCustomerGatewayResponse, error) {
-	resp, err := s.cs.newRequest("deleteVpnCustomerGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVpnCustomerGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1541,7 +1541,7 @@ func (s *VPNService) NewDeleteVpnGatewayParams(id string) *DeleteVpnGatewayParam
 
 // Delete site to site vpn gateway
 func (s *VPNService) DeleteVpnGateway(p *DeleteVpnGatewayParams) (*DeleteVpnGatewayResponse, error) {
-	resp, err := s.cs.newRequest("deleteVpnGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVpnGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3512,7 +3512,7 @@ func (s *VPNService) NewRemoveVpnUserParams(username string) *RemoveVpnUserParam
 
 // Removes vpn user
 func (s *VPNService) RemoveVpnUser(p *RemoveVpnUserParams) (*RemoveVpnUserResponse, error) {
-	resp, err := s.cs.newRequest("removeVpnUser", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeVpnUser", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3642,7 +3642,7 @@ func (s *VPNService) NewResetVpnConnectionParams(id string) *ResetVpnConnectionP
 
 // Reset site to site vpn connection
 func (s *VPNService) ResetVpnConnection(p *ResetVpnConnectionParams) (*ResetVpnConnectionResponse, error) {
-	resp, err := s.cs.newRequest("resetVpnConnection", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetVpnConnection", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3802,7 +3802,7 @@ func (s *VPNService) NewUpdateRemoteAccessVpnParams(id string) *UpdateRemoteAcce
 
 // Updates remote access vpn
 func (s *VPNService) UpdateRemoteAccessVpn(p *UpdateRemoteAccessVpnParams) (*UpdateRemoteAccessVpnResponse, error) {
-	resp, err := s.cs.newRequest("updateRemoteAccessVpn", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateRemoteAccessVpn", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3949,7 +3949,7 @@ func (s *VPNService) NewUpdateVpnConnectionParams(id string) *UpdateVpnConnectio
 
 // Updates site to site vpn connection
 func (s *VPNService) UpdateVpnConnection(p *UpdateVpnConnectionParams) (*UpdateVpnConnectionResponse, error) {
-	resp, err := s.cs.newRequest("updateVpnConnection", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVpnConnection", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4406,7 +4406,7 @@ func (s *VPNService) NewUpdateVpnCustomerGatewayParams(cidrlist string, esppolic
 
 // Update site to site vpn customer gateway
 func (s *VPNService) UpdateVpnCustomerGateway(p *UpdateVpnCustomerGatewayParams) (*UpdateVpnCustomerGatewayResponse, error) {
-	resp, err := s.cs.newRequest("updateVpnCustomerGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVpnCustomerGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4562,7 +4562,7 @@ func (s *VPNService) NewUpdateVpnGatewayParams(id string) *UpdateVpnGatewayParam
 
 // Updates site to site vpn local gateway
 func (s *VPNService) UpdateVpnGateway(p *UpdateVpnGatewayParams) (*UpdateVpnGatewayResponse, error) {
-	resp, err := s.cs.newRequest("updateVpnGateway", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVpnGateway", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -254,7 +254,7 @@ func (s *VirtualMachineService) NewAddNicToVirtualMachineParams(networkid string
 
 // Adds VM to specified network by creating a NIC
 func (s *VirtualMachineService) AddNicToVirtualMachine(p *AddNicToVirtualMachineParams) (*AddNicToVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("addNicToVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addNicToVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +624,7 @@ func (s *VirtualMachineService) NewAssignVirtualMachineParams(virtualmachineid s
 
 // Change ownership of a VM from one account to another. This API is available for Basic zones with security groups and Advanced zones with guest networks. A root administrator can reassign a VM from any account to any other account in any domain. A domain administrator can reassign a VM to any account in the same domain.
 func (s *VirtualMachineService) AssignVirtualMachine(p *AssignVirtualMachineParams) (*AssignVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("assignVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("assignVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1004,7 +1004,7 @@ func (s *VirtualMachineService) NewChangeServiceForVirtualMachineParams(id strin
 
 // (This API is deprecated, use scaleVirtualMachine API)Changes the service offering for a virtual machine. The virtual machine must be in a "Stopped" state for this command to take effect.
 func (s *VirtualMachineService) ChangeServiceForVirtualMachine(p *ChangeServiceForVirtualMachineParams) (*ChangeServiceForVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("changeServiceForVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeServiceForVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1207,7 +1207,7 @@ func (s *VirtualMachineService) NewCleanVMReservationsParams() *CleanVMReservati
 
 // Cleanups VM reservations in the database.
 func (s *VirtualMachineService) CleanVMReservations(p *CleanVMReservationsParams) (*CleanVMReservationsResponse, error) {
-	resp, err := s.cs.newRequest("cleanVMReservations", p.toURLValues())
+	resp, err := s.cs.newPostRequest("cleanVMReservations", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2901,7 +2901,7 @@ func (s *VirtualMachineService) NewDestroyVirtualMachineParams(id string) *Destr
 
 // Destroys a virtual machine. Once destroyed, only the administrator can recover it.
 func (s *VirtualMachineService) DestroyVirtualMachine(p *DestroyVirtualMachineParams) (*DestroyVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("destroyVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("destroyVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3149,7 +3149,7 @@ func (s *VirtualMachineService) NewExpungeVirtualMachineParams(id string) *Expun
 
 // Expunge a virtual machine. Once expunged, it cannot be recoverd.
 func (s *VirtualMachineService) ExpungeVirtualMachine(p *ExpungeVirtualMachineParams) (*ExpungeVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("expungeVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("expungeVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6185,7 +6185,7 @@ func (s *VirtualMachineService) NewMigrateVirtualMachineParams(virtualmachineid 
 
 // Attempts Migration of a VM to a different host or Root volume of the vm to a different storage pool
 func (s *VirtualMachineService) MigrateVirtualMachine(p *MigrateVirtualMachineParams) (*MigrateVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("migrateVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6525,7 +6525,7 @@ func (s *VirtualMachineService) NewMigrateVirtualMachineWithVolumeParams(virtual
 
 // Attempts Migration of a VM with its volumes to a different host
 func (s *VirtualMachineService) MigrateVirtualMachineWithVolume(p *MigrateVirtualMachineWithVolumeParams) (*MigrateVirtualMachineWithVolumeResponse, error) {
-	resp, err := s.cs.newRequest("migrateVirtualMachineWithVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateVirtualMachineWithVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6823,7 +6823,7 @@ func (s *VirtualMachineService) NewRebootVirtualMachineParams(id string) *Reboot
 
 // Reboots a virtual machine.
 func (s *VirtualMachineService) RebootVirtualMachine(p *RebootVirtualMachineParams) (*RebootVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("rebootVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("rebootVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7071,7 +7071,7 @@ func (s *VirtualMachineService) NewRecoverVirtualMachineParams(id string) *Recov
 
 // Recovers a virtual machine.
 func (s *VirtualMachineService) RecoverVirtualMachine(p *RecoverVirtualMachineParams) (*RecoverVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("recoverVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("recoverVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7324,7 +7324,7 @@ func (s *VirtualMachineService) NewRemoveNicFromVirtualMachineParams(nicid strin
 
 // Removes VM from specified network by deleting a NIC
 func (s *VirtualMachineService) RemoveNicFromVirtualMachine(p *RemoveNicFromVirtualMachineParams) (*RemoveNicFromVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("removeNicFromVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeNicFromVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7596,7 +7596,7 @@ func (s *VirtualMachineService) NewResetPasswordForVirtualMachineParams(id strin
 
 // Resets the password for virtual machine. The virtual machine must be in a "Stopped" state and the template must already support this feature for this command to take effect. [async]
 func (s *VirtualMachineService) ResetPasswordForVirtualMachine(p *ResetPasswordForVirtualMachineParams) (*ResetPasswordForVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("resetPasswordForVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetPasswordForVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -7992,7 +7992,7 @@ func (s *VirtualMachineService) NewResetUserDataForVirtualMachineParams(id strin
 
 // Resets the UserData for virtual machine. The virtual machine must be in a "Stopped" state.
 func (s *VirtualMachineService) ResetUserDataForVirtualMachine(p *ResetUserDataForVirtualMachineParams) (*ResetUserDataForVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("resetUserDataForVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resetUserDataForVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8345,7 +8345,7 @@ func (s *VirtualMachineService) NewRestoreVirtualMachineParams(virtualmachineid 
 
 // Restore a VM to original template/ISO or new template/ISO
 func (s *VirtualMachineService) RestoreVirtualMachine(p *RestoreVirtualMachineParams) (*RestoreVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("restoreVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("restoreVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8745,7 +8745,7 @@ func (s *VirtualMachineService) NewScaleVirtualMachineParams(id string, serviceo
 
 // Scales the virtual machine to a new service offering. This command also considers the volume size in the service offering or disk offering linked to the new service offering and apply all characteristics to the root volume.
 func (s *VirtualMachineService) ScaleVirtualMachine(p *ScaleVirtualMachineParams) (*ScaleVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("scaleVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("scaleVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -8973,7 +8973,7 @@ func (s *VirtualMachineService) NewStartVirtualMachineParams(id string) *StartVi
 
 // Starts a virtual machine.
 func (s *VirtualMachineService) StartVirtualMachine(p *StartVirtualMachineParams) (*StartVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("startVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("startVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -9246,7 +9246,7 @@ func (s *VirtualMachineService) NewStopVirtualMachineParams(id string) *StopVirt
 
 // Stops a virtual machine.
 func (s *VirtualMachineService) StopVirtualMachine(p *StopVirtualMachineParams) (*StopVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("stopVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("stopVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -9519,7 +9519,7 @@ func (s *VirtualMachineService) NewUpdateDefaultNicForVirtualMachineParams(nicid
 
 // Changes the default NIC on a VM
 func (s *VirtualMachineService) UpdateDefaultNicForVirtualMachine(p *UpdateDefaultNicForVirtualMachineParams) (*UpdateDefaultNicForVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("updateDefaultNicForVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateDefaultNicForVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -11656,7 +11656,7 @@ func (s *VirtualMachineService) NewImportVmParams(clusterid string, hypervisor s
 
 // Import virtual machine from a unmanaged host into CloudStack
 func (s *VirtualMachineService) ImportVm(p *ImportVmParams) (*ImportVmResponse, error) {
-	resp, err := s.cs.newRequest("importVm", p.toURLValues())
+	resp, err := s.cs.newPostRequest("importVm", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -11904,7 +11904,7 @@ func (s *VirtualMachineService) NewUnmanageVirtualMachineParams(id string) *Unma
 
 // Unmanage a guest virtual machine.
 func (s *VirtualMachineService) UnmanageVirtualMachine(p *UnmanageVirtualMachineParams) (*UnmanageVirtualMachineResponse, error) {
-	resp, err := s.cs.newRequest("unmanageVirtualMachine", p.toURLValues())
+	resp, err := s.cs.newPostRequest("unmanageVirtualMachine", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -12542,7 +12542,7 @@ func (s *VirtualMachineService) NewImportUnmanagedInstanceParams(clusterid strin
 
 // Import unmanaged virtual machine from a given cluster.
 func (s *VirtualMachineService) ImportUnmanagedInstance(p *ImportUnmanagedInstanceParams) (*ImportUnmanagedInstanceResponse, error) {
-	resp, err := s.cs.newRequest("importUnmanagedInstance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("importUnmanagedInstance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -12962,7 +12962,7 @@ func (s *VirtualMachineService) NewCreateVMScheduleParams(action string, schedul
 
 // Create VM Schedule
 func (s *VirtualMachineService) CreateVMSchedule(p *CreateVMScheduleParams) (*CreateVMScheduleResponse, error) {
-	resp, err := s.cs.newRequest("createVMSchedule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVMSchedule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -13185,7 +13185,7 @@ func (s *VirtualMachineService) NewUpdateVMScheduleParams(id string) *UpdateVMSc
 
 // Update VM Schedule.
 func (s *VirtualMachineService) UpdateVMSchedule(p *UpdateVMScheduleParams) (*UpdateVMScheduleResponse, error) {
-	resp, err := s.cs.newRequest("updateVMSchedule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVMSchedule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -13573,7 +13573,7 @@ func (s *VirtualMachineService) NewDeleteVMScheduleParams(virtualmachineid strin
 
 // Delete VM Schedule.
 func (s *VirtualMachineService) DeleteVMSchedule(p *DeleteVMScheduleParams) (*DeleteVMScheduleResponse, error) {
-	resp, err := s.cs.newRequest("deleteVMSchedule", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVMSchedule", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VirtualNetworkFunctionsService.go
+++ b/cloudstack/VirtualNetworkFunctionsService.go
@@ -169,7 +169,7 @@ func (s *VirtualNetworkFunctionsService) NewDeleteVnfTemplateParams(id string) *
 
 // Deletes a VNF template from the system. All virtual machines using the deleted template will not be affected.
 func (s *VirtualNetworkFunctionsService) DeleteVnfTemplate(p *DeleteVnfTemplateParams) (*DeleteVnfTemplateResponse, error) {
-	resp, err := s.cs.newRequest("deleteVnfTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVnfTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1522,7 +1522,7 @@ func (s *VirtualNetworkFunctionsService) NewDeployVnfApplianceParams(serviceoffe
 
 // Creates and automatically starts a VNF appliance based on a service offering, disk offering, and template.
 func (s *VirtualNetworkFunctionsService) DeployVnfAppliance(p *DeployVnfApplianceParams) (*DeployVnfApplianceResponse, error) {
-	resp, err := s.cs.newRequest("deployVnfAppliance", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deployVnfAppliance", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4419,7 +4419,7 @@ func (s *VirtualNetworkFunctionsService) NewRegisterVnfTemplateParams(format str
 
 // Registers an existing VNF template into the CloudStack cloud.
 func (s *VirtualNetworkFunctionsService) RegisterVnfTemplate(p *RegisterVnfTemplateParams) (*RegisterVnfTemplateResponse, error) {
-	resp, err := s.cs.newRequest("registerVnfTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("registerVnfTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5066,7 +5066,7 @@ func (s *VirtualNetworkFunctionsService) NewUpdateVnfTemplateParams(id string) *
 
 // Updates a template to VNF template or attributes of a VNF template.
 func (s *VirtualNetworkFunctionsService) UpdateVnfTemplate(p *UpdateVnfTemplateParams) (*UpdateVnfTemplateResponse, error) {
-	resp, err := s.cs.newRequest("updateVnfTemplate", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVnfTemplate", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -185,7 +185,7 @@ func (s *VolumeService) NewAttachVolumeParams(id string, virtualmachineid string
 
 // Attaches a disk volume to a virtual machine.
 func (s *VolumeService) AttachVolume(p *AttachVolumeParams) (*AttachVolumeResponse, error) {
-	resp, err := s.cs.newRequest("attachVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("attachVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (s *VolumeService) NewChangeOfferingForVolumeParams(diskofferingid string, 
 
 // Change disk offering of the volume and also an option to auto migrate if required to apply the new disk offering
 func (s *VolumeService) ChangeOfferingForVolume(p *ChangeOfferingForVolumeParams) (*ChangeOfferingForVolumeResponse, error) {
-	resp, err := s.cs.newRequest("changeOfferingForVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("changeOfferingForVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (s *VolumeService) NewCheckVolumeParams(id string) *CheckVolumeParams {
 
 // Check the volume for any errors or leaks and also repairs when repair parameter is passed, this is currently supported for KVM only
 func (s *VolumeService) CheckVolume(p *CheckVolumeParams) (*CheckVolumeResponse, error) {
-	resp, err := s.cs.newRequest("checkVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("checkVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1118,7 +1118,7 @@ func (s *VolumeService) NewCreateVolumeParams() *CreateVolumeParams {
 
 // Creates a disk volume from a disk offering. This disk volume must still be attached to a virtual machine to make use of it.
 func (s *VolumeService) CreateVolume(p *CreateVolumeParams) (*CreateVolumeResponse, error) {
-	resp, err := s.cs.newRequest("createVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1274,7 +1274,7 @@ func (s *VolumeService) NewDeleteVolumeParams(id string) *DeleteVolumeParams {
 
 // Deletes a detached disk volume.
 func (s *VolumeService) DeleteVolume(p *DeleteVolumeParams) (*DeleteVolumeResponse, error) {
-	resp, err := s.cs.newRequest("deleteVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1393,7 +1393,7 @@ func (s *VolumeService) NewDestroyVolumeParams(id string) *DestroyVolumeParams {
 
 // Destroys a Volume.
 func (s *VolumeService) DestroyVolume(p *DestroyVolumeParams) (*DestroyVolumeResponse, error) {
-	resp, err := s.cs.newRequest("destroyVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("destroyVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1597,7 +1597,7 @@ func (s *VolumeService) NewDetachVolumeParams() *DetachVolumeParams {
 
 // Detaches a disk volume from a virtual machine.
 func (s *VolumeService) DetachVolume(p *DetachVolumeParams) (*DetachVolumeResponse, error) {
-	resp, err := s.cs.newRequest("detachVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("detachVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1827,7 +1827,7 @@ func (s *VolumeService) NewExtractVolumeParams(id string, mode string, zoneid st
 
 // Extracts volume
 func (s *VolumeService) ExtractVolume(p *ExtractVolumeParams) (*ExtractVolumeResponse, error) {
-	resp, err := s.cs.newRequest("extractVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("extractVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -2473,7 +2473,7 @@ func (s *VolumeService) NewImportVolumeParams(path string, storageid string) *Im
 
 // Import an unmanaged volume from a storage pool on a host into CloudStack
 func (s *VolumeService) ImportVolume(p *ImportVolumeParams) (*ImportVolumeResponse, error) {
-	resp, err := s.cs.newRequest("importVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("importVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4666,7 +4666,7 @@ func (s *VolumeService) NewMigrateVolumeParams(storageid string, volumeid string
 
 // Migrate volume
 func (s *VolumeService) MigrateVolume(p *MigrateVolumeParams) (*MigrateVolumeResponse, error) {
-	resp, err := s.cs.newRequest("migrateVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("migrateVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4822,7 +4822,7 @@ func (s *VolumeService) NewRecoverVolumeParams(id string) *RecoverVolumeParams {
 
 // Recovers a Destroy volume.
 func (s *VolumeService) RecoverVolume(p *RecoverVolumeParams) (*RecoverVolumeResponse, error) {
-	resp, err := s.cs.newRequest("recoverVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("recoverVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5082,7 +5082,7 @@ func (s *VolumeService) NewResizeVolumeParams(id string) *ResizeVolumeParams {
 
 // Resizes a volume
 func (s *VolumeService) ResizeVolume(p *ResizeVolumeParams) (*ResizeVolumeResponse, error) {
-	resp, err := s.cs.newRequest("resizeVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("resizeVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5238,7 +5238,7 @@ func (s *VolumeService) NewUnmanageVolumeParams(id string) *UnmanageVolumeParams
 
 // Unmanage a volume on storage pool.
 func (s *VolumeService) UnmanageVolume(p *UnmanageVolumeParams) (*UnmanageVolumeResponse, error) {
-	resp, err := s.cs.newRequest("unmanageVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("unmanageVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5513,7 +5513,7 @@ func (s *VolumeService) NewUpdateVolumeParams() *UpdateVolumeParams {
 
 // Updates the volume.
 func (s *VolumeService) UpdateVolume(p *UpdateVolumeParams) (*UpdateVolumeResponse, error) {
-	resp, err := s.cs.newRequest("updateVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -5888,7 +5888,7 @@ func (s *VolumeService) NewUploadVolumeParams(format string, name string, url st
 
 // Uploads a data disk.
 func (s *VolumeService) UploadVolume(p *UploadVolumeParams) (*UploadVolumeResponse, error) {
-	resp, err := s.cs.newRequest("uploadVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("uploadVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -6418,7 +6418,7 @@ func (s *VolumeService) NewAssignVolumeParams(volumeid string) *AssignVolumePara
 
 // Changes ownership of a Volume from one account to another.
 func (s *VolumeService) AssignVolume(p *AssignVolumeParams) (*AssignVolumeResponse, error) {
-	resp, err := s.cs.newRequest("assignVolume", p.toURLValues())
+	resp, err := s.cs.newPostRequest("assignVolume", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/WebhookService.go
+++ b/cloudstack/WebhookService.go
@@ -315,7 +315,7 @@ func (s *WebhookService) NewCreateWebhookParams(name string, payloadurl string) 
 
 // Creates a Webhook
 func (s *WebhookService) CreateWebhook(p *CreateWebhookParams) (*CreateWebhookResponse, error) {
-	resp, err := s.cs.newRequest("createWebhook", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createWebhook", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +395,7 @@ func (s *WebhookService) NewDeleteWebhookParams(id string) *DeleteWebhookParams 
 
 // Deletes a Webhook
 func (s *WebhookService) DeleteWebhook(p *DeleteWebhookParams) (*DeleteWebhookResponse, error) {
-	resp, err := s.cs.newRequest("deleteWebhook", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteWebhook", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (s *WebhookService) NewDeleteWebhookDeliveryParams() *DeleteWebhookDelivery
 
 // Deletes Webhook delivery
 func (s *WebhookService) DeleteWebhookDelivery(p *DeleteWebhookDeliveryParams) (*DeleteWebhookDeliveryResponse, error) {
-	resp, err := s.cs.newRequest("deleteWebhookDelivery", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteWebhookDelivery", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -798,7 +798,7 @@ func (s *WebhookService) NewExecuteWebhookDeliveryParams() *ExecuteWebhookDelive
 
 // Executes a Webhook delivery
 func (s *WebhookService) ExecuteWebhookDelivery(p *ExecuteWebhookDeliveryParams) (*ExecuteWebhookDeliveryResponse, error) {
-	resp, err := s.cs.newRequest("executeWebhookDelivery", p.toURLValues())
+	resp, err := s.cs.newPostRequest("executeWebhookDelivery", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1868,7 +1868,7 @@ func (s *WebhookService) NewUpdateWebhookParams(id string) *UpdateWebhookParams 
 
 // Updates a Webhook
 func (s *WebhookService) UpdateWebhook(p *UpdateWebhookParams) (*UpdateWebhookResponse, error) {
-	resp, err := s.cs.newRequest("updateWebhook", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateWebhook", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -228,7 +228,7 @@ func (s *ZoneService) NewCreateIpv4SubnetForZoneParams(subnet string, zoneid str
 
 // Creates a IPv4 subnet for a zone.
 func (s *ZoneService) CreateIpv4SubnetForZone(p *CreateIpv4SubnetForZoneParams) (*CreateIpv4SubnetForZoneResponse, error) {
-	resp, err := s.cs.newRequest("createIpv4SubnetForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createIpv4SubnetForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +665,7 @@ func (s *ZoneService) NewCreateZoneParams(dns1 string, internaldns1 string, name
 
 // Creates a Zone.
 func (s *ZoneService) CreateZone(p *CreateZoneParams) (*CreateZoneResponse, error) {
-	resp, err := s.cs.newRequest("createZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("createZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -854,7 +854,7 @@ func (s *ZoneService) NewDedicateIpv4SubnetForZoneParams(id string) *DedicateIpv
 
 // Dedicates an existing IPv4 subnet for a zone to an account or a domain.
 func (s *ZoneService) DedicateIpv4SubnetForZone(p *DedicateIpv4SubnetForZoneParams) (*DedicateIpv4SubnetForZoneResponse, error) {
-	resp, err := s.cs.newRequest("dedicateIpv4SubnetForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicateIpv4SubnetForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -998,7 +998,7 @@ func (s *ZoneService) NewDedicateZoneParams(domainid string, zoneid string) *Ded
 
 // Dedicates a zones.
 func (s *ZoneService) DedicateZone(p *DedicateZoneParams) (*DedicateZoneResponse, error) {
-	resp, err := s.cs.newRequest("dedicateZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("dedicateZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1089,7 +1089,7 @@ func (s *ZoneService) NewDeleteZoneParams(id string) *DeleteZoneParams {
 
 // Deletes a Zone.
 func (s *ZoneService) DeleteZone(p *DeleteZoneParams) (*DeleteZoneResponse, error) {
-	resp, err := s.cs.newRequest("deleteZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1183,7 +1183,7 @@ func (s *ZoneService) NewDeleteIpv4SubnetForZoneParams(id string) *DeleteIpv4Sub
 
 // Deletes an existing IPv4 subnet for a zone.
 func (s *ZoneService) DeleteIpv4SubnetForZone(p *DeleteIpv4SubnetForZoneParams) (*DeleteIpv4SubnetForZoneResponse, error) {
-	resp, err := s.cs.newRequest("deleteIpv4SubnetForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("deleteIpv4SubnetForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1265,7 +1265,7 @@ func (s *ZoneService) NewDisableOutOfBandManagementForZoneParams(zoneid string) 
 
 // Disables out-of-band management for a zone
 func (s *ZoneService) DisableOutOfBandManagementForZone(p *DisableOutOfBandManagementForZoneParams) (*DisableOutOfBandManagementForZoneResponse, error) {
-	resp, err := s.cs.newRequest("disableOutOfBandManagementForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableOutOfBandManagementForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1361,7 +1361,7 @@ func (s *ZoneService) NewEnableOutOfBandManagementForZoneParams(zoneid string) *
 
 // Enables out-of-band management for a zone
 func (s *ZoneService) EnableOutOfBandManagementForZone(p *EnableOutOfBandManagementForZoneParams) (*EnableOutOfBandManagementForZoneResponse, error) {
-	resp, err := s.cs.newRequest("enableOutOfBandManagementForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableOutOfBandManagementForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1457,7 +1457,7 @@ func (s *ZoneService) NewDisableHAForZoneParams(zoneid string) *DisableHAForZone
 
 // Disables HA for a zone
 func (s *ZoneService) DisableHAForZone(p *DisableHAForZoneParams) (*DisableHAForZoneResponse, error) {
-	resp, err := s.cs.newRequest("disableHAForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("disableHAForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -1539,7 +1539,7 @@ func (s *ZoneService) NewEnableHAForZoneParams(zoneid string) *EnableHAForZonePa
 
 // Enables HA for a zone
 func (s *ZoneService) EnableHAForZone(p *EnableHAForZoneParams) (*EnableHAForZoneResponse, error) {
-	resp, err := s.cs.newRequest("enableHAForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("enableHAForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3114,7 +3114,7 @@ func (s *ZoneService) NewReleaseDedicatedZoneParams(zoneid string) *ReleaseDedic
 
 // Release dedication of zone
 func (s *ZoneService) ReleaseDedicatedZone(p *ReleaseDedicatedZoneParams) (*ReleaseDedicatedZoneResponse, error) {
-	resp, err := s.cs.newRequest("releaseDedicatedZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseDedicatedZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3196,7 +3196,7 @@ func (s *ZoneService) NewReleaseIpv4SubnetForZoneParams(id string) *ReleaseIpv4S
 
 // Releases an existing dedicated IPv4 subnet for a zone.
 func (s *ZoneService) ReleaseIpv4SubnetForZone(p *ReleaseIpv4SubnetForZoneParams) (*ReleaseIpv4SubnetForZoneResponse, error) {
-	resp, err := s.cs.newRequest("releaseIpv4SubnetForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("releaseIpv4SubnetForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -3683,7 +3683,7 @@ func (s *ZoneService) NewUpdateZoneParams(id string) *UpdateZoneParams {
 
 // Updates a Zone.
 func (s *ZoneService) UpdateZone(p *UpdateZoneParams) (*UpdateZoneResponse, error) {
-	resp, err := s.cs.newRequest("updateZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4161,7 +4161,7 @@ func (s *ZoneService) NewAddVmwareDcParams(name string, vcenter string, zoneid s
 
 // Adds a VMware datacenter to specified zone
 func (s *ZoneService) AddVmwareDc(p *AddVmwareDcParams) (*AddVmwareDcResponse, error) {
-	resp, err := s.cs.newRequest("addVmwareDc", p.toURLValues())
+	resp, err := s.cs.newPostRequest("addVmwareDc", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4418,7 +4418,7 @@ func (s *ZoneService) NewRemoveVmwareDcParams(zoneid string) *RemoveVmwareDcPara
 
 // Remove a VMware datacenter from a zone.
 func (s *ZoneService) RemoveVmwareDc(p *RemoveVmwareDcParams) (*RemoveVmwareDcResponse, error) {
-	resp, err := s.cs.newRequest("removeVmwareDc", p.toURLValues())
+	resp, err := s.cs.newPostRequest("removeVmwareDc", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4537,7 +4537,7 @@ func (s *ZoneService) NewUpdateIpv4SubnetForZoneParams(id string, subnet string)
 
 // Updates an existing IPv4 subnet for a zone.
 func (s *ZoneService) UpdateIpv4SubnetForZone(p *UpdateIpv4SubnetForZoneParams) (*UpdateIpv4SubnetForZoneResponse, error) {
-	resp, err := s.cs.newRequest("updateIpv4SubnetForZone", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateIpv4SubnetForZone", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}
@@ -4753,7 +4753,7 @@ func (s *ZoneService) NewUpdateVmwareDcParams(zoneid string) *UpdateVmwareDcPara
 
 // Updates a VMware datacenter details for a zone
 func (s *ZoneService) UpdateVmwareDc(p *UpdateVmwareDcParams) (*UpdateVmwareDcResponse, error) {
-	resp, err := s.cs.newRequest("updateVmwareDc", p.toURLValues())
+	resp, err := s.cs.newPostRequest("updateVmwareDc", p.toURLValues())
 	if err != nil {
 		return nil, err
 	}

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -511,7 +511,7 @@ func (cs *CloudStackClient) GetAsyncJobResult(jobid string, timeout int64) (json
 // Execute the request against a CS API. Will return the raw JSON data returned by the API and nil if
 // no error occurred. If the API returns an error the result will be nil and the HTTP error code and CS
 // error details. If a processing (code) error occurs the result will be nil and the generated error
-func (cs *CloudStackClient) newPostRequest(api string, params url.Values) (json.RawMessage, error) {
+func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {
 	return cs.newRawRequest(api, false, params)
 }
 

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -511,7 +511,7 @@ func (cs *CloudStackClient) GetAsyncJobResult(jobid string, timeout int64) (json
 // Execute the request against a CS API. Will return the raw JSON data returned by the API and nil if
 // no error occurred. If the API returns an error the result will be nil and the HTTP error code and CS
 // error details. If a processing (code) error occurs the result will be nil and the generated error
-func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {
+func (cs *CloudStackClient) newPostRequest(api string, params url.Values) (json.RawMessage, error) {
 	return cs.newRawRequest(api, false, params)
 }
 

--- a/cloudstack/cloudstack.go
+++ b/cloudstack/cloudstack.go
@@ -39,7 +39,7 @@ import (
 	"strings"
 	"time"
 
-        gomock "go.uber.org/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // UnlimitedResourceID is a special ID to define an unlimited resource
@@ -529,6 +529,8 @@ func (cs *CloudStackClient) newRawRequest(api string, post bool, params url.Valu
 	params.Set("apiKey", cs.apiKey)
 	params.Set("command", api)
 	params.Set("response", "json")
+	params.Set("signatureversion", "3")
+	params.Set("expires", time.Now().UTC().Add(15*time.Minute).Format(time.RFC3339))
 
 	// Generate signature for API call
 	// * Serialize parameters, URL encoding only values and sort them by key, done by EncodeValues

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -560,7 +560,7 @@ func (as *allServices) GeneralCode() ([]byte, error) {
 	pn("// Execute the request against a CS API. Will return the raw JSON data returned by the API and nil if")
 	pn("// no error occurred. If the API returns an error the result will be nil and the HTTP error code and CS")
 	pn("// error details. If a processing (code) error occurs the result will be nil and the generated error")
-	pn("func (cs *CloudStackClient) newPostRequest(api string, params url.Values) (json.RawMessage, error) {")
+	pn("func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {")
 	pn("		return cs.newRawRequest(api, false, params)")
 	pn("}")
 	pn("")

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -560,7 +560,7 @@ func (as *allServices) GeneralCode() ([]byte, error) {
 	pn("// Execute the request against a CS API. Will return the raw JSON data returned by the API and nil if")
 	pn("// no error occurred. If the API returns an error the result will be nil and the HTTP error code and CS")
 	pn("// error details. If a processing (code) error occurs the result will be nil and the generated error")
-	pn("func (cs *CloudStackClient) newRequest(api string, params url.Values) (json.RawMessage, error) {")
+	pn("func (cs *CloudStackClient) newPostRequest(api string, params url.Values) (json.RawMessage, error) {")
 	pn("		return cs.newRawRequest(api, false, params)")
 	pn("}")
 	pn("")
@@ -1065,7 +1065,7 @@ func (s *service) GenerateCode() ([]byte, error) {
 		pn("}")
 		pn("")
 		pn("func (s *CustomService) CustomRequest(api string, p *CustomServiceParams, result interface{}) error {")
-		pn("	resp, err := s.cs.newRequest(api, p.toURLValues())")
+		pn("	resp, err := s.cs.newPostRequest(api, p.toURLValues())")
 		pn("	if err != nil {")
 		pn("		return err")
 		pn("	}")
@@ -1752,7 +1752,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 		pn("")
 		pn("	// We should be able to retry on failure as this call is idempotent")
 		pn("	for i := 0; i < 3; i++ {")
-		pn("		resp, err = s.cs.newRequest(\"%s\", p.toURLValues())", a.Name)
+		pn("		resp, err = s.cs.newPostRequest(\"%s\", p.toURLValues())", a.Name)
 		pn("		if err == nil {")
 		pn("			break")
 		pn("		}")
@@ -1762,7 +1762,7 @@ func (s *service) generateNewAPICallFunc(a *API) {
 		if requiresPostMethod[a.Name] {
 			pn("	resp, err := s.cs.newPostRequest(\"%s\", p.toURLValues())", a.Name)
 		} else {
-			pn("	resp, err := s.cs.newRequest(\"%s\", p.toURLValues())", a.Name)
+			pn("	resp, err := s.cs.newPostRequest(\"%s\", p.toURLValues())", a.Name)
 		}
 	}
 	pn("	if err != nil {")

--- a/generate/requiredParams.go
+++ b/generate/requiredParams.go
@@ -49,10 +49,7 @@ var requiredParams = map[string][]string{
 		"displaytext",
 	},
 	"createVPC": {
-		"name",
 		"displaytext",
-		"vpcofferingid",
-		"zoneid",
 		"cidr",
 	},
 	"createVPCOffering": {

--- a/generate/requiredParams.go
+++ b/generate/requiredParams.go
@@ -49,7 +49,11 @@ var requiredParams = map[string][]string{
 		"displaytext",
 	},
 	"createVPC": {
+		"name",
 		"displaytext",
+		"vpcofferingid",
+		"zoneid",
+		"cidr",
 	},
 	"createVPCOffering": {
 		"displaytext",

--- a/test/VPCService_test.go
+++ b/test/VPCService_test.go
@@ -69,7 +69,7 @@ func TestVPCService(t *testing.T) {
 		if _, ok := response["createVPC"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.VPC.NewCreateVPCParams("displaytext", "name", "vpcofferingid", "zoneid")
+		p := client.VPC.NewCreateVPCParams("cidr", "displaytext", "name", "vpcofferingid", "zoneid")
 		r, err := client.VPC.CreateVPC(p)
 		if err != nil {
 			t.Errorf(err.Error())


### PR DESCRIPTION
Currently State Changing Request utilize GET request but this is a potential security vulnerability since attackers may be able to intercept and extract the query parameters of GET requests. Utilizing POST requests will help mitigate this security vulnerability since the parameters of the POST body will be encrypted in transport. 