### PR TITLE
Fix format of details map for update VM

### DIFF
--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -9858,8 +9858,8 @@ func (p *UpdateVirtualMachineParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["details"]; found {
 		m := v.(map[string]string)
-		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
+		for _, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[0].%s", k), m[k])
 		}
 	}
 	if v, found := p.p["dhcpoptionsnetworklist"]; found {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -54,10 +54,23 @@ var detailsRequireKeyValue = map[string]bool{
 // detailsRequireZeroIndex is a prefilled map with a list of details
 // that need to be encoded using zero indexing
 var detailsRequireZeroIndex = map[string]bool{
-	"registerTemplate": true,
-	"updateTemplate":   true,
-	"createAccount":    true,
-	"updateAccount":    true,
+	"registerTemplate":     true,
+	"updateTemplate":       true,
+	"createAccount":        true,
+	"updateAccount":        true,
+	"updateVirtualMachine": true,
+}
+
+// parametersRequireIndexing contains map parameters that always need
+// index variables (i) even when the command uses zero indexing
+var parametersRequireIndexing = map[string]bool{
+	"userdatadetails":       true,
+	"serviceproviderlist":   true,
+	"usersecuritygrouplist": true,
+	"tags":                  true,
+	"nicnetworklist":        true,
+	"nicipaddresslist":      true,
+	"datadiskofferinglist":  true,
 }
 
 // requiresPost is a prefilled set of API names that require POST
@@ -1363,7 +1376,10 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 	case "map[string]string":
 		pn("m := v.(map[string]string)")
 		zeroIndex := detailsRequireZeroIndex[cmd]
-		if zeroIndex {
+		needsIndex := parametersRequireIndexing[name]
+
+		// Use index variable if parameter requires it or command doesn't use zero indexing
+		if zeroIndex && !needsIndex {
 			pn("for _, k := range getSortedKeysFromMap(m) {")
 		} else {
 			pn("for i, k := range getSortedKeysFromMap(m) {")
@@ -1408,7 +1424,7 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].name\", i), k)", name)
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].value\", i), m[k])", name)
 		default:
-			if zeroIndex && !detailsRequireKeyValue[cmd] {
+			if zeroIndex && !detailsRequireKeyValue[cmd] && !needsIndex {
 				pn("	u.Set(fmt.Sprintf(\"%s[0].%%s\", k), m[k])", name)
 			} else {
 				pn("	u.Set(fmt.Sprintf(\"%s[%%d].key\", i), k)", name)


### PR DESCRIPTION
Ref: https://github.com/apache/cloudstack-terraform-provider/pull/158#pullrequestreview-3172189779

This pull request improves the handling and code generation for parameters that require specific indexing formats in CloudStack API requests. The main changes address how map parameters are serialized, especially for commands and parameters that use zero-based indexing or require explicit index variables.

**Improvements to parameter indexing logic:**

* Added `updateVirtualMachine` to the `detailsRequireZeroIndex` map, ensuring its `details` parameter uses zero-based indexing in generated code.
* Introduced a new `parametersRequireIndexing` map to track parameters that always need index variables, even if the command uses zero indexing.

**Adjustments to code generation:**

* Updated the code generation logic in `generateConvertCode` to use index variables only when required by the new maps, improving accuracy for map parameter serialization.
* Refined the conditional logic for formatting key-value pairs, ensuring zero-based indexing is only applied when appropriate, and index variables are used when needed.

**Bug fix in VM update parameter serialization:**

* Fixed the `UpdateVirtualMachineParams.toURLValues` method to always use zero-based indexing for the `details` parameter, aligning with API expectations.