### PR TITLE
Fix panic when serializing UUID-typed request parameters

### DIFF
--- a/cloudstack/AsyncjobService.go
+++ b/cloudstack/AsyncjobService.go
@@ -60,7 +60,7 @@ func (p *ListAsyncJobsParams) toURLValues() url.Values {
 		u.Set("listall", vv)
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	if v, found := p.p["page"]; found {
 		vv := strconv.Itoa(v.(int))

--- a/cloudstack/HostService.go
+++ b/cloudstack/HostService.go
@@ -2842,7 +2842,7 @@ func (p *ListHostsParams) toURLValues() url.Values {
 		u.Set("keyword", v.(string))
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	if v, found := p.p["name"]; found {
 		u.Set("name", v.(string))
@@ -3546,7 +3546,7 @@ func (p *ListHostsMetricsParams) toURLValues() url.Values {
 		u.Set("keyword", v.(string))
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	if v, found := p.p["name"]; found {
 		u.Set("name", v.(string))

--- a/cloudstack/ManagementService.go
+++ b/cloudstack/ManagementService.go
@@ -58,7 +58,7 @@ func (p *CancelShutdownParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	return u
 }
@@ -765,7 +765,7 @@ func (p *PrepareForShutdownParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	return u
 }
@@ -838,7 +838,7 @@ func (p *ReadyForShutdownParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	return u
 }
@@ -914,7 +914,7 @@ func (p *TriggerShutdownParams) toURLValues() url.Values {
 		return u
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	return u
 }

--- a/cloudstack/WebhookService.go
+++ b/cloudstack/WebhookService.go
@@ -458,7 +458,7 @@ func (p *DeleteWebhookDeliveryParams) toURLValues() url.Values {
 		u.Set("id", v.(string))
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	if v, found := p.p["startdate"]; found {
 		u.Set("startdate", v.(string))
@@ -878,7 +878,7 @@ func (p *ListWebhookDeliveriesParams) toURLValues() url.Values {
 		u.Set("keyword", v.(string))
 	}
 	if v, found := p.p["managementserverid"]; found {
-		u.Set("managementserverid", v.(string))
+		u.Set("managementserverid", string(v.(UUID)))
 	}
 	if v, found := p.p["page"]; found {
 		vv := strconv.Itoa(v.(int))

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1355,8 +1355,10 @@ func (s *service) generateConvertCode(cmd, name, typ string) {
 	pn := s.pn
 
 	switch typ {
-	case "string", "UUID":
+	case "string":
 		pn("u.Set(\"%s\", v.(string))", name)
+	case "UUID":
+		pn("u.Set(\"%s\", string(v.(UUID)))", name)
 	case "int":
 		pn("vv := strconv.Itoa(v.(int))")
 		pn("u.Set(\"%s\", vv)", name)


### PR DESCRIPTION
## Summary

`generateConvertCode` in the generator treats the generated `UUID` Go type the same as `string` when building `toURLValues()`, emitting `v.(string)` for a value that is actually stored as `cloudstack.UUID`. Since Go type assertions require an exact dynamic type match, this panics at runtime for any parameter whose Go type is `UUID`.

Currently `managementserverid` is the only parameter routed through the `UUID` type (via the `longToStringConvertedParams` map), and it's used on `listAsyncJobs`, `listHosts`, `listHostsMetrics`, `triggerShutdown`, `cancelShutdown`, `prepareForShutdown`, `listWebhookDeliveries`, and `deleteWebhookDelivery`. This has been dormant so far because `managementserverid` is optional on all of these commands, so the setter is never exercised by the standard generated tests, but it panics on every real call that actually sets it.

Fix: assert the value as `UUID` and convert to `string`, instead of asserting it as `string`:

```go
case "string":
    pn("u.Set(\"%s\", v.(string))", name)
case "UUID":
    pn("u.Set(\"%s\", string(v.(UUID)))", name)
```

Regenerated the affected service files (`AsyncjobService.go`, `HostService.go`, `ManagementService.go`, `WebhookService.go`); no other diff.

## Testing
Tested against a real CloudStack installation, calling `listHosts`, `listHostsMetrics`, and `listAsyncJobs` with `managementserverid` set (the three read-only commands among the affected list; skipped `triggerShutdown`/`cancelShutdown`/`prepareForShutdown` since those actually change the management server's shutdown state).

**Before:**
```
=== listHosts (with managementserverid filter) - EXPECTING PANIC ===
panic: interface conversion: interface {} is cloudstack.UUID, not string

github.com/apache/cloudstack-go/v2/cloudstack.(*ListHostsParams).toURLValues(...)
	cloudstack/HostService.go:2845
github.com/apache/cloudstack-go/v2/cloudstack.(*HostService).ListHosts(...)
	cloudstack/HostService.go:3402
```

**After:**
```
=== listHosts (with managementserverid filter) ===
  ok, count=4
=== listHostsMetrics (with managementserverid filter) ===
  ok, count=2
=== listAsyncJobs (with managementserverid filter) ===
  ok, count=0
All calls succeeded, no panic.
```

