### PR TITLE
Fix userdatadetails

### DIFF
--- a/cloudstack/AutoScaleService.go
+++ b/cloudstack/AutoScaleService.go
@@ -651,8 +651,7 @@ func (p *CreateAutoScaleVmProfileParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {
@@ -4709,8 +4708,7 @@ func (p *UpdateAutoScaleVmProfileParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {

--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -1446,8 +1446,7 @@ func (p *DeployVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {
@@ -7935,8 +7934,7 @@ func (p *ResetUserDataForVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {
@@ -9917,8 +9915,7 @@ func (p *UpdateVirtualMachineParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {

--- a/cloudstack/VirtualNetworkFunctionsService.go
+++ b/cloudstack/VirtualNetworkFunctionsService.go
@@ -396,8 +396,7 @@ func (p *DeployVnfApplianceParams) toURLValues() url.Values {
 	if v, found := p.p["userdatadetails"]; found {
 		m := v.(map[string]string)
 		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("userdatadetails[%d].key", i), k)
-			u.Set(fmt.Sprintf("userdatadetails[%d].value", i), m[k])
+			u.Set(fmt.Sprintf("userdatadetails[%d].%s", i, k), m[k])
 		}
 	}
 	if v, found := p.p["userdataid"]; found {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1380,6 +1380,8 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 					pn("	u.Set(fmt.Sprintf(\"%s[%%d].%%s\", i, k), m[k])", name)
 				}
 			}
+		case "userdatadetails":
+			pn("	u.Set(fmt.Sprintf(\"%s[%%d].%%s\", i, k), m[k])", name)
 		case "serviceproviderlist":
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].service\", i), k)", name)
 			pn("	u.Set(fmt.Sprintf(\"%s[%%d].provider\", i), m[k])", name)


### PR DESCRIPTION
Fixes https://github.com/apache/cloudstack-go/issues/104

<details><summary>Details</summary>
<p>

This pull request updates the way `userdatadetails` are serialized to URL parameters across several CloudStack API parameter structs. Instead of using fixed `.key` and `.value` fields, the code now dynamically uses the map key as the parameter name, improving flexibility and aligning with expected API conventions. The code generator is also updated to reflect this change, ensuring future code generation remains consistent.

**Parameter serialization changes:**

* Updated all usages of `userdatadetails` in `toURLValues()` methods to serialize each key-value pair as `userdatadetails[i].<key>=<value>` instead of `userdatadetails[i].key=<key>` and `userdatadetails[i].value=<value>`. This affects:
  - `DeployVirtualMachineParams` (`cloudstack/VirtualMachineService.go`)
  - `UpdateVirtualMachineParams` (`cloudstack/VirtualMachineService.go`)
  - `ResetUserDataForVirtualMachineParams` (`cloudstack/VirtualMachineService.go`)
  - `DeployVnfApplianceParams` (`cloudstack/VirtualNetworkFunctionsService.go`)
  - `CreateAutoScaleVmProfileParams` (`cloudstack/AutoScaleService.go`)
  - `UpdateAutoScaleVmProfileParams` (`cloudstack/AutoScaleService.go`)

**Code generation update:**

* Modified the code generator (`generate/generate.go`) to emit the new serialization logic for `userdatadetails`, ensuring future generated code uses the correct format.

</p>
</details> 

I used the below script for testing.
```golang
package main

import (
	"fmt"
	"log"

	"github.com/apache/cloudstack-go/v2/cloudstack"
)

func main() {
	cs := cloudstack.NewAsyncClient("API",
		"access-key",
		"secret",
		false)

	// Create a new parameter struct
	p := cs.VirtualMachine.NewDeployVirtualMachineParams("fa2e4525-307e-4882-921c-52c1353b2c12", "3abf9626-c94e-11f0-a79a-1e0058000137", "4ad5637c-b7f4-498c-8ebd-299ea07b9d2c")
	p.SetNetworkids([]string{"cfccbcc7-cc55-4b55-ae63-57cc5d772589"})

	p.SetUserdatadetails(map[string]string{
		"vm_id": "t",
		"abc":   "abc",
		"xy":    "xy",
	})

	p.SetStartvm(false)

	r, err := cs.VirtualMachine.DeployVirtualMachine(p)
	if err != nil {
		log.Fatalf("Error deploying the virtual machine %s", err)
	}

	fmt.Printf("UUID or the deployed virtual machine: id: %s, %+v", r.Id, r)
}
```
Used this to create the VM before and after the changes.
<img width="720" height="95" alt="image" src="https://github.com/user-attachments/assets/01f5195a-b7eb-4444-aeb3-d7934330bf11" />

7 is after the changes
8 is before
