### PR TITLE
Add support for managing guest OS category - create, delete, update

### DIFF
--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -55,6 +55,12 @@ type GuestOSServiceIface interface {
 	NewUpdateGuestOsMappingParams(id string, osnameforhypervisor string) *UpdateGuestOsMappingParams
 	GetHypervisorGuestOsNames(p *GetHypervisorGuestOsNamesParams) (*GetHypervisorGuestOsNamesResponse, error)
 	NewGetHypervisorGuestOsNamesParams(hypervisor string, hypervisorversion string) *GetHypervisorGuestOsNamesParams
+	AddOsCategory(p *AddOsCategoryParams) (*AddOsCategoryResponse, error)
+	NewAddOsCategoryParams(name string) *AddOsCategoryParams
+	DeleteOsCategory(p *DeleteOsCategoryParams) (*DeleteOsCategoryResponse, error)
+	NewDeleteOsCategoryParams(id string) *DeleteOsCategoryParams
+	UpdateOsCategory(p *UpdateOsCategoryParams) (*UpdateOsCategoryResponse, error)
+	NewUpdateOsCategoryParams(id string) *UpdateOsCategoryParams
 }
 
 type AddGuestOsParams struct {
@@ -2250,4 +2256,337 @@ type GetHypervisorGuestOsNamesResponse struct {
 type GetHypervisorGuestOsNamesResponseGuestoslist struct {
 	Osdisplayname       string `json:"osdisplayname"`
 	Osnameforhypervisor string `json:"osnameforhypervisor"`
+}
+
+type AddOsCategoryParams struct {
+	p map[string]interface{}
+}
+
+func (p *AddOsCategoryParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	return u
+}
+
+func (p *AddOsCategoryParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+}
+
+func (p *AddOsCategoryParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
+}
+
+func (p *AddOsCategoryParams) GetIsfeatured() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["isfeatured"].(bool)
+	return value, ok
+}
+
+func (p *AddOsCategoryParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+}
+
+func (p *AddOsCategoryParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
+func (p *AddOsCategoryParams) GetName() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["name"].(string)
+	return value, ok
+}
+
+// You should always use this function to get a new AddOsCategoryParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewAddOsCategoryParams(name string) *AddOsCategoryParams {
+	p := &AddOsCategoryParams{}
+	p.p = make(map[string]interface{})
+	p.p["name"] = name
+	return p
+}
+
+// Adds a new OS category
+func (s *GuestOSService) AddOsCategory(p *AddOsCategoryParams) (*AddOsCategoryResponse, error) {
+	resp, err := s.cs.newPostRequest("addOsCategory", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r AddOsCategoryResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type AddOsCategoryResponse struct {
+	Created    string      `json:"created"`
+	Icon       interface{} `json:"icon"`
+	Id         string      `json:"id"`
+	Isfeatured bool        `json:"isfeatured"`
+	JobID      string      `json:"jobid"`
+	Jobstatus  int         `json:"jobstatus"`
+	Name       string      `json:"name"`
+}
+
+type DeleteOsCategoryParams struct {
+	p map[string]interface{}
+}
+
+func (p *DeleteOsCategoryParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	return u
+}
+
+func (p *DeleteOsCategoryParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+}
+
+func (p *DeleteOsCategoryParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
+func (p *DeleteOsCategoryParams) GetId() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["id"].(string)
+	return value, ok
+}
+
+// You should always use this function to get a new DeleteOsCategoryParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewDeleteOsCategoryParams(id string) *DeleteOsCategoryParams {
+	p := &DeleteOsCategoryParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Deletes an OS category
+func (s *GuestOSService) DeleteOsCategory(p *DeleteOsCategoryParams) (*DeleteOsCategoryResponse, error) {
+	resp, err := s.cs.newPostRequest("deleteOsCategory", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r DeleteOsCategoryResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type DeleteOsCategoryResponse struct {
+	Displaytext string `json:"displaytext"`
+	JobID       string `json:"jobid"`
+	Jobstatus   int    `json:"jobstatus"`
+	Success     bool   `json:"success"`
+}
+
+func (r *DeleteOsCategoryResponse) UnmarshalJSON(b []byte) error {
+	var m map[string]interface{}
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+
+	if success, ok := m["success"].(string); ok {
+		m["success"] = success == "true"
+		b, err = json.Marshal(m)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ostypeid, ok := m["ostypeid"].(float64); ok {
+		m["ostypeid"] = strconv.Itoa(int(ostypeid))
+		b, err = json.Marshal(m)
+		if err != nil {
+			return err
+		}
+	}
+
+	type alias DeleteOsCategoryResponse
+	return json.Unmarshal(b, (*alias)(r))
+}
+
+type UpdateOsCategoryParams struct {
+	p map[string]interface{}
+}
+
+func (p *UpdateOsCategoryParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["id"]; found {
+		u.Set("id", v.(string))
+	}
+	if v, found := p.p["isfeatured"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("isfeatured", vv)
+	}
+	if v, found := p.p["name"]; found {
+		u.Set("name", v.(string))
+	}
+	if v, found := p.p["sortkey"]; found {
+		vv := strconv.Itoa(v.(int))
+		u.Set("sortkey", vv)
+	}
+	return u
+}
+
+func (p *UpdateOsCategoryParams) SetId(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["id"] = v
+}
+
+func (p *UpdateOsCategoryParams) ResetId() {
+	if p.p != nil && p.p["id"] != nil {
+		delete(p.p, "id")
+	}
+}
+
+func (p *UpdateOsCategoryParams) GetId() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["id"].(string)
+	return value, ok
+}
+
+func (p *UpdateOsCategoryParams) SetIsfeatured(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["isfeatured"] = v
+}
+
+func (p *UpdateOsCategoryParams) ResetIsfeatured() {
+	if p.p != nil && p.p["isfeatured"] != nil {
+		delete(p.p, "isfeatured")
+	}
+}
+
+func (p *UpdateOsCategoryParams) GetIsfeatured() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["isfeatured"].(bool)
+	return value, ok
+}
+
+func (p *UpdateOsCategoryParams) SetName(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["name"] = v
+}
+
+func (p *UpdateOsCategoryParams) ResetName() {
+	if p.p != nil && p.p["name"] != nil {
+		delete(p.p, "name")
+	}
+}
+
+func (p *UpdateOsCategoryParams) GetName() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["name"].(string)
+	return value, ok
+}
+
+func (p *UpdateOsCategoryParams) SetSortkey(v int) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["sortkey"] = v
+}
+
+func (p *UpdateOsCategoryParams) ResetSortkey() {
+	if p.p != nil && p.p["sortkey"] != nil {
+		delete(p.p, "sortkey")
+	}
+}
+
+func (p *UpdateOsCategoryParams) GetSortkey() (int, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["sortkey"].(int)
+	return value, ok
+}
+
+// You should always use this function to get a new UpdateOsCategoryParams instance,
+// as then you are sure you have configured all required params
+func (s *GuestOSService) NewUpdateOsCategoryParams(id string) *UpdateOsCategoryParams {
+	p := &UpdateOsCategoryParams{}
+	p.p = make(map[string]interface{})
+	p.p["id"] = id
+	return p
+}
+
+// Updates an OS category
+func (s *GuestOSService) UpdateOsCategory(p *UpdateOsCategoryParams) (*UpdateOsCategoryResponse, error) {
+	resp, err := s.cs.newPostRequest("updateOsCategory", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateOsCategoryResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type UpdateOsCategoryResponse struct {
+	Created    string      `json:"created"`
+	Icon       interface{} `json:"icon"`
+	Id         string      `json:"id"`
+	Isfeatured bool        `json:"isfeatured"`
+	JobID      string      `json:"jobid"`
+	Jobstatus  int         `json:"jobstatus"`
+	Name       string      `json:"name"`
 }

--- a/cloudstack/GuestOSService.go
+++ b/cloudstack/GuestOSService.go
@@ -2335,10 +2335,13 @@ func (s *GuestOSService) AddOsCategory(p *AddOsCategoryParams) (*AddOsCategoryRe
 		return nil, err
 	}
 
-	var r AddOsCategoryResponse
-	if err := json.Unmarshal(resp, &r); err != nil {
+	var nested struct {
+		Response AddOsCategoryResponse `json:"oscategory"`
+	}
+	if err := json.Unmarshal(resp, &nested); err != nil {
 		return nil, err
 	}
+	r := nested.Response
 
 	return &r, nil
 }
@@ -2573,10 +2576,13 @@ func (s *GuestOSService) UpdateOsCategory(p *UpdateOsCategoryParams) (*UpdateOsC
 		return nil, err
 	}
 
-	var r UpdateOsCategoryResponse
-	if err := json.Unmarshal(resp, &r); err != nil {
+	var nested struct {
+		Response UpdateOsCategoryResponse `json:"oscategory"`
+	}
+	if err := json.Unmarshal(resp, &nested); err != nil {
 		return nil, err
 	}
+	r := nested.Response
 
 	return &r, nil
 }

--- a/cloudstack/GuestOSService_mock.go
+++ b/cloudstack/GuestOSService_mock.go
@@ -88,6 +88,36 @@ func (mr *MockGuestOSServiceIfaceMockRecorder) AddGuestOsMapping(p any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGuestOsMapping", reflect.TypeOf((*MockGuestOSServiceIface)(nil).AddGuestOsMapping), p)
 }
 
+// AddOsCategory mocks base method.
+func (m *MockGuestOSServiceIface) AddOsCategory(p *AddOsCategoryParams) (*AddOsCategoryResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOsCategory", p)
+	ret0, _ := ret[0].(*AddOsCategoryResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddOsCategory indicates an expected call of AddOsCategory.
+func (mr *MockGuestOSServiceIfaceMockRecorder) AddOsCategory(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOsCategory", reflect.TypeOf((*MockGuestOSServiceIface)(nil).AddOsCategory), p)
+}
+
+// DeleteOsCategory mocks base method.
+func (m *MockGuestOSServiceIface) DeleteOsCategory(p *DeleteOsCategoryParams) (*DeleteOsCategoryResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOsCategory", p)
+	ret0, _ := ret[0].(*DeleteOsCategoryResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOsCategory indicates an expected call of DeleteOsCategory.
+func (mr *MockGuestOSServiceIfaceMockRecorder) DeleteOsCategory(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOsCategory", reflect.TypeOf((*MockGuestOSServiceIface)(nil).DeleteOsCategory), p)
+}
+
 // GetGuestOsMappingByID mocks base method.
 func (m *MockGuestOSServiceIface) GetGuestOsMappingByID(id string, opts ...OptionFunc) (*GuestOsMapping, int, error) {
 	m.ctrl.T.Helper()
@@ -323,6 +353,34 @@ func (mr *MockGuestOSServiceIfaceMockRecorder) NewAddGuestOsParams(oscategoryid,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddGuestOsParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewAddGuestOsParams), oscategoryid, osdisplayname)
 }
 
+// NewAddOsCategoryParams mocks base method.
+func (m *MockGuestOSServiceIface) NewAddOsCategoryParams(name string) *AddOsCategoryParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAddOsCategoryParams", name)
+	ret0, _ := ret[0].(*AddOsCategoryParams)
+	return ret0
+}
+
+// NewAddOsCategoryParams indicates an expected call of NewAddOsCategoryParams.
+func (mr *MockGuestOSServiceIfaceMockRecorder) NewAddOsCategoryParams(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddOsCategoryParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewAddOsCategoryParams), name)
+}
+
+// NewDeleteOsCategoryParams mocks base method.
+func (m *MockGuestOSServiceIface) NewDeleteOsCategoryParams(id string) *DeleteOsCategoryParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewDeleteOsCategoryParams", id)
+	ret0, _ := ret[0].(*DeleteOsCategoryParams)
+	return ret0
+}
+
+// NewDeleteOsCategoryParams indicates an expected call of NewDeleteOsCategoryParams.
+func (mr *MockGuestOSServiceIfaceMockRecorder) NewDeleteOsCategoryParams(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDeleteOsCategoryParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewDeleteOsCategoryParams), id)
+}
+
 // NewGetHypervisorGuestOsNamesParams mocks base method.
 func (m *MockGuestOSServiceIface) NewGetHypervisorGuestOsNamesParams(hypervisor, hypervisorversion string) *GetHypervisorGuestOsNamesParams {
 	m.ctrl.T.Helper()
@@ -435,6 +493,20 @@ func (mr *MockGuestOSServiceIfaceMockRecorder) NewUpdateGuestOsParams(id, osdisp
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpdateGuestOsParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewUpdateGuestOsParams), id, osdisplayname)
 }
 
