### PR TITLE
ci(rat): fetch apache-rat from archive.apache.org (0.17 aged off downloads mirror)

### DIFF
--- a/.github/workflows/rat.yaml
+++ b/.github/workflows/rat.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Download Apache RAT
         run: |
-          curl -L -O https://downloads.apache.org/creadur/apache-rat-0.17/apache-rat-0.17-bin.tar.gz
+          curl -L -O https://archive.apache.org/dist/creadur/apache-rat-0.17/apache-rat-0.17-bin.tar.gz
           tar -xzf apache-rat-0.17-bin.tar.gz
 
       - name: Run RAT


### PR DESCRIPTION
The `Apache RAT Check` workflow downloads apache-rat 0.17 from `downloads.apache.org`, which only mirrors *current* releases. 0.17 has since aged off that mirror, so the `curl` fetches a ~196-byte error page and the job fails at the **Download Apache RAT** step (`gzip: stdin: not in gzip format`, exit 2) — before RAT even runs. That fails the check on every PR (e.g. the one I'm preparing for the security model), regardless of the actual license state.

This points the download at `archive.apache.org/dist`, the permanent home for all ASF releases, so the tarball resolves regardless of release age. No version bump — apache-rat 0.17 and the existing `.rat-excludes` are unchanged.

Generated-by: Claude Code
