### PR TITLE
Fix generation of otherdeployparams's setters

### DIFF
--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -632,7 +632,7 @@ func (p *CreateAutoScaleVmProfileParams) toURLValues() url.Values {
 	if v, found := p.p["otherdeployparams"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("otherdeployparams[%d].key", i), k)
+			u.Set(fmt.Sprintf("otherdeployparams[%d].name", i), k)
 			u.Set(fmt.Sprintf("otherdeployparams[%d].value", i), m[k])
 		}
 	}
@@ -4693,7 +4693,7 @@ func (p *UpdateAutoScaleVmProfileParams) toURLValues() url.Values {
 	if v, found := p.p["otherdeployparams"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("otherdeployparams[%d].key", i), k)
+			u.Set(fmt.Sprintf("otherdeployparams[%d].name", i), k)
 			u.Set(fmt.Sprintf("otherdeployparams[%d].value", i), m[k])
 		}
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1404,6 +1404,9 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 		case "datadiskofferinglist":
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].disk\", i), k)", name)
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].diskOffering\", i), m[k])", name)
+		case "otherdeployparams":
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].name\", i), k)", name)
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
 		default:
 			if zeroIndex && !detailsRequireKeyValue[cmd] {
 				pn("	u.Set(fmt.Sprintf(\"%s[0].%%s\", k), m[k])", name)


### PR DESCRIPTION
`otherdeployparams` for create autoscale vm profile requires the map to have the key `name` and not `key`. This PR fixes the generation of the keys for `otherdeployparams`.
Ref: https://github.com/apache/cloudstack-terraform-provider/issues/173#issuecomment-3219421448