### PR TITLE
Fix JSON tag mismatch for metrics responses

### DIFF
--- a/cloudstack/ClusterService.go
+++ b/cloudstack/ClusterService.go
@@ -2686,7 +2686,7 @@ func (s *ClusterService) ListClustersMetrics(p *ListClustersMetricsParams) (*Lis
 
 type ListClustersMetricsResponse struct {
 	Count           int               `json:"count"`
-	ClustersMetrics []*ClustersMetric `json:"clustersmetric"`
+	ClustersMetrics []*ClustersMetric `json:"cluster"`
 }
 
 type ClustersMetric struct {

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -4118,7 +4118,7 @@ func (s *HostService) ListHostsMetrics(p *ListHostsMetricsParams) (*ListHostsMet
 
 type ListHostsMetricsResponse struct {
 	Count        int            `json:"count"`
-	HostsMetrics []*HostsMetric `json:"hostsmetric"`
+	HostsMetrics []*HostsMetric `json:"host"`
 }
 
 type HostsMetric struct {

--- a/cloudstack/InfrastructureUsageService.go
+++ b/cloudstack/InfrastructureUsageService.go
@@ -65,7 +65,7 @@ func (s *InfrastructureUsageService) ListDbMetrics(p *ListDbMetricsParams) (*Lis
 }
 
 type ListDbMetricsResponse struct {
-	DbMetrics DbMetric `json:"dbMetrics"`
+	DbMetrics DbMetric `json:"db"`
 }
 
 type DbMetric struct {

--- a/cloudstack/UsageService.go
+++ b/cloudstack/UsageService.go
@@ -2129,7 +2129,7 @@ func (s *UsageService) ListUsageServerMetrics(p *ListUsageServerMetricsParams) (
 
 type ListUsageServerMetricsResponse struct {
 	Count              int                  `json:"count"`
-	UsageServerMetrics []*UsageServerMetric `json:"usageservermetric"`
+	UsageServerMetrics []*UsageServerMetric `json:"usageserver"`
 }
 
 type UsageServerMetric struct {

--- a/cloudstack/VolumeService.go
+++ b/cloudstack/VolumeService.go
@@ -4466,7 +4466,7 @@ func (s *VolumeService) ListVolumesMetrics(p *ListVolumesMetricsParams) (*ListVo
 
 type ListVolumesMetricsResponse struct {
 	Count          int              `json:"count"`
-	VolumesMetrics []*VolumesMetric `json:"volumesmetric"`
+	VolumesMetrics []*VolumesMetric `json:"volume"`
 }
 
 type VolumesMetric struct {

--- a/cloudstack/ZoneService.go
+++ b/cloudstack/ZoneService.go
@@ -3076,7 +3076,7 @@ func (s *ZoneService) ListZonesMetrics(p *ListZonesMetricsParams) (*ListZonesMet
 
 type ListZonesMetricsResponse struct {
 	Count        int            `json:"count"`
-	ZonesMetrics []*ZonesMetric `json:"zonesmetric"`
+	ZonesMetrics []*ZonesMetric `json:"zone"`
 }
 
 type ZonesMetric struct {


### PR DESCRIPTION
CloudStack metrics APIs return lists under updated JSON keys (e.g. `"host"` for host metrics).
The cloudstack-go response structs still used older json tags (e.g. `"hostmetric"`/`"hostmetrics"`),
causing unmarshalling issues where metrics lists become nil/null.
This PR updates the relevant response struct json tags to match the actual CloudStack API response keys.