### PR TITLE
Add privateendport and publicendport parameters to createPortForwardingRule API

### DIFF
--- a/cloudstack/FirewallService.go
+++ b/cloudstack/FirewallService.go
@@ -87,7 +87,7 @@ type FirewallServiceIface interface {
 	CreateFirewallRule(p *CreateFirewallRuleParams) (*CreateFirewallRuleResponse, error)
 	NewCreateFirewallRuleParams(ipaddressid string, protocol string) *CreateFirewallRuleParams
 	CreatePortForwardingRule(p *CreatePortForwardingRuleParams) (*CreatePortForwardingRuleResponse, error)
-	NewCreatePortForwardingRuleParams(ipaddressid string, privateport int, protocol string, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams
+	NewCreatePortForwardingRuleParams(ipaddressid string, privateendport int, privateport int, protocol string, publicendport int, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams
 	CreateRoutingFirewallRule(p *CreateRoutingFirewallRuleParams) (*CreateRoutingFirewallRuleResponse, error)
 	NewCreateRoutingFirewallRuleParams(networkid string, protocol string) *CreateRoutingFirewallRuleParams
 	DeleteEgressFirewallRule(p *DeleteEgressFirewallRuleParams) (*DeleteEgressFirewallRuleResponse, error)
@@ -1412,12 +1412,14 @@ func (p *CreatePortForwardingRuleParams) GetVmguestip() (string, bool) {
 
 // You should always use this function to get a new CreatePortForwardingRuleParams instance,
 // as then you are sure you have configured all required params
-func (s *FirewallService) NewCreatePortForwardingRuleParams(ipaddressid string, privateport int, protocol string, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams {
+func (s *FirewallService) NewCreatePortForwardingRuleParams(ipaddressid string, privateendport int, privateport int, protocol string, publicendport int, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams {
 	p := &CreatePortForwardingRuleParams{}
 	p.p = make(map[string]interface{})
 	p.p["ipaddressid"] = ipaddressid
+	p.p["privateendport"] = privateendport
 	p.p["privateport"] = privateport
 	p.p["protocol"] = protocol
+	p.p["publicendport"] = publicendport
 	p.p["publicport"] = publicport
 	p.p["virtualmachineid"] = virtualmachineid
 	return p

--- a/cloudstack/FirewallService_mock.go
+++ b/cloudstack/FirewallService_mock.go
@@ -519,17 +519,17 @@ func (mr *MockFirewallServiceIfaceMockRecorder) NewCreateIpv6FirewallRuleParams(
 }
 
 // NewCreatePortForwardingRuleParams mocks base method.
-func (m *MockFirewallServiceIface) NewCreatePortForwardingRuleParams(ipaddressid string, privateport int, protocol string, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams {
+func (m *MockFirewallServiceIface) NewCreatePortForwardingRuleParams(ipaddressid string, privateendport, privateport int, protocol string, publicendport, publicport int, virtualmachineid string) *CreatePortForwardingRuleParams {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewCreatePortForwardingRuleParams", ipaddressid, privateport, protocol, publicport, virtualmachineid)
+	ret := m.ctrl.Call(m, "NewCreatePortForwardingRuleParams", ipaddressid, privateendport, privateport, protocol, publicendport, publicport, virtualmachineid)
 	ret0, _ := ret[0].(*CreatePortForwardingRuleParams)
 	return ret0
 }
 
 // NewCreatePortForwardingRuleParams indicates an expected call of NewCreatePortForwardingRuleParams.
-func (mr *MockFirewallServiceIfaceMockRecorder) NewCreatePortForwardingRuleParams(ipaddressid, privateport, protocol, publicport, virtualmachineid any) *gomock.Call {
+func (mr *MockFirewallServiceIfaceMockRecorder) NewCreatePortForwardingRuleParams(ipaddressid, privateendport, privateport, protocol, publicendport, publicport, virtualmachineid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreatePortForwardingRuleParams", reflect.TypeOf((*MockFirewallServiceIface)(nil).NewCreatePortForwardingRuleParams), ipaddressid, privateport, protocol, publicport, virtualmachineid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCreatePortForwardingRuleParams", reflect.TypeOf((*MockFirewallServiceIface)(nil).NewCreatePortForwardingRuleParams), ipaddressid, privateendport, privateport, protocol, publicendport, publicport, virtualmachineid)
 }
 
 // NewCreateRoutingFirewallRuleParams mocks base method.

--- a/generate/requiredParams.go
+++ b/generate/requiredParams.go
@@ -70,4 +70,8 @@ var requiredParams = map[string][]string{
 	"updateGuestOs": {
 		"osdisplayname",
 	},
+        "createPortForwardingRule": {
+		"privateendport",
+		"publicendport",
+	},
 }

--- a/test/FirewallService_test.go
+++ b/test/FirewallService_test.go
@@ -93,7 +93,7 @@ func TestFirewallService(t *testing.T) {
 		if _, ok := response["createPortForwardingRule"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
 		}
-		p := client.Firewall.NewCreatePortForwardingRuleParams("ipaddressid", 0, "protocol", 0, "virtualmachineid")
+		p := client.Firewall.NewCreatePortForwardingRuleParams("ipaddressid", 0, 0, "protocol", 0, 0, "virtualmachineid")
 		r, err := client.Firewall.CreatePortForwardingRule(p)
 		if err != nil {
 			t.Errorf(err.Error())


### PR DESCRIPTION
This PR adds _privateendport_ and _publicendport_ parameters to createPortForwardingRule API.

Fixes #101 