### PR TITLE
Updated MS maintenance APIs

### DIFF
--- a/cloudstack/ManagementService.go
+++ b/cloudstack/ManagementService.go
@@ -28,8 +28,6 @@ import (
 )
 
 type ManagementServiceIface interface {
-	CancelShutdown(p *CancelShutdownParams) (*CancelShutdownResponse, error)
-	NewCancelShutdownParams(managementserverid UUID) *CancelShutdownParams
 	ListManagementServers(p *ListManagementServersParams) (*ListManagementServersResponse, error)
 	NewListManagementServersParams() *ListManagementServersParams
 	GetManagementServerID(name string, opts ...OptionFunc) (string, int, error)
@@ -40,85 +38,20 @@ type ManagementServiceIface interface {
 	GetManagementServersMetricID(name string, opts ...OptionFunc) (string, int, error)
 	GetManagementServersMetricByName(name string, opts ...OptionFunc) (*ManagementServersMetric, int, error)
 	GetManagementServersMetricByID(id string, opts ...OptionFunc) (*ManagementServersMetric, int, error)
+	RemoveManagementServer(p *RemoveManagementServerParams) (*RemoveManagementServerResponse, error)
+	NewRemoveManagementServerParams(id string) *RemoveManagementServerParams
+	PrepareForMaintenance(p *PrepareForMaintenanceParams) (*PrepareForMaintenanceResponse, error)
+	NewPrepareForMaintenanceParams(managementserverid UUID) *PrepareForMaintenanceParams
+	CancelMaintenance(p *CancelMaintenanceParams) (*CancelMaintenanceResponse, error)
+	NewCancelMaintenanceParams(managementserverid UUID) *CancelMaintenanceParams
+	CancelShutdown(p *CancelShutdownParams) (*CancelShutdownResponse, error)
+	NewCancelShutdownParams(managementserverid UUID) *CancelShutdownParams
 	PrepareForShutdown(p *PrepareForShutdownParams) (*PrepareForShutdownResponse, error)
 	NewPrepareForShutdownParams(managementserverid UUID) *PrepareForShutdownParams
 	ReadyForShutdown(p *ReadyForShutdownParams) (*ReadyForShutdownResponse, error)
 	NewReadyForShutdownParams(managementserverid UUID) *ReadyForShutdownParams
 	TriggerShutdown(p *TriggerShutdownParams) (*TriggerShutdownResponse, error)
 	NewTriggerShutdownParams(managementserverid UUID) *TriggerShutdownParams
-}
-
-type CancelShutdownParams struct {
-	p map[string]interface{}
-}
-
-func (p *CancelShutdownParams) toURLValues() url.Values {
-	u := url.Values{}
-	if p.p == nil {
-		return u
-	}
-	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
-	}
-	return u
-}
-
-func (p *CancelShutdownParams) SetManagementserverid(v UUID) {
-	if p.p == nil {
-		p.p = make(map[string]interface{})
-	}
-	p.p["managementserverid"] = v
-}
-
-func (p *CancelShutdownParams) ResetManagementserverid() {
-	if p.p != nil && p.p["managementserverid"] != nil {
-		delete(p.p, "managementserverid")
-	}
-}
-
-func (p *CancelShutdownParams) GetManagementserverid() (UUID, bool) {
-	if p.p == nil {
-		p.p = make(map[string]interface{})
-	}
-	value, ok := p.p["managementserverid"].(UUID)
-	return value, ok
-}
-
-// You should always use this function to get a new CancelShutdownParams instance,
-// as then you are sure you have configured all required params
-func (s *ManagementService) NewCancelShutdownParams(managementserverid UUID) *CancelShutdownParams {
-	p := &CancelShutdownParams{}
-	p.p = make(map[string]interface{})
-	p.p["managementserverid"] = managementserverid
-	return p
-}
-
-// Cancels a triggered shutdown
-func (s *ManagementService) CancelShutdown(p *CancelShutdownParams) (*CancelShutdownResponse, error) {
-	resp, err := s.cs.newPostRequest("cancelShutdown", p.toURLValues())
-	if err != nil {
-		return nil, err
-	}
-
-	var r CancelShutdownResponse
-	if err := json.Unmarshal(resp, &r); err != nil {
-		return nil, err
-	}
-
-	return &r, nil
-}
-
-type CancelShutdownResponse struct {
-	Agents               []string `json:"agents"`
-	Agentscount          int64    `json:"agentscount"`
-	JobID                string   `json:"jobid"`
-	Jobstatus            int      `json:"jobstatus"`
-	Maintenanceinitiated bool     `json:"maintenanceinitiated"`
-	Managementserverid   UUID     `json:"managementserverid"`
-	Pendingjobscount     int64    `json:"pendingjobscount"`
-	Readyforshutdown     bool     `json:"readyforshutdown"`
-	Shutdowntriggered    bool     `json:"shutdowntriggered"`
-	State                string   `json:"state"`
 }
 
 type ListManagementServersParams struct {
@@ -753,6 +686,393 @@ type ManagementServersMetric struct {
 	Threadswaitingcount     int       `json:"threadswaitingcount"`
 	Usageislocal            bool      `json:"usageislocal"`
 	Version                 string    `json:"version"`
+}
+
+type RemoveManagementServerParams struct {
+	p map[string]interface{}
+}
+
+func (p *RemoveManagementServerParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *RemoveManagementServerParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+}
+
+func (p *RemoveManagementServerParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
+func (p *RemoveManagementServerParams) GetId() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["id"].(string)
+	return value, ok
+}
+
+// You should always use this function to get a new RemoveManagementServerParams instance,
+// as then you are sure you have configured all required params
+func (s *ManagementService) NewRemoveManagementServerParams(id string) *RemoveManagementServerParams {
+	p := &RemoveManagementServerParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Removes a Management Server.
+func (s *ManagementService) RemoveManagementServer(p *RemoveManagementServerParams) (*RemoveManagementServerResponse, error) {
+	resp, err := s.cs.newPostRequest("removeManagementServer", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r RemoveManagementServerResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type RemoveManagementServerResponse struct {
+	Displaytext string `json:"displaytext"`
+	JobID       string `json:"jobid"`
+	Jobstatus   int    `json:"jobstatus"`
+	Success     bool   `json:"success"`
+}
+
+func (r *RemoveManagementServerResponse) UnmarshalJSON(b []byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+
+	if success, ok := m["success"].(string); ok {
+		m["success"] = success == "true"
+		b, err = json.Marshal(m)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ostypeid, ok := m["ostypeid"].(float64); ok {
+		m["ostypeid"] = strconv.Itoa(int(ostypeid))
+		b, err = json.Marshal(m)
+		if err != nil {
+			return err
+		}
+	}
+
+	type alias RemoveManagementServerResponse
+	return json.Unmarshal(b, (*alias)(r))
+}
+
+type PrepareForMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *PrepareForMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["algorithm"]; found {
+		u.Set("algorithm", v.(string))
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["managementserverid"]; found {
+		u.Set("managementserverid", v.(string))
+	}
+	return u
+}
+
+func (p *PrepareForMaintenanceParams) SetAlgorithm(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["algorithm"] = v
+}
+
+func (p *PrepareForMaintenanceParams) ResetAlgorithm() {
+	if p.p != nil && p.p["algorithm"] != nil {
+		delete(p.p, "algorithm")
+	}
+}
+
+func (p *PrepareForMaintenanceParams) GetAlgorithm() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["algorithm"].(string)
+	return value, ok
+}
+
+func (p *PrepareForMaintenanceParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+}
+
+func (p *PrepareForMaintenanceParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
+func (p *PrepareForMaintenanceParams) GetForced() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["forced"].(bool)
+	return value, ok
+}
+
+func (p *PrepareForMaintenanceParams) SetManagementserverid(v UUID) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managementserverid"] = v
+}
+
+func (p *PrepareForMaintenanceParams) ResetManagementserverid() {
+	if p.p != nil && p.p["managementserverid"] != nil {
+		delete(p.p, "managementserverid")
+	}
+}
+
+func (p *PrepareForMaintenanceParams) GetManagementserverid() (UUID, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["managementserverid"].(UUID)
+	return value, ok
+}
+
+// You should always use this function to get a new PrepareForMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *ManagementService) NewPrepareForMaintenanceParams(managementserverid UUID) *PrepareForMaintenanceParams {
+	p := &PrepareForMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["managementserverid"] = managementserverid
+	return p
+}
+
+// Prepares management server for maintenance by preventing new jobs from being accepted after completion of active jobs and migrating the agents
+func (s *ManagementService) PrepareForMaintenance(p *PrepareForMaintenanceParams) (*PrepareForMaintenanceResponse, error) {
+	resp, err := s.cs.newPostRequest("prepareForMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r PrepareForMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type PrepareForMaintenanceResponse struct {
+	Agents               []string `json:"agents"`
+	Agentscount          int64    `json:"agentscount"`
+	JobID                string   `json:"jobid"`
+	Jobstatus            int      `json:"jobstatus"`
+	Maintenanceinitiated bool     `json:"maintenanceinitiated"`
+	Managementserverid   UUID     `json:"managementserverid"`
+	Pendingjobscount     int64    `json:"pendingjobscount"`
+	Readyforshutdown     bool     `json:"readyforshutdown"`
+	Shutdowntriggered    bool     `json:"shutdowntriggered"`
+	State                string   `json:"state"`
+}
+
+type CancelMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *CancelMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["managementserverid"]; found {
+		u.Set("managementserverid", v.(string))
+	}
+	if v, found := p.p["rebalance"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("rebalance", vv)
+	}
+	return u
+}
+
+func (p *CancelMaintenanceParams) SetManagementserverid(v UUID) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managementserverid"] = v
+}
+
+func (p *CancelMaintenanceParams) ResetManagementserverid() {
+	if p.p != nil && p.p["managementserverid"] != nil {
+		delete(p.p, "managementserverid")
+	}
+}
+
+func (p *CancelMaintenanceParams) GetManagementserverid() (UUID, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["managementserverid"].(UUID)
+	return value, ok
+}
+
+func (p *CancelMaintenanceParams) SetRebalance(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["rebalance"] = v
+}
+
+func (p *CancelMaintenanceParams) ResetRebalance() {
+	if p.p != nil && p.p["rebalance"] != nil {
+		delete(p.p, "rebalance")
+	}
+}
+
+func (p *CancelMaintenanceParams) GetRebalance() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["rebalance"].(bool)
+	return value, ok
+}
+
+// You should always use this function to get a new CancelMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *ManagementService) NewCancelMaintenanceParams(managementserverid UUID) *CancelMaintenanceParams {
+	p := &CancelMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["managementserverid"] = managementserverid
+	return p
+}
+
+// Cancels maintenance of the management server
+func (s *ManagementService) CancelMaintenance(p *CancelMaintenanceParams) (*CancelMaintenanceResponse, error) {
+	resp, err := s.cs.newPostRequest("cancelMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CancelMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type CancelMaintenanceResponse struct {
+	Agents               []string `json:"agents"`
+	Agentscount          int64    `json:"agentscount"`
+	JobID                string   `json:"jobid"`
+	Jobstatus            int      `json:"jobstatus"`
+	Maintenanceinitiated bool     `json:"maintenanceinitiated"`
+	Managementserverid   UUID     `json:"managementserverid"`
+	Pendingjobscount     int64    `json:"pendingjobscount"`
+	Readyforshutdown     bool     `json:"readyforshutdown"`
+	Shutdowntriggered    bool     `json:"shutdowntriggered"`
+	State                string   `json:"state"`
+}
+
+type CancelShutdownParams struct {
+	p map[string]interface{}
+}
+
+func (p *CancelShutdownParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["managementserverid"]; found {
+		u.Set("managementserverid", v.(string))
+	}
+	return u
+}
+
+func (p *CancelShutdownParams) SetManagementserverid(v UUID) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managementserverid"] = v
+}
+
+func (p *CancelShutdownParams) ResetManagementserverid() {
+	if p.p != nil && p.p["managementserverid"] != nil {
+		delete(p.p, "managementserverid")
+	}
+}
+
+func (p *CancelShutdownParams) GetManagementserverid() (UUID, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["managementserverid"].(UUID)
+	return value, ok
+}
+
+// You should always use this function to get a new CancelShutdownParams instance,
+// as then you are sure you have configured all required params
+func (s *ManagementService) NewCancelShutdownParams(managementserverid UUID) *CancelShutdownParams {
+	p := &CancelShutdownParams{}
+	p.p = make(map[string]interface{})
+	p.p["managementserverid"] = managementserverid
+	return p
+}
+
+// Cancels a triggered shutdown
+func (s *ManagementService) CancelShutdown(p *CancelShutdownParams) (*CancelShutdownResponse, error) {
+	resp, err := s.cs.newPostRequest("cancelShutdown", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CancelShutdownResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type CancelShutdownResponse struct {
+	Agents               []string `json:"agents"`
+	Agentscount          int64    `json:"agentscount"`
+	JobID                string   `json:"jobid"`
+	Jobstatus            int      `json:"jobstatus"`
+	Maintenanceinitiated bool     `json:"maintenanceinitiated"`
+	Managementserverid   UUID     `json:"managementserverid"`
+	Pendingjobscount     int64    `json:"pendingjobscount"`
+	Readyforshutdown     bool     `json:"readyforshutdown"`
+	Shutdowntriggered    bool     `json:"shutdowntriggered"`
+	State                string   `json:"state"`
 }
 
 type PrepareForShutdownParams struct {

--- a/cloudstack/ManagementService.go
+++ b/cloudstack/ManagementService.go
@@ -799,7 +799,7 @@ func (p *PrepareForMaintenanceParams) toURLValues() url.Values {
 		u.Set("forced", vv)
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	return u
 }
@@ -914,7 +914,7 @@ func (p *CancelMaintenanceParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	if v, found := p.p["rebalance"]; found {
 		vv := strconv.FormatBool(v.(bool))
@@ -1012,7 +1012,7 @@ func (p *CancelShutdownParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	return u
 }

--- a/cloudstack/ManagementService_mock.go
+++ b/cloudstack/ManagementService_mock.go
@@ -58,6 +58,21 @@ func (m *MockManagementServiceIface) EXPECT() *MockManagementServiceIfaceMockRec
 	return m.recorder
 }
 
+// CancelMaintenance mocks base method.
+func (m *MockManagementServiceIface) CancelMaintenance(p *CancelMaintenanceParams) (*CancelMaintenanceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelMaintenance", p)
+	ret0, _ := ret[0].(*CancelMaintenanceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CancelMaintenance indicates an expected call of CancelMaintenance.
+func (mr *MockManagementServiceIfaceMockRecorder) CancelMaintenance(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMaintenance", reflect.TypeOf((*MockManagementServiceIface)(nil).CancelMaintenance), p)
+}
+
 // CancelShutdown mocks base method.
 func (m *MockManagementServiceIface) CancelShutdown(p *CancelShutdownParams) (*CancelShutdownResponse, error) {
 	m.ctrl.T.Helper()
@@ -229,6 +244,20 @@ func (mr *MockManagementServiceIfaceMockRecorder) ListManagementServersMetrics(p
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagementServersMetrics", reflect.TypeOf((*MockManagementServiceIface)(nil).ListManagementServersMetrics), p)
 }
 
+// NewCancelMaintenanceParams mocks base method.
+func (m *MockManagementServiceIface) NewCancelMaintenanceParams(managementserverid UUID) *CancelMaintenanceParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewCancelMaintenanceParams", managementserverid)
+	ret0, _ := ret[0].(*CancelMaintenanceParams)
+	return ret0
+}
+
+// NewCancelMaintenanceParams indicates an expected call of NewCancelMaintenanceParams.
+func (mr *MockManagementServiceIfaceMockRecorder) NewCancelMaintenanceParams(managementserverid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCancelMaintenanceParams", reflect.TypeOf((*MockManagementServiceIface)(nil).NewCancelMaintenanceParams), managementserverid)
+}
+
 // NewCancelShutdownParams mocks base method.
 func (m *MockManagementServiceIface) NewCancelShutdownParams(managementserverid UUID) *CancelShutdownParams {
 	m.ctrl.T.Helper()
@@ -271,6 +300,20 @@ func (mr *MockManagementServiceIfaceMockRecorder) NewListManagementServersParams
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListManagementServersParams", reflect.TypeOf((*MockManagementServiceIface)(nil).NewListManagementServersParams))
 }
 
+// NewPrepareForMaintenanceParams mocks base method.
+func (m *MockManagementServiceIface) NewPrepareForMaintenanceParams(managementserverid UUID) *PrepareForMaintenanceParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewPrepareForMaintenanceParams", managementserverid)
+	ret0, _ := ret[0].(*PrepareForMaintenanceParams)
+	return ret0
+}
+
+// NewPrepareForMaintenanceParams indicates an expected call of NewPrepareForMaintenanceParams.
+func (mr *MockManagementServiceIfaceMockRecorder) NewPrepareForMaintenanceParams(managementserverid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewPrepareForMaintenanceParams", reflect.TypeOf((*MockManagementServiceIface)(nil).NewPrepareForMaintenanceParams), managementserverid)
+}
+
 // NewPrepareForShutdownParams mocks base method.
 func (m *MockManagementServiceIface) NewPrepareForShutdownParams(managementserverid UUID) *PrepareForShutdownParams {
 	m.ctrl.T.Helper()
@@ -299,6 +342,20 @@ func (mr *MockManagementServiceIfaceMockRecorder) NewReadyForShutdownParams(mana
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReadyForShutdownParams", reflect.TypeOf((*MockManagementServiceIface)(nil).NewReadyForShutdownParams), managementserverid)
 }
 
+// NewRemoveManagementServerParams mocks base method.
+func (m *MockManagementServiceIface) NewRemoveManagementServerParams(id string) *RemoveManagementServerParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewRemoveManagementServerParams", id)
+	ret0, _ := ret[0].(*RemoveManagementServerParams)
+	return ret0
+}
+
+// NewRemoveManagementServerParams indicates an expected call of NewRemoveManagementServerParams.
+func (mr *MockManagementServiceIfaceMockRecorder) NewRemoveManagementServerParams(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoveManagementServerParams", reflect.TypeOf((*MockManagementServiceIface)(nil).NewRemoveManagementServerParams), id)
+}
+
 // NewTriggerShutdownParams mocks base method.
 func (m *MockManagementServiceIface) NewTriggerShutdownParams(managementserverid UUID) *TriggerShutdownParams {
 	m.ctrl.T.Helper()
@@ -311,6 +368,21 @@ func (m *MockManagementServiceIface) NewTriggerShutdownParams(managementserverid
 func (mr *MockManagementServiceIfaceMockRecorder) NewTriggerShutdownParams(managementserverid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTriggerShutdownParams", reflect.TypeOf((*MockManagementServiceIface)(nil).NewTriggerShutdownParams), managementserverid)
+}
+
+// PrepareForMaintenance mocks base method.
+func (m *MockManagementServiceIface) PrepareForMaintenance(p *PrepareForMaintenanceParams) (*PrepareForMaintenanceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareForMaintenance", p)
+	ret0, _ := ret[0].(*PrepareForMaintenanceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareForMaintenance indicates an expected call of PrepareForMaintenance.
+func (mr *MockManagementServiceIfaceMockRecorder) PrepareForMaintenance(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForMaintenance", reflect.TypeOf((*MockManagementServiceIface)(nil).PrepareForMaintenance), p)
 }
 
 // PrepareForShutdown mocks base method.
@@ -341,6 +413,21 @@ func (m *MockManagementServiceIface) ReadyForShutdown(p *ReadyForShutdownParams)
 func (mr *MockManagementServiceIfaceMockRecorder) ReadyForShutdown(p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadyForShutdown", reflect.TypeOf((*MockManagementServiceIface)(nil).ReadyForShutdown), p)
+}
+
+// RemoveManagementServer mocks base method.
+func (m *MockManagementServiceIface) RemoveManagementServer(p *RemoveManagementServerParams) (*RemoveManagementServerResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveManagementServer", p)
+	ret0, _ := ret[0].(*RemoveManagementServerResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveManagementServer indicates an expected call of RemoveManagementServer.
+func (mr *MockManagementServiceIfaceMockRecorder) RemoveManagementServer(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveManagementServer", reflect.TypeOf((*MockManagementServiceIface)(nil).RemoveManagementServer), p)
 }
 
 // TriggerShutdown mocks base method.

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -2255,7 +2255,7 @@ func logMissingApis(ai map[string]*API, as *allServices) {
 	for apiName, _ := range ai {
 		_, found := asMap[apiName]
 		if !found {
-			log.Printf("Api missing in layout: %s", apiName)
+			log.Printf("API missing in layout: %s", apiName)
 		}
 	}
 }

--- a/generate/layout.go
+++ b/generate/layout.go
@@ -953,9 +953,12 @@ var layout = apiInfo{
 		"cloudianIsEnabled",
 	},
 	"ManagementService": {
-		"cancelShutdown",
 		"listManagementServers",
 		"listManagementServersMetrics",
+		"removeManagementServer",
+		"prepareForMaintenance",
+		"cancelMaintenance",
+		"cancelShutdown",
 		"prepareForShutdown",
 		"readyForShutdown",
 		"triggerShutdown",

--- a/test/ManagementService_test.go
+++ b/test/ManagementService_test.go
@@ -35,18 +35,6 @@ func TestManagementService(t *testing.T) {
 	client := cloudstack.NewClient(server.URL, "APIKEY", "SECRETKEY", true)
 	defer server.Close()
 
-	testcancelShutdown := func(t *testing.T) {
-		if _, ok := response["cancelShutdown"]; !ok {
-			t.Skipf("Skipping as no json response is provided in testdata")
-		}
-		p := client.Management.NewCancelShutdownParams("managementserverid")
-		_, err := client.Management.CancelShutdown(p)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-	}
-	t.Run("CancelShutdown", testcancelShutdown)
-
 	testlistManagementServers := func(t *testing.T) {
 		if _, ok := response["listManagementServers"]; !ok {
 			t.Skipf("Skipping as no json response is provided in testdata")
@@ -70,6 +58,54 @@ func TestManagementService(t *testing.T) {
 		}
 	}
 	t.Run("ListManagementServersMetrics", testlistManagementServersMetrics)
+
+	testremoveManagementServer := func(t *testing.T) {
+		if _, ok := response["removeManagementServer"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Management.NewRemoveManagementServerParams("id")
+		_, err := client.Management.RemoveManagementServer(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("RemoveManagementServer", testremoveManagementServer)
+
+	testprepareForMaintenance := func(t *testing.T) {
+		if _, ok := response["prepareForMaintenance"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Management.NewPrepareForMaintenanceParams("managementserverid")
+		_, err := client.Management.PrepareForMaintenance(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("PrepareForMaintenance", testprepareForMaintenance)
+
+	testcancelMaintenance := func(t *testing.T) {
+		if _, ok := response["cancelMaintenance"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Management.NewCancelMaintenanceParams("managementserverid")
+		_, err := client.Management.CancelMaintenance(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("CancelMaintenance", testcancelMaintenance)
+
+	testcancelShutdown := func(t *testing.T) {
+		if _, ok := response["cancelShutdown"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Management.NewCancelShutdownParams("managementserverid")
+		_, err := client.Management.CancelShutdown(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("CancelShutdown", testcancelShutdown)
 
 	testprepareForShutdown := func(t *testing.T) {
 		if _, ok := response["prepareForShutdown"]; !ok {


### PR DESCRIPTION
MS maintenance APIs (_prepareForMaintenance_ , _cancelMaintenance_) were introduced in 4.21.0. _removeManagementServer_ API as well.