### PR TITLE
Fix details serialization in ImportVmParams 

### DIFF
--- a/cloudstack/VirtualMachineService.go
+++ b/cloudstack/VirtualMachineService.go
@@ -11516,8 +11516,8 @@ func (p *ImportVmParams) toURLValues() url.Values {
 	}
 	if v, found := p.p["details"]; found {
 		m := v.(map[string]string)
-		for i, k := range getSortedKeysFromMap(m) {
-			u.Set(fmt.Sprintf("details[%d].%s", i, k), m[k])
+		for _, k := range getSortedKeysFromMap(m) {
+			u.Set(fmt.Sprintf("details[0].%s", k), m[k])
 		}
 	}
 	if v, found := p.p["diskpath"]; found {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -59,6 +59,7 @@ var detailsRequireZeroIndex = map[string]bool{
 	"createAccount":        true,
 	"updateAccount":        true,
 	"updateVirtualMachine": true,
+	"importVm":             true,
 }
 
 // parametersRequireIndexing contains map parameters that always need


### PR DESCRIPTION
When trying to import a VM with a custom constrained service offering the import fails:
```txt
resultCode: 431, result: org.apache.cloudstack.api.response.ExceptionResponse/null/{"uuidList":[],"errorcode":"431","errortext":"Detail 'memory' must be provided."}
```
This is because details are currently being serialized like this:
```
i | key | serialized as
--------------
0 | cpuNumber | details[0].cpuNumber
1 | cpuSpeed | details[1].cpuSpeed
2 | memory | details[2].memory
```

Here some logs from the management server:
```
2026-05-29 11:33:01,697 DEBUG [o.a.c.f.j.i.AsyncJobManagerImpl$5] (API-Job-Executor-13:[ctx-f71005c7, job-3932]) (logid:be359699) Executing AsyncJob {"accountId":2,"cmd":"org.apache.cloudstack.api.command.admin.vm.ImportVmCmd","cmdInfo":"{\"expires\":\"2026-05-29T09:48:01Z\",\"apiKey\":\"REDACTED\",\"signature\":\"REDACTED\",\"hostid\":\"e4dd8624-f379-4906-b801-adfc56ad5736\",\"httpmethod\":\"POST\",\"ctxAccountId\":\"2\",\"cmdEventType\":\"VM.IMPORT\",
\"details[1].cpuSpeed\" <--
:\"\",\"hostname\":\"test-import\",\"hypervisor\":\"KVM\",\"ctxStartEventId\":\"145224\",
\"details[2].memory*\":\"4194304\" <--
....
\"details[0].cpuNumber\":\"4\" <--
...
importsource\":\"local\",\"signatureversion\":\"3\",\"serviceofferingid\":\"c24ce908-ffaa-4ced-9610-f99fb9f8b4c8\",\"response\":\"json\",\"ctxUserId\":\"2\",\"name\":\"test-import\",...cmdVersion":0,"completeMsid":null,"created":null,"id":3932,"initMsid":90520745250807,"instanceId":null,"instanceType":"None","lastPolled":null,"lastUpdated":null,"processStatus":0,"removed":null,"result":null,"resultCode":0,"status":"IN_PROGRESS","userId":2,"uuid":"be359699-5322-43d6-b524-69fff205c850"}
```

This PR wants to fix this, fixing the details array's index to 0. I've edited the generate.go file and ran "make all" to reflect the wanted changes.