+// NewUpdateOsCategoryParams mocks base method.
+func (m *MockGuestOSServiceIface) NewUpdateOsCategoryParams(id string) *UpdateOsCategoryParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewUpdateOsCategoryParams", id)
+	ret0, _ := ret[0].(*UpdateOsCategoryParams)
+	return ret0
+}
+
+// NewUpdateOsCategoryParams indicates an expected call of NewUpdateOsCategoryParams.
+func (mr *MockGuestOSServiceIfaceMockRecorder) NewUpdateOsCategoryParams(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpdateOsCategoryParams", reflect.TypeOf((*MockGuestOSServiceIface)(nil).NewUpdateOsCategoryParams), id)
+}
+
 // RemoveGuestOs mocks base method.
 func (m *MockGuestOSServiceIface) RemoveGuestOs(p *RemoveGuestOsParams) (*RemoveGuestOsResponse, error) {
 	m.ctrl.T.Helper()
@@ -493,4 +565,19 @@ func (m *MockGuestOSServiceIface) UpdateGuestOsMapping(p *UpdateGuestOsMappingPa
 func (mr *MockGuestOSServiceIfaceMockRecorder) UpdateGuestOsMapping(p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGuestOsMapping", reflect.TypeOf((*MockGuestOSServiceIface)(nil).UpdateGuestOsMapping), p)
+}
+
+// UpdateOsCategory mocks base method.
+func (m *MockGuestOSServiceIface) UpdateOsCategory(p *UpdateOsCategoryParams) (*UpdateOsCategoryResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateOsCategory", p)
+	ret0, _ := ret[0].(*UpdateOsCategoryResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateOsCategory indicates an expected call of UpdateOsCategory.
+func (mr *MockGuestOSServiceIfaceMockRecorder) UpdateOsCategory(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOsCategory", reflect.TypeOf((*MockGuestOSServiceIface)(nil).UpdateOsCategory), p)
 }

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -140,6 +140,8 @@ var nestedResponse = map[string]string{
 	"setupUserTwoFactorAuthentication": "setup2fa",
 	"updateSecondaryStorageSelector":   "heuristics",
 	"createSecondaryStorageSelector":   "heuristics",
+	"addOsCategory":                    "oscategory",
+	"updateOsCategory":                 "oscategory",
 }
 
 // longToStringConvertedParams is a prefilled map with the list of

--- a/generate/layout.go
+++ b/generate/layout.go
@@ -528,6 +528,9 @@ var layout = apiInfo{
 		"updateGuestOs",
 		"updateGuestOsMapping",
 		"getHypervisorGuestOsNames",
+		"addOsCategory",
+		"deleteOsCategory",
+		"updateOsCategory",
 	},
 	"ClusterService": {
 		"addCluster",

--- a/test/GuestOSService_test.go
+++ b/test/GuestOSService_test.go
@@ -167,4 +167,46 @@ func TestGuestOSService(t *testing.T) {
 	}
 	t.Run("GetHypervisorGuestOsNames", testgetHypervisorGuestOsNames)
 
+	testaddOsCategory := func(t *testing.T) {
+		if _, ok := response["addOsCategory"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.GuestOS.NewAddOsCategoryParams("name")
+		r, err := client.GuestOS.AddOsCategory(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		if r.Id == "" {
+			t.Errorf("Failed to parse response. ID not found")
+		}
+	}
+	t.Run("AddOsCategory", testaddOsCategory)
+
+	testdeleteOsCategory := func(t *testing.T) {
+		if _, ok := response["deleteOsCategory"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.GuestOS.NewDeleteOsCategoryParams("id")
+		_, err := client.GuestOS.DeleteOsCategory(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("DeleteOsCategory", testdeleteOsCategory)
+
+	testupdateOsCategory := func(t *testing.T) {
+		if _, ok := response["updateOsCategory"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.GuestOS.NewUpdateOsCategoryParams("id")
+		r, err := client.GuestOS.UpdateOsCategory(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		if r.Id == "" {
+			t.Errorf("Failed to parse response. ID not found")
+		}
+	}
+	t.Run("UpdateOsCategory", testupdateOsCategory)
+
 }


### PR DESCRIPTION
Adds support for managing guestOS category - Added 
- addOsCategory
- deleteOsCategory
- updateOsCategory
to layout.go - that was the only change, all other files we autogenerated