### PR TITLE
Add support for prepare and cancel maintenance

### DIFF
--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -100,6 +100,10 @@ type HostServiceIface interface {
 	NewDeclareHostAsDegradedParams(id string) *DeclareHostAsDegradedParams
 	UpdateSecondaryStorageSelector(p *UpdateSecondaryStorageSelectorParams) (*UpdateSecondaryStorageSelectorResponse, error)
 	NewUpdateSecondaryStorageSelectorParams(heuristicrule string, id string) *UpdateSecondaryStorageSelectorParams
+	PrepareForMaintenance(p *PrepareForMaintenanceParams) (*PrepareForMaintenanceResponse, error)
+	NewPrepareForMaintenanceParams(managementserverid UUID) *PrepareForMaintenanceParams
+	CancelMaintenance(p *CancelMaintenanceParams) (*CancelMaintenanceResponse, error)
+	NewCancelMaintenanceParams(managementserverid UUID) *CancelMaintenanceParams
 }
 
 type AddBaremetalHostParams struct {
@@ -6644,4 +6648,224 @@ type UpdateSecondaryStorageSelectorResponse struct {
 	Removed       string `json:"removed"`
 	Type          string `json:"type"`
 	Zoneid        string `json:"zoneid"`
+}
+
+type PrepareForMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *PrepareForMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["algorithm"]; found {
+		u.Set("algorithm", v.(string))
+	}
+	if v, found := p.p["forced"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("forced", vv)
+	}
+	if v, found := p.p["managementserverid"]; found {
+		u.Set("managementserverid", v.(string))
+	}
+	return u
+}
+
+func (p *PrepareForMaintenanceParams) SetAlgorithm(v string) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["algorithm"] = v
+}
+
+func (p *PrepareForMaintenanceParams) ResetAlgorithm() {
+	if p.p != nil && p.p["algorithm"] != nil {
+		delete(p.p, "algorithm")
+	}
+}
+
+func (p *PrepareForMaintenanceParams) GetAlgorithm() (string, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["algorithm"].(string)
+	return value, ok
+}
+
+func (p *PrepareForMaintenanceParams) SetForced(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["forced"] = v
+}
+
+func (p *PrepareForMaintenanceParams) ResetForced() {
+	if p.p != nil && p.p["forced"] != nil {
+		delete(p.p, "forced")
+	}
+}
+
+func (p *PrepareForMaintenanceParams) GetForced() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["forced"].(bool)
+	return value, ok
+}
+
+func (p *PrepareForMaintenanceParams) SetManagementserverid(v UUID) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managementserverid"] = v
+}
+
+func (p *PrepareForMaintenanceParams) ResetManagementserverid() {
+	if p.p != nil && p.p["managementserverid"] != nil {
+		delete(p.p, "managementserverid")
+	}
+}
+
+func (p *PrepareForMaintenanceParams) GetManagementserverid() (UUID, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["managementserverid"].(UUID)
+	return value, ok
+}
+
+// You should always use this function to get a new PrepareForMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewPrepareForMaintenanceParams(managementserverid UUID) *PrepareForMaintenanceParams {
+	p := &PrepareForMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["managementserverid"] = managementserverid
+	return p
+}
+
+// Prepares management server for maintenance by preventing new jobs from being accepted after completion of active jobs and migrating the agents
+func (s *HostService) PrepareForMaintenance(p *PrepareForMaintenanceParams) (*PrepareForMaintenanceResponse, error) {
+	resp, err := s.cs.newPostRequest("prepareForMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r PrepareForMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type PrepareForMaintenanceResponse struct {
+	Agents               []string `json:"agents"`
+	Agentscount          int64    `json:"agentscount"`
+	JobID                string   `json:"jobid"`
+	Jobstatus            int      `json:"jobstatus"`
+	Maintenanceinitiated bool     `json:"maintenanceinitiated"`
+	Managementserverid   UUID     `json:"managementserverid"`
+	Pendingjobscount     int64    `json:"pendingjobscount"`
+	Readyforshutdown     bool     `json:"readyforshutdown"`
+	Shutdowntriggered    bool     `json:"shutdowntriggered"`
+	State                string   `json:"state"`
+}
+
+type CancelMaintenanceParams struct {
+	p map[string]interface{}
+}
+
+func (p *CancelMaintenanceParams) toURLValues() url.Values {
+	u := url.Values{}
+	if p.p == nil {
+		return u
+	}
+	if v, found := p.p["managementserverid"]; found {
+		u.Set("managementserverid", v.(string))
+	}
+	if v, found := p.p["rebalance"]; found {
+		vv := strconv.FormatBool(v.(bool))
+		u.Set("rebalance", vv)
+	}
+	return u
+}
+
+func (p *CancelMaintenanceParams) SetManagementserverid(v UUID) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["managementserverid"] = v
+}
+
+func (p *CancelMaintenanceParams) ResetManagementserverid() {
+	if p.p != nil && p.p["managementserverid"] != nil {
+		delete(p.p, "managementserverid")
+	}
+}
+
+func (p *CancelMaintenanceParams) GetManagementserverid() (UUID, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["managementserverid"].(UUID)
+	return value, ok
+}
+
+func (p *CancelMaintenanceParams) SetRebalance(v bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	p.p["rebalance"] = v
+}
+
+func (p *CancelMaintenanceParams) ResetRebalance() {
+	if p.p != nil && p.p["rebalance"] != nil {
+		delete(p.p, "rebalance")
+	}
+}
+
+func (p *CancelMaintenanceParams) GetRebalance() (bool, bool) {
+	if p.p == nil {
+		p.p = make(map[string]interface{})
+	}
+	value, ok := p.p["rebalance"].(bool)
+	return value, ok
+}
+
+// You should always use this function to get a new CancelMaintenanceParams instance,
+// as then you are sure you have configured all required params
+func (s *HostService) NewCancelMaintenanceParams(managementserverid UUID) *CancelMaintenanceParams {
+	p := &CancelMaintenanceParams{}
+	p.p = make(map[string]interface{})
+	p.p["managementserverid"] = managementserverid
+	return p
+}
+
+// Cancels maintenance of the management server
+func (s *HostService) CancelMaintenance(p *CancelMaintenanceParams) (*CancelMaintenanceResponse, error) {
+	resp, err := s.cs.newPostRequest("cancelMaintenance", p.toURLValues())
+	if err != nil {
+		return nil, err
+	}
+
+	var r CancelMaintenanceResponse
+	if err := json.Unmarshal(resp, &r); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+type CancelMaintenanceResponse struct {
+	Agents               []string `json:"agents"`
+	Agentscount          int64    `json:"agentscount"`
+	JobID                string   `json:"jobid"`
+	Jobstatus            int      `json:"jobstatus"`
+	Maintenanceinitiated bool     `json:"maintenanceinitiated"`
+	Managementserverid   UUID     `json:"managementserverid"`
+	Pendingjobscount     int64    `json:"pendingjobscount"`
+	Readyforshutdown     bool     `json:"readyforshutdown"`
+	Shutdowntriggered    bool     `json:"shutdowntriggered"`
+	State                string   `json:"state"`
 }

--- a/cloudstack/HostService_mock.go
+++ b/cloudstack/HostService_mock.go
@@ -148,6 +148,21 @@ func (mr *MockHostServiceIfaceMockRecorder) CancelHostMaintenance(p any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelHostMaintenance", reflect.TypeOf((*MockHostServiceIface)(nil).CancelHostMaintenance), p)
 }
 
+// CancelMaintenance mocks base method.
+func (m *MockHostServiceIface) CancelMaintenance(p *CancelMaintenanceParams) (*CancelMaintenanceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelMaintenance", p)
+	ret0, _ := ret[0].(*CancelMaintenanceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CancelMaintenance indicates an expected call of CancelMaintenance.
+func (mr *MockHostServiceIfaceMockRecorder) CancelMaintenance(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMaintenance", reflect.TypeOf((*MockHostServiceIface)(nil).CancelMaintenance), p)
+}
+
 // ConfigureHAForHost mocks base method.
 func (m *MockHostServiceIface) ConfigureHAForHost(p *ConfigureHAForHostParams) (*HAForHostResponse, error) {
 	m.ctrl.T.Helper()
@@ -670,6 +685,20 @@ func (mr *MockHostServiceIfaceMockRecorder) NewCancelHostMaintenanceParams(id an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCancelHostMaintenanceParams", reflect.TypeOf((*MockHostServiceIface)(nil).NewCancelHostMaintenanceParams), id)
 }
 
+// NewCancelMaintenanceParams mocks base method.
+func (m *MockHostServiceIface) NewCancelMaintenanceParams(managementserverid UUID) *CancelMaintenanceParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewCancelMaintenanceParams", managementserverid)
+	ret0, _ := ret[0].(*CancelMaintenanceParams)
+	return ret0
+}
+
+// NewCancelMaintenanceParams indicates an expected call of NewCancelMaintenanceParams.
+func (mr *MockHostServiceIfaceMockRecorder) NewCancelMaintenanceParams(managementserverid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewCancelMaintenanceParams", reflect.TypeOf((*MockHostServiceIface)(nil).NewCancelMaintenanceParams), managementserverid)
+}
+
 // NewConfigureHAForHostParams mocks base method.
 func (m *MockHostServiceIface) NewConfigureHAForHostParams(hostid, provider string) *ConfigureHAForHostParams {
 	m.ctrl.T.Helper()
@@ -922,6 +951,20 @@ func (mr *MockHostServiceIfaceMockRecorder) NewMigrateSecondaryStorageDataParams
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMigrateSecondaryStorageDataParams", reflect.TypeOf((*MockHostServiceIface)(nil).NewMigrateSecondaryStorageDataParams), destpools, srcpool)
 }
 
+// NewPrepareForMaintenanceParams mocks base method.
+func (m *MockHostServiceIface) NewPrepareForMaintenanceParams(managementserverid UUID) *PrepareForMaintenanceParams {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewPrepareForMaintenanceParams", managementserverid)
+	ret0, _ := ret[0].(*PrepareForMaintenanceParams)
+	return ret0
+}
+
+// NewPrepareForMaintenanceParams indicates an expected call of NewPrepareForMaintenanceParams.
+func (mr *MockHostServiceIfaceMockRecorder) NewPrepareForMaintenanceParams(managementserverid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewPrepareForMaintenanceParams", reflect.TypeOf((*MockHostServiceIface)(nil).NewPrepareForMaintenanceParams), managementserverid)
+}
+
 // NewPrepareHostForMaintenanceParams mocks base method.
 func (m *MockHostServiceIface) NewPrepareHostForMaintenanceParams(id string) *PrepareHostForMaintenanceParams {
 	m.ctrl.T.Helper()
@@ -1032,6 +1075,21 @@ func (m *MockHostServiceIface) NewUpdateSecondaryStorageSelectorParams(heuristic
 func (mr *MockHostServiceIfaceMockRecorder) NewUpdateSecondaryStorageSelectorParams(heuristicrule, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewUpdateSecondaryStorageSelectorParams", reflect.TypeOf((*MockHostServiceIface)(nil).NewUpdateSecondaryStorageSelectorParams), heuristicrule, id)
+}
+
+// PrepareForMaintenance mocks base method.
+func (m *MockHostServiceIface) PrepareForMaintenance(p *PrepareForMaintenanceParams) (*PrepareForMaintenanceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareForMaintenance", p)
+	ret0, _ := ret[0].(*PrepareForMaintenanceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareForMaintenance indicates an expected call of PrepareForMaintenance.
+func (mr *MockHostServiceIfaceMockRecorder) PrepareForMaintenance(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForMaintenance", reflect.TypeOf((*MockHostServiceIface)(nil).PrepareForMaintenance), p)
 }
 
 // PrepareHostForMaintenance mocks base method.

--- a/generate/layout.go
+++ b/generate/layout.go
@@ -262,6 +262,8 @@ var layout = apiInfo{
 		"listHostHAResources",
 		"declareHostAsDegraded",
 		"updateSecondaryStorageSelector",
+		"prepareForMaintenance",
+		"cancelMaintenance",
 	},
 	"VolumeService": {
 		"attachVolume",

--- a/test/HostService_test.go
+++ b/test/HostService_test.go
@@ -455,4 +455,28 @@ func TestHostService(t *testing.T) {
 	}
 	t.Run("UpdateSecondaryStorageSelector", testupdateSecondaryStorageSelector)
 
+	testprepareForMaintenance := func(t *testing.T) {
+		if _, ok := response["prepareForMaintenance"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Host.NewPrepareForMaintenanceParams("managementserverid")
+		_, err := client.Host.PrepareForMaintenance(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("PrepareForMaintenance", testprepareForMaintenance)
+
+	testcancelMaintenance := func(t *testing.T) {
+		if _, ok := response["cancelMaintenance"]; !ok {
+			t.Skipf("Skipping as no json response is provided in testdata")
+		}
+		p := client.Host.NewCancelMaintenanceParams("managementserverid")
+		_, err := client.Host.CancelMaintenance(p)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+	}
+	t.Run("CancelMaintenance", testcancelMaintenance)
+
 }


### PR DESCRIPTION
Updated in 4.21: https://github.com/apache/cloudstack/pull/10995 - but since it wasn't an LTS release introducing these APIs in 4.22.1.0