### PR TITLE
Fix dropped generate error

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -901,6 +901,9 @@ func (s *service) WriteGeneratedCode() error {
 			return err
 		}
 		testdir, err := testDir()
+		if err != nil {
+			return err
+		}
 		file := path.Join(testdir, s.name+"_test.go")
 		ioutil.WriteFile(file, tests, 0644)
 	}


### PR DESCRIPTION
This picks up a dropped `err` variable in the `generate` package.There are no tests in `generate` to break or validate changes